### PR TITLE
An integration test and a workaround for issue #41

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ out
 *.iws
 .idea
 .gradle
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,6 +19,6 @@ Vagrant.configure(2) do |config|
   SH
   config.vm.provision 'docker' do |d|
     d.run 'registry', args: '-p 5000:5000'
-    d.pull_image 'busybox'
+    d.pull_images 'busybox'
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -19,5 +19,6 @@ Vagrant.configure(2) do |config|
   SH
   config.vm.provision 'docker' do |d|
     d.run 'registry', args: '-p 5000:5000'
+    d.pull_image 'busybox'
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ Vagrant.configure(2) do |config|
   end
 
   config.vm.network "forwarded_port", guest: 2375, host: 2375
+  config.vm.network "forwarded_port", guest: 5000, host: 5000
 
   config.vm.provision 'shell', inline: <<-SH
     sudo echo DOCKER_OPTS=\\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375\\" > /etc/default/docker
@@ -16,5 +17,7 @@ Vagrant.configure(2) do |config|
     sudo echo Europe/Helsinki > /etc/timezone
     sudo /usr/sbin/dpkg-reconfigure --frontend noninteractive tzdata
   SH
-  config.vm.provision 'docker'
+  config.vm.provision 'docker' do |d|
+    d.run 'registry:2.0', args: '-p 5000:5000', auto_assign_name: false
+  end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,20 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+  config.vm.box = "ubuntu/trusty64"
+
+  config.vm.provider "virtualbox" do |vb|
+     vb.memory = "1024"
+  end
+
+  config.vm.network "forwarded_port", guest: 2375, host: 2375
+
+  config.vm.provision 'shell', inline: <<-SH
+    sudo echo DOCKER_OPTS=\\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375\\" > /etc/default/docker
+
+    sudo echo Europe/Helsinki > /etc/timezone
+    sudo /usr/sbin/dpkg-reconfigure --frontend noninteractive tzdata
+  SH
+  config.vm.provision 'docker'
+end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -18,6 +18,6 @@ Vagrant.configure(2) do |config|
     sudo /usr/sbin/dpkg-reconfigure --frontend noninteractive tzdata
   SH
   config.vm.provision 'docker' do |d|
-    d.run 'registry:2.0', args: '-p 5000:5000', auto_assign_name: false
+    d.run 'registry', args: '-p 5000:5000'
   end
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -5,7 +5,7 @@ Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
 
   config.vm.provider "virtualbox" do |vb|
-     vb.memory = "1024"
+     vb.memory = "2048"
   end
 
   config.vm.network "forwarded_port", guest: 2375, host: 2375

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,10 +13,8 @@ Vagrant.configure(2) do |config|
 
   config.vm.provision 'shell', inline: <<-SH
     sudo echo DOCKER_OPTS=\\"-H unix:///var/run/docker.sock -H tcp://0.0.0.0:2375\\" > /etc/default/docker
-
-    sudo echo Europe/Helsinki > /etc/timezone
-    sudo /usr/sbin/dpkg-reconfigure --frontend noninteractive tzdata
   SH
