### PR TITLE
Fix case typo that causes javaApplication configuration to not be applied

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -61,7 +61,7 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
     private DockerJavaApplication configureExtension(DockerExtension dockerExtension) {
         DockerJavaApplication dockerJavaApplication = new DockerJavaApplication()
         dockerExtension.metaClass.javaApplication = dockerJavaApplication
-        DockerExtension.metaClass.javaApplication = { Closure closure ->
+        dockerExtension.metaClass.javaApplication = { Closure closure ->
             ConfigureUtil.configure(closure, dockerJavaApplication)
         }
 


### PR DESCRIPTION
This pull request fixes a typo within `DockerJavaApplication.configureExtension()` that causes the given configuration to not be applied within a multi module build with multiple docker submodules.

Fixes gh-28.