### PR TITLE
Add add-host parameter option

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -113,6 +113,10 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
     @Input
     @Optional
     Map<String,String> binds
+    
+    @Input
+    @Optional
+    String[] extraHosts
 
     String containerId
 
@@ -234,6 +238,9 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
             def createdBinds = threadContextClassLoader.createBinds(getBinds())
             containerCommand.withBinds(createdBinds)
         }
+        
+        if(getExtraHosts()) {
+            containerCommand.withExtraHosts(getExtraHosts())
+        }
     }
 }
-


### PR DESCRIPTION
Added a call to the 'ExtraHosts' option within docker remote api to enable containers to be run that will edit the hosts file.

This is the equivalent to using the docker run command with the 'add-host' parameter.