### PR TITLE
Issue #30: Specify port bindings when starting a container.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -210,6 +210,7 @@ task createMyAppContainer(type: DockerCreateContainer) {
 task startMyAppContainer(type: DockerStartContainer) {
     dependsOn createMyAppContainer
     targetContainerId { createMyAppContainer.getContainerId() }
+    portBindings = ['8080:8080']
 }
 
 task stopMyAppContainer(type: DockerStopContainer) {

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowIntegrationTest.groovy
@@ -114,6 +114,7 @@ task createContainer(type: DockerCreateContainer) {
 task startContainer(type: DockerStartContainer) {
     dependsOn createContainer
     targetContainerId { createContainer.getContainerId() }
+    portBindings = ['8080:8080']
 }
 """
         expect:

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStartContainerIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStartContainerIntegrationTest.groovy
@@ -17,6 +17,9 @@ package com.bmuschko.gradle.docker.tasks.container
 
 import org.gradle.api.Task
 import com.bmuschko.gradle.docker.tasks.DockerTaskIntegrationTest
+import spock.lang.IgnoreIf
+
+import static com.bmuschko.gradle.docker.AbstractIntegrationTest.isDockerServerInfoUrlReachable
 
 class DockerStartContainerIntegrationTest extends DockerTaskIntegrationTest {
     @Override
@@ -24,5 +27,16 @@ class DockerStartContainerIntegrationTest extends DockerTaskIntegrationTest {
         project.task('startContainer', type: DockerStartContainer) {
             containerId = 'busybox'
         }
+    }
+
+    @IgnoreIf({ !isDockerServerInfoUrlReachable() })
+    def "Set port bindings"() {
+        when:
+        DockerStartContainer task = createAndConfigureTask()
+        task.portBindings = ['8080:80']
+        task.execute()
+
+        then:
+        task.containerId
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStartContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStartContainer.groovy
@@ -15,11 +15,27 @@
  */
 package com.bmuschko.gradle.docker.tasks.container
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class DockerStartContainer extends DockerExistingContainer {
+    @Input
+    @Optional
+    String[] portBindings
+
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Starting container with ID '${getContainerId()}'."
-        dockerClient.startContainerCmd(getContainerId()).exec()
+        def containerCommand = dockerClient.startContainerCmd(getContainerId())
+        setContainerCommandConfig(containerCommand)
+        containerCommand.exec()
+    }
+
+    private void setContainerCommandConfig(containerCommand) {
+        if (getPortBindings()) {
+            def createdPortBindings = getPortBindings().collect { threadContextClassLoader.createPortBinding(it) }
+            containerCommand.withPortBindings(threadContextClassLoader.createPorts(createdPortBindings))
+        }
     }
 }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -90,4 +90,22 @@ interface ThreadContextClassLoader {
      * @return Instance
      */
     def createExposedPorts(List<Object> exposedPorts)
+
+    /**
+     * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/PortBinding.java">PortBinding</a>
+     * from thread context classloader.
+     *
+     * @param portBinding Port binding
+     * @return Instance
+     */
+    def createPortBinding(String portBinding)
+
+    /**
+     * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/Ports.java">Ports</a>
+     * from thread context classloader.
+     *
+     * @param portBindings List of PortBindings
+     * @return Instance
+     */
+    def createPorts(List<Object> portBindings)
 }


### PR DESCRIPTION
I tested a local build of this plugin and was able to specify port bindings when starting a container. Also added an example of the syntax to the "Executing functional tests against a running container" section of README (and `startContainer` example in `DockerWorkflowIntegrationTest`).

The integration tests pass because I'm running boot2docker on OS X and the docker API is not available (most are skipped). I notice the same thing happens in the snap-ci build anyhow, perhaps still TODO?