### PR TITLE
Separate application lib from rest of deployed resources.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -269,7 +269,7 @@ The plugin defines the following extension properties in the `javaApplication` c
 ----
 docker {
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jre'
+        baseImage = 'library/java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         port = 9090
         tag = 'jettyapp:1.115'
@@ -285,9 +285,9 @@ The plugin provides a set of tasks for your project and preconfigures them with 
 [options="header"]
 |=======
 |Task name                 |Depends On                |Type                                                                                 |Description
-|`dockerCopyDistResources` |`distTar`                 |link:http://www.gradle.org/docs/current/javadoc/org/gradle/api/tasks/Copy.html[Copy] |Copies the resource files (like the Java application's TAR file) to a temporary directory for image creation.
-|`dockerDistTar`           |`dockerCopyDistResources` |Dockerfile                                                                           |Creates the Docker image for the Java application.
-|`dockerBuildImage`        |`dockerDistTar`           |DockerBuildImage                                                                     |Builds the Docker image for the Java application.
+|`dockerCopyDistResources` |`installDist`             |link:http://www.gradle.org/docs/current/javadoc/org/gradle/api/tasks/Copy.html[Copy] |Copies the resource files (like the Java application's TAR file) to a temporary directory for image creation.
+|`dockerfile`              |`dockerCopyDistResources` |Dockerfile                                                                           |Creates the Docker image for the Java application.
+|`dockerBuildImage`        |`dockerfile`              |DockerBuildImage                                                                     |Builds the Docker image for the Java application.
 |`dockerPushImage`         |`dockerBuildImage`        |DockerPushImage                                                                      |Pushes created Docker image to the repository.
 |=======
 

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -18,9 +18,10 @@ class DockerJavaApplicationPluginIntegrationTest extends ToolingApiIntegrationTe
         dockerfile.text ==
 """FROM java
 MAINTAINER ${System.getProperty('user.name')}
-ADD integTest-1.0.tar /
-ENTRYPOINT ["/integTest-1.0/bin/integTest"]
 EXPOSE 8080
+ENTRYPOINT ["/integTest/bin/integTest"]
+ADD integTest/ /integTest
+ADD app-lib/integTest-1.0.jar /integTest/lib/integTest-1.0.jar
 """
         result.output.contains('Author           : ')
     }
@@ -33,7 +34,7 @@ EXPOSE 8080
         buildFile << """
 docker {
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jre'
+        baseImage = 'library/java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         port = 9090
         tag = 'jettyapp:1.115'
@@ -48,11 +49,12 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-"""FROM dockerfile/java:openjdk-7-jre
+"""FROM library/java:openjdk-7-jre
 MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"
-ADD integTest-1.0.tar /
-ENTRYPOINT ["/integTest-1.0/bin/integTest"]
 EXPOSE 9090
+ENTRYPOINT ["/integTest/bin/integTest"]
+ADD integTest/ /integTest
+ADD app-lib/integTest-1.0.jar /integTest/lib/integTest-1.0.jar
 """
         result.output.contains('Author           : Benjamin Muschko "benjamin.muschko@gmail.com"')
     }
@@ -70,14 +72,14 @@ dockerCopyDistResources {
     from file('file2.txt')
 }
 