+
   config.vm.provision 'docker' do |d|
     d.run 'registry', args: '-p 5000:5000'
     d.pull_images 'busybox'

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -33,7 +33,7 @@ EXPOSE 8080
         buildFile << """
 docker {
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jre'
+        baseImage = 'java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         port = 9090
         tag = 'jettyapp:1.115'
@@ -48,7 +48,7 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-"""FROM dockerfile/java:openjdk-7-jre
+"""FROM java:openjdk-7-jre
 MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"
 ADD integTest-1.0.tar /
 ENTRYPOINT ["/integTest-1.0/bin/integTest"]
@@ -77,7 +77,7 @@ dockerDistTar {
 
 docker {
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jre'
+        baseImage = 'java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         port = 9090
         tag = 'jettyapp:1.115'
@@ -92,7 +92,7 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-"""FROM dockerfile/java:openjdk-7-jre
+"""FROM java:openjdk-7-jre
 MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"
 ADD integTest-1.0.tar /
 ENTRYPOINT ["/integTest-1.0/bin/integTest"]
@@ -120,7 +120,7 @@ docker {
     }
 
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jdk'
+        baseImage = 'java:openjdk-7-jdk'
         tag = "\$docker.registryCredentials.username/javaapp"
     }
 }
@@ -133,7 +133,7 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-                """FROM dockerfile/java:openjdk-7-jdk
+                """FROM java:openjdk-7-jdk
 MAINTAINER ${System.getProperty('user.name')}
 ADD javaapp-1.0.tar /
 ENTRYPOINT ["/javaapp-1.0/bin/javaapp"]
@@ -156,7 +156,7 @@ EXPOSE 8080
       }
 
       javaApplication {
-          baseImage = 'dockerfile/java:openjdk-7-jdk'
+          baseImage = 'java:openjdk-7-jdk'
           tag = "\$docker.registryCredentials.username/javaapp:1.0"
       }
   }
@@ -169,7 +169,7 @@ EXPOSE 8080
       File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
       dockerfile.exists()
       dockerfile.text ==
-              """FROM dockerfile/java:openjdk-7-jdk
+              """FROM java:openjdk-7-jdk
 MAINTAINER ${System.getProperty('user.name')}
 ADD javaapp-1.0.tar /
 ENTRYPOINT ["/javaapp-1.0/bin/javaapp"]
@@ -186,7 +186,7 @@ applicationName = 'javaapp'
 
 docker {
     javaApplication {
-        baseImage = 'dockerfile/java:openjdk-7-jdk'
+        baseImage = 'java:openjdk-7-jdk'
         tag = '${TestConfiguration.dockerPrivateRegistryDomain}/javaapp'
     }
 }
@@ -199,7 +199,7 @@ docker {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-                """FROM dockerfile/java:openjdk-7-jdk
+                """FROM java:openjdk-7-jdk
 MAINTAINER ${System.getProperty('user.name')}
 ADD javaapp-1.0.tar /
 ENTRYPOINT ["/javaapp-1.0/bin/javaapp"]

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -124,6 +124,12 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
     }
 
     static String imageNameFromTag(String tag) {
-        tag.split(':')[0]
+        String repository = ""
+        String[] components = tag.split('/')
+
+        if (components.length > 1) repository = components.first() + '/'
+
+        String image = components.last()
+        repository + image.split(':').first()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -119,7 +119,11 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
         project.task(PUSH_IMAGE_TASK_NAME, type: DockerPushImage) {
             description = 'Pushes created Docker image to the repository.'
             dependsOn dockerBuildImageTask
-            conventionMapping.imageName = { dockerBuildImageTask.getTag() }
+            conventionMapping.imageName = { imageNameFromTag(dockerBuildImageTask.getTag()) }
         }
+    }
+
+    static String imageNameFromTag(String tag) {
+        tag.split(':')[0]
     }
 }

--- a/src/test/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginTest.groovy
@@ -1,0 +1,35 @@
+package com.bmuschko.gradle.docker
+
+import spock.lang.Specification
+
+class DockerJavaApplicationPluginTest extends Specification {
+  def "Can convert simple tag into an image name for pushing to DockerHub"() {
+    when:
+    String name = DockerJavaApplicationPlugin.imageNameFromTag('simple_tag')
+    then:
+    name == 'simple_tag'
+  }
+
+  def "Can convert versioned tag into an image name for pushing to DockerHub"() {
+    when:
+    String name = DockerJavaApplicationPlugin.imageNameFromTag('versioned_tag:1.0')
+    then:
+    name == 'versioned_tag'
+  }
+
+  def "Can convert simple tag into an image name for pushing to private registry"() {
+    when:
+    String name = DockerJavaApplicationPlugin.imageNameFromTag('localhost:5000/simple_tag')
+    then:
+    name == 'localhost:5000/simple_tag'
+  }
+
+  def "Can convert versioned tag into an image name for pushing to private registry"() {
+    when:
+    String name = DockerJavaApplicationPlugin.imageNameFromTag('localhost:5000/versioned_tag:1.0')
+    then:
+    name == 'localhost:5000/versioned_tag'
+  }
+
+
+}

--- a/src/test/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginTest.groovy
@@ -3,33 +3,31 @@ package com.bmuschko.gradle.docker
 import spock.lang.Specification
 
 class DockerJavaApplicationPluginTest extends Specification {
-  def "Can convert simple tag into an image name for pushing to DockerHub"() {
-    when:
-    String name = DockerJavaApplicationPlugin.imageNameFromTag('simple_tag')
-    then:
-    name == 'simple_tag'
-  }
+    def "Can convert simple tag into an image name for pushing to DockerHub"() {
+        when:
+        String name = DockerJavaApplicationPlugin.imageNameFromTag('simple_tag')
+        then:
+        name == 'simple_tag'
+    }
 
-  def "Can convert versioned tag into an image name for pushing to DockerHub"() {
-    when:
-    String name = DockerJavaApplicationPlugin.imageNameFromTag('versioned_tag:1.0')
-    then:
-    name == 'versioned_tag'
-  }
+    def "Can convert versioned tag into an image name for pushing to DockerHub"() {
+        when:
+        String name = DockerJavaApplicationPlugin.imageNameFromTag('versioned_tag:1.0')
+        then:
+        name == 'versioned_tag'
+    }
 
-  def "Can convert simple tag into an image name for pushing to private registry"() {
-    when:
-    String name = DockerJavaApplicationPlugin.imageNameFromTag('localhost:5000/simple_tag')
-    then:
-    name == 'localhost:5000/simple_tag'
-  }
+    def "Can convert simple tag into an image name for pushing to private registry"() {
+        when:
+        String name = DockerJavaApplicationPlugin.imageNameFromTag('localhost:5000/simple_tag')
+        then:
+        name == 'localhost:5000/simple_tag'
+    }
 
-  def "Can convert versioned tag into an image name for pushing to private registry"() {
-    when:
-    String name = DockerJavaApplicationPlugin.imageNameFromTag('localhost:5000/versioned_tag:1.0')
-    then:
-    name == 'localhost:5000/versioned_tag'
-  }
-
-
+    def "Can convert versioned tag into an image name for pushing to private registry"() {
+        when:
+        String name = DockerJavaApplicationPlugin.imageNameFromTag('localhost:5000/versioned_tag:1.0')
+        then:
+        name == 'localhost:5000/versioned_tag'
+    }
 }


### PR DESCRIPTION
As discussed in the issue's thread the problem is using the full tag (with ':<version>' part) as an image name. I added an integration test and a solution for this issue. 

The solution is to strip the version part off the image name in conventionMapping for DockerJavaApplicationPlugin. I can't say the solution is elegant (basically, I have to split the image tag that was composed just a few steps before), but it's working well for both DockerHub and private repositories. 

I also fixed the integration tests that used 'dockerfile/' repository. It seems nowadays we have to refer to those repositories without 'dockerfile/' prefix. 

Finally, a Vagrantfile is added to the project that hosts Docker daemon instance and a private repository required for integration tests. Useful for those who want to run the tests on MacOS or Windows. 
