### PR TITLE
Only include pem files in cert_path as input

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -36,7 +36,6 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     /**
      * Path to the <a href="https://docs.docker.com/articles/https/">Docker certificate and key</a>.
      */
-    @InputDirectory
     @Optional
     File certPath
 
@@ -49,6 +48,13 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
         }
     }
 
+    public void setCertPath(File certPath) {
+      File[] pemFiles = certPath.listFiles().findAll( { it.name.endsWith("pem") } )
+      getInputs().files(pemFiles)
+
+      this.certPath = certPath
+    }
+
     private DockerClientConfiguration createDockerClientConfig() {
         DockerClientConfiguration dockerClientConfig = new DockerClientConfiguration()
         dockerClientConfig.url = getUrl()
@@ -58,4 +64,3 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
 
     abstract void runRemoteCommand(dockerClient)
 }
-

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -48,11 +48,12 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
         }
     }
 
-    public void setCertPath(File certPath) {
-      File[] pemFiles = certPath.listFiles().findAll( { it.name.endsWith("pem") } )
-      getInputs().files(pemFiles)
-
-      this.certPath = certPath
+    @InputFiles
+    public File[] getCertPathKeys() {
+      if (certPath) {
+        return certPath.listFiles().findAll( { it.name.endsWith("pem") } )
+      }
+      return []
     }
 
     private DockerClientConfiguration createDockerClientConfig() {


### PR DESCRIPTION
Addresses issue #99.

Removes `@InputDir` annotation from certPath and creates a setter that sets task inputs to only contain pem files in that directory.
