### PR TITLE
Add project group to javaApplication tag if present.

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-1.12-bin.zip

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -115,7 +115,7 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
         String artifactAndVersion = "${project.applicationName}:${tagVersion}".toLowerCase().toString()
 
         String group = project.group
-        if (!Strings.isNullOrEmpty(group)){
+        if (group != null && !group.isEmpty()){
           "$group/$artifactAndVersion"
         }
 


### PR DESCRIPTION
If the user specifies a property 'group', as it is done with most projects that are published somewhere, This property will be used as prefix of the docker image tag.

This will result in an image tag like 'org.github/any-image:$version'.

Fixes gh-25.