### PR TITLE
Upgrade to Docker Java 2.0.0

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -6,7 +6,7 @@ image:https://d3oypxn00j2a10.cloudfront.net/0.12.6/img/nav/docker-logo-loggedout
 Gradle plugin for managing link:https://www.docker.io/[Docker] images and containers using via its
 link:http://docs.docker.io/reference/api/docker_remote_api/[remote API]. The heavy lifting of communicating with the
 Docker remote API is handled by the link:https://github.com/docker-java/docker-java[Docker Java library]. Currently,
-version 1.4.0. Please refer to the library's documentation for more information on the supported Docker's client API
+version 2.0.0. Please refer to the library's documentation for more information on the supported Docker's client API
 and Docker server version.
 
 link:https://snap-ci.com/bmuschko/gradle-docker-plugin/branch/master[image:https://snap-ci.com/bmuschko/gradle-docker-plugin/branch/master/build_image[Build Image]]

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.artifacts.Dependency
  */
 class DockerRemoteApiPlugin implements Plugin<Project> {
     public static final String DOCKER_JAVA_CONFIGURATION_NAME = 'dockerJava'
-    public static final String DOCKER_JAVA_DEFAULT_VERSION = '1.4.0'
+    public static final String DOCKER_JAVA_DEFAULT_VERSION = '2.0.0'
     public static final String EXTENSION_NAME = 'docker'
     public static final String DEFAULT_TASK_GROUP = 'Docker'
 


### PR DESCRIPTION
Bumped to java 2.0.0 in an effort to move the below linked to issue forward. Tests, except for those contacting github, seemed to work fine for me on my box locally.

https://github.com/bmuschko/gradle-docker-plugin/issues/81
