### PR TITLE
Issue #42: Creating a container is not offering options for linking cont...

### DIFF
--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
@@ -139,4 +139,47 @@ class DockerThreadContextClassLoaderIntegrationTest extends ProjectBuilderIntegr
         instance
         instance.ports.size() == 2
     }
+
+    def "Can create class of type Link"() {
+        when:
+        def instance = null
+
+        threadContextClassLoader.withClasspath(project.configurations.dockerJava.files, dockerClientConfiguration) {
+            instance = createLink('name:alias')
+        }
+
+        then:
+        noExceptionThrown()
+        instance
+    }
+
+    def "Can create class of type Links"() {
+        when:
+        def instance = null
+
+        threadContextClassLoader.withClasspath(project.configurations.dockerJava.files, dockerClientConfiguration) {
+            def link = createLink('name:alias')
+            def link2 = createLink('name2:alias2')
+            instance = createLinks([link, link2])
+        }
+
+        then:
+        noExceptionThrown()
+        instance
+        instance.links.size() == 2
+    }
+
+    def "Can create class of type HostConfig"() {
+        when:
+        def instance = null
+
+        threadContextClassLoader.withClasspath(project.configurations.dockerJava.files, dockerClientConfiguration) {
+            instance = createHostConfig(["links": []])
+        }
+
+        then:
+        noExceptionThrown()
+        instance
+        instance.links.links.size() == 0
+    }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.artifacts.Dependency
  */
 class DockerRemoteApiPlugin implements Plugin<Project> {
     static final String DOCKER_JAVA_CONFIGURATION_NAME = 'dockerJava'
-    static final String DOCKER_JAVA_DEFAULT_VERSION = '1.1.0'
+    static final String DOCKER_JAVA_DEFAULT_VERSION = '1.2.0'
     static final String EXTENSION_NAME = 'docker'
     static final String DEFAULT_TASK_GROUP = 'Docker'
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -22,6 +22,8 @@ import org.gradle.api.tasks.Optional
 class DockerCreateContainer extends AbstractDockerRemoteApiTask {
     String imageId
 
+    List<String> links
+
     @Input
     @Optional
     String containerName
@@ -113,6 +115,10 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
         containerId = container.id
     }
 
+    void links (Closure links) {
+        conventionMapping.links = links
+    }
+
     void targetImageId(Closure imageId) {
         conventionMapping.imageId = imageId
     }
@@ -186,6 +192,11 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
         if(getVolumes()) {
             def createdVolumes = getVolumes().collect { threadContextClassLoader.createVolume(it) }
             containerCommand.volumes = threadContextClassLoader.createVolumes(createdVolumes)
+        }
+
+        if (getLinks()) {
+            def createdLinks = getLinks().collect( { threadContextClassLoader.createLink(it) })
+            containerCommand.withHostConfig(threadContextClassLoader.createHostConfig(["links":createdLinks]))
         }
 
         if(getVolumesFrom()) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
@@ -20,7 +20,8 @@ class DockerInspectContainer extends DockerExistingContainer {
     void runRemoteCommand(dockerClient) {
         logger.quiet "Inspecting container with ID '${getContainerId()}'."
         def container = dockerClient.inspectContainerCmd(getContainerId()).exec()
-        logger.quiet "Image ID : $container.imageId"
-        logger.quiet "Name     : $container.name"
+        logger.quiet "Image ID   : $container.imageId"
+        logger.quiet "Name       : $container.name"
+        logger.quiet "Links      : $container.hostConfig.links"
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -133,6 +133,40 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
      * {@inheritDoc}
      */
     @Override
+    def createLink(String link) {
+        Class linkClass = loadClass('com.github.dockerjava.api.model.Link')
+        Method method = linkClass.getMethod("parse", String)
+        method.invoke(null, link)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    def createLinks(List<Object> links) {
+        Class linksClass = loadClass('com.github.dockerjava.api.model.Links')
+        Constructor constructor = linksClass.getConstructor(List.class)
+        constructor.newInstance(links)
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    def createHostConfig(Map hostConfigProperties) {
+        Class hostConfigClass = loadClass('com.github.dockerjava.api.model.HostConfig')
+        Constructor constructor = hostConfigClass.getConstructor()
+        def hostConfig = constructor.newInstance()
+        hostConfigProperties.each {
+            hostConfig."${it.key}" = it.value
+        }
+        hostConfig
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     def createExposedPort(String scheme, Integer port) {
         Class exposedPortClass = loadClass('com.github.dockerjava.api.model.ExposedPort')
         Constructor constructor = exposedPortClass.getConstructor(Integer.TYPE, loadInternetProtocolClass())

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -64,6 +64,33 @@ interface ThreadContextClassLoader {
     def createVolumes(List<Object> volumes)
 
     /**
+     * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/Link.java">Link</a>
+     * from thread context classloader.
+     *
+     * @param link a container link
+     * @return Instance
+     */
+    def createLink(String link)
+
+    /**
+     * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/Links.java">Links</a>
+     * from thread context classloader.
+     *
+     * @param volumes List of Links
+     * @return Instance
+     */
+    def createLinks(List<Object> links)
+
+    /**
+     * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/HostConfig.java">Links</a>
+     * from thread context classloader.
+     *
+     * @param hostConfigProperties a map containing all HostConfig properties to be set. The map entry key is the property name while the map entry value is the property value.
+     * @return Instance
+     */
+    def createHostConfig(Map hostConfigProperties)
+
+    /**
      * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/InternetProtocol.java">InternetProtocol</a>
      * from thread context classloader.
      *


### PR DESCRIPTION
This pull request enables containers to be linked as demonstrated by the sample below:

```groovy
task createContainer(type: DockerCreateContainer) {
    dependsOn buildImage

    targetImageId {
        buildImage.getImageId()
    }

    containerName = "container1"
}

task createContainer2(type: DockerCreateContainer) {
    dependsOn createContainer

    targetImageId {
        buildImage.getImageId()
    }

    containerName = "container2"

    links {
        ["${createContainer.getContainerId()}:container1"]
    }
}
```

Please note that this already increments the version of the docker-java library to version 1.2.0