-dockerDistTar {
+dockerfile {
     addFile 'file1.txt', '/some/dir/file1.txt'
     addFile 'file2.txt', '/other/dir/file2.txt'
 }
 
 docker {
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jre'
+        baseImage = 'library/java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         port = 9090
         tag = 'jettyapp:1.115'
@@ -92,11 +94,12 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-"""FROM dockerfile/java:openjdk-7-jre
+"""FROM library/java:openjdk-7-jre
 MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"
-ADD integTest-1.0.tar /
-ENTRYPOINT ["/integTest-1.0/bin/integTest"]
 EXPOSE 9090
+ENTRYPOINT ["/integTest/bin/integTest"]
+ADD integTest/ /integTest
+ADD app-lib/integTest-1.0.jar /integTest/lib/integTest-1.0.jar
 ADD file1.txt /some/dir/file1.txt
 ADD file2.txt /other/dir/file2.txt
 """
@@ -120,7 +123,7 @@ docker {
     }
 
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jdk'
+        baseImage = 'library/java:openjdk-7-jdk'
         tag = "\$docker.registryCredentials.username/javaapp"
     }
 }
@@ -133,11 +136,12 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-                """FROM dockerfile/java:openjdk-7-jdk
+                """FROM library/java:openjdk-7-jdk
 MAINTAINER ${System.getProperty('user.name')}
-ADD javaapp-1.0.tar /
-ENTRYPOINT ["/javaapp-1.0/bin/javaapp"]
 EXPOSE 8080
+ENTRYPOINT ["/javaapp/bin/javaapp"]
+ADD javaapp/ /javaapp
+ADD app-lib/javaapp-1.0.jar /javaapp/lib/javaapp-1.0.jar
 """
     }
 
@@ -150,7 +154,7 @@ applicationName = 'javaapp'
 
 docker {
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jdk'
+        baseImage = 'library/java:openjdk-7-jdk'
         tag = '${TestConfiguration.dockerPrivateRegistryDomain}/javaapp'
     }
 }
@@ -163,11 +167,12 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-                """FROM dockerfile/java:openjdk-7-jdk
+                """FROM library/java:openjdk-7-jdk
 MAINTAINER ${System.getProperty('user.name')}
-ADD javaapp-1.0.tar /
-ENTRYPOINT ["/javaapp-1.0/bin/javaapp"]
 EXPOSE 8080
