### PR TITLE
Pass docker hostconfig in StartContainer task

### DIFF
--- a/src/main/groovy/org/gradle/api/plugins/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/org/gradle/api/plugins/docker/tasks/container/DockerCreateContainer.groovy
@@ -85,6 +85,10 @@ class DockerCreateContainer extends AbstractDockerTask {
 
     @Input
     @Optional
+    List<String> volumes
+
+    @Input
+    @Optional
     String volumesFrom
 
     @Input
@@ -198,6 +202,11 @@ class DockerCreateContainer extends AbstractDockerTask {
 
         if(getImage()) {
             containerConfig.image = getImage()
+        }
+
+        if(getVolumes()) {
+            Class volumesConfigClass = classLoader.loadClass('com.kpelykh.docker.client.model.BoundHostVolumes')
+            containerConfig.volumes = volumesConfigClass.newInstance(getVolumes())
         }
 
         if(getVolumesFrom()) {


### PR DESCRIPTION
This PR enables running of containers with docker hostconfig params. Also adds volumes param to CreateContainer, to enable mounting of host directories.

For mounting host directories into a container the docker api requires the mount config as volumes on creation, as well as binds on container start. Else you end up with a docker volume or nothing depending on which param you ommit.

``` groovy
ext.mountConfig = [ "/host/path:/var/www/localhost/htdocs" ]

task createLocalDev(type: DockerCreateContainer) {
    imageId = 'foo'
    volumes = mountConfig
}

task startLocalDev(type: DockerStartContainer) {
    dependsOn createLocalDev
    targetContainerId { createLocalDev.getContainerId() }
    binds = mountConfig
    portBindings = [ [scheme: "tcp", port: "80", hostIp: "127.0.0.1", hostPort: "80" ],
                     [scheme: "tcp", port: "443", hostIp: "127.0.0.1", hostPort: "443" ] 
                   ]
    links = [ "some-other-container:db" ]
}
```