+ENTRYPOINT ["/javaapp]/bin/javaapp"]
+ADD javaapp/ /javaapp
+ADD app-lib/javaapp-1.0.jar /javaapp/lib/javaapp-1.0.jar
 """
         noExceptionThrown()
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -20,9 +20,11 @@ import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.distribution.plugins.DistributionPlugin
 import org.gradle.api.plugins.ApplicationPlugin
-import org.gradle.api.tasks.Copy
-import org.gradle.api.tasks.bundling.Tar
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.tasks.Sync
+import org.gradle.jvm.tasks.Jar
 import org.gradle.util.ConfigureUtil
 
 /**
@@ -30,7 +32,7 @@ import org.gradle.util.ConfigureUtil
  */
 class DockerJavaApplicationPlugin implements Plugin<Project> {
     public static final String COPY_DIST_RESOURCES_TASK_NAME = 'dockerCopyDistResources'
-    public static final String DOCKERFILE_TASK_NAME = 'dockerDistTar'
+    public static final String DOCKERFILE_TASK_NAME = 'dockerfile'
     public static final String BUILD_IMAGE_TASK_NAME = 'dockerBuildImage'
     public static final String PUSH_IMAGE_TASK_NAME = 'dockerPushImage'
 
@@ -42,10 +44,11 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
         DockerJavaApplication dockerJavaApplication = configureExtension(dockerExtension)
 
         project.plugins.withType(ApplicationPlugin) {
-            Tar tarTask = project.tasks.getByName(ApplicationPlugin.TASK_DIST_TAR_NAME)
+            Sync installTask = project.tasks.getByName(DistributionPlugin.TASK_INSTALL_NAME)
+            Jar jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
 
-            Dockerfile createDockerfileTask = createDockerfileTask(project, tarTask, dockerJavaApplication)
-            Copy copyTarTask = createDistCopyResourcesTask(project, tarTask, createDockerfileTask)
+            Dockerfile createDockerfileTask = createDockerfileTask(project, installTask, jarTask, dockerJavaApplication)
+            Sync copyTarTask = createDistCopyResourcesTask(project, installTask, jarTask, createDockerfileTask)
             createDockerfileTask.dependsOn copyTarTask
             DockerBuildImage dockerBuildImageTask = createBuildImageTask(project, createDockerfileTask, dockerJavaApplication)
             createPushImageTask(project, dockerBuildImageTask)
@@ -68,31 +71,37 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
         dockerJavaApplication
     }
 
-    private Dockerfile createDockerfileTask(Project project, Tar tarTask, DockerJavaApplication dockerJavaApplication) {
+    private Dockerfile createDockerfileTask(Project project, Sync installTask, Jar jarTask, DockerJavaApplication dockerJavaApplication) {
         project.task(DOCKERFILE_TASK_NAME, type: Dockerfile) {
             description = 'Creates the Docker image for the Java application.'
-            dependsOn tarTask
+            String projectDir = installTask.destinationDir.name
+            dependsOn jarTask
 
             from { dockerJavaApplication.baseImage }
             maintainer { dockerJavaApplication.maintainer }
-            addFile({ tarTask.archivePath.name }, { '/' })
-            entryPoint { determineEntryPoint(project, tarTask) }
             exposePort { dockerJavaApplication.port }
+            entryPoint { determineEntryPoint(project, installTask) }
+            addFile({ "$projectDir/" }, { "/$projectDir" })
+            addFile({ "app-lib/${jarTask.archiveName}" }, { "/$projectDir/lib/${jarTask.archiveName}" })
         }
     }
 
-    private Copy createDistCopyResourcesTask(Project project, Tar tarTask, Dockerfile createDockerfileTask) {
-        project.task(COPY_DIST_RESOURCES_TASK_NAME, type: Copy) {
+    private Sync createDistCopyResourcesTask(Project project, Sync installTask, Jar jarTask, Dockerfile createDockerfileTask) {
+        project.task(COPY_DIST_RESOURCES_TASK_NAME, type: Sync) {
             group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
             description = "Copies the distribution resources to a temporary directory for image creation."
-            dependsOn tarTask
-            from { tarTask.archivePath }
+            dependsOn installTask
+            from { installTask.destinationDir.parentFile }
             into { createDockerfileTask.destFile.parentFile }
+            exclude "**/lib/${jarTask.archiveName}"
+            into("app-lib") {
+                from jarTask
+            }
         }
     }
 
-    private String determineEntryPoint(Project project, Tar tarTask) {
-        String installDir = tarTask.archiveName - ".${tarTask.extension}"
+    private String determineEntryPoint(Project project, Sync installTask) {
+        String installDir = installTask.destinationDir.name
         "/$installDir/bin/$project.applicationName".toString()
     }
 

--- a/src/test/groovy/com/bmuschko/gradle/docker/response/BuildImageResponseHandlerTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/response/BuildImageResponseHandlerTest.groovy
@@ -30,7 +30,7 @@ class BuildImageResponseHandlerTest extends Specification {
     }
 
     def "Handle successful response"() {
-        String response = """{"stream":"Step 0 : FROM dockerfile/java:openjdk-7-jre\\n"}
+        String response = """{"stream":"Step 0 : FROM library/java:openjdk-7-jre\\n"}
 {"stream":" ---\\u003e 13a4762ffb1c\\n"}
 {"stream":"Step 1 : MAINTAINER Benjamin Muschko \\"benjamin.muschko@gmail.com\\"\\n"}
 {"stream":" ---\\u003e Using cache\\n"}
@@ -54,7 +54,7 @@ class BuildImageResponseHandlerTest extends Specification {
         String imageId = responseHandler.handle(inputStream)
 
         then:
-        1 * logger.info('Step 0 : FROM dockerfile/java:openjdk-7-jre\n')
+        1 * logger.info('Step 0 : FROM library/java:openjdk-7-jre\n')
         1 * logger.info(' ---\u003e 13a4762ffb1c\n')
         1 * logger.info('Step 1 : MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"\n')
         1 * logger.info(' ---\u003e Using cache\n')


### PR DESCRIPTION
Allows for increase caching when only the application code is changing.

This is what the `Dockerfile` ended up looking like:

```
FROM java:8
MAINTAINER john
EXPOSE 8080
ENTRYPOINT ["/example-books/bin/example-books"]
ADD example-books/ /example-books
ADD app-lib/example-books.jar /example-books/lib/example-books.jar
```

I also changed the name of the task that creates the `Dockerfile` from `dockerDistTar` to `dockerfile` since this task is not longer reliant on the `distTar` task. It actually using the `installDist` task now.
