### PR TITLE
Suppport for outputs.upToDateWhen for DockerBuildImage -  issue #98

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -44,9 +44,13 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
 
     @TaskAction
     void start() {
-        threadContextClassLoader.withClasspath(getClasspath().files, createDockerClientConfig()) { dockerClient ->
+        runInDockerClassPath { dockerClient ->
             runRemoteCommand(dockerClient)
         }
+    }
+
+    void runInDockerClassPath(Closure closure) {
+      threadContextClassLoader.withClasspath(getClasspath().files, createDockerClientConfig(), closure)
     }
 
     private DockerClientConfiguration createDockerClientConfig() {
@@ -58,4 +62,3 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
 
     abstract void runRemoteCommand(dockerClient)
 }
-

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -138,22 +138,29 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     boolean previouslyBuiltImageExists() {
         def imageExists = false
 
-        def imageId = new TaskStateHelper(name, project).get("imageId")
-        if (!imageId?.trim()) {
+        def prevImageId = new TaskStateHelper(name, project).get("imageId")
+        if (!prevImageId?.trim()) {
             logger.info "No previously saved imageId exists"
             return false
         }
 
         runInDockerClassPath { dockerClient ->
             try {
-                dockerClient.inspectImageCmd(imageId).exec()
-                logger.info "Image ${imageId} found via call to inspectImage"
+                dockerClient.inspectImageCmd(prevImageId).exec()
+                logger.info "Image ${prevImageId} found via call to inspectImage"
+
                 imageExists = true
             } catch(Exception e) {
-                logger.info "Image ${imageId} not found via call to inspectImage"
+                logger.info "Image ${prevImageId} not found via call to inspectImage"
                 imageExists = false
             }
         }
-        imageExists
+
+        if (imageExists) {
+          this.imageId = prevImageId
+          return true
+        } else {
+          return false
+        }
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/TaskStateHelper.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/TaskStateHelper.groovy
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.docker.utils
+
+import org.gradle.api.Project
+
+class TaskStateHelper {
+
+    String taskName
+
+    Project project
+
+    public TaskStateHelper(String taskName, Project project) {
+        this.taskName = taskName
+        this.project = project
+    }
+
+    public void put(String key, String value) {
+        put([ "${key}" : value])
+    }
+
+    public void put(Map<String, String> state) {
+        def map = get()
+        state.each { k, v -> map[k] = v}
+        saveState(state)
+    }
+
+    public String get(String key) {
+        get()[key]
+    }
+
+    public Map<String, String> get() {
+        def map = [:]
+        def props = loadStateProps()
+        def names = props.propertyNames()
+
+        while (names.hasMoreElements()) {
+          def propName = names.nextElement()
+          map[propName] = props.getProperty(propName)
+        }
+        map
+    }
+
+    Properties loadStateProps() {
+        def stateFile = getStateFile()
+        def props = new Properties()
+        if(stateFile.exists()) {
+          stateFile.withInputStream {
+              props.load(it)
+          }
+        }
+        props
+    }
+
+    File getStateFile() {
+        def stateDir = "${project.buildDir}/docker/state"
+        new File(stateDir).mkdirs()
+        new File("${stateDir}/${taskName}")
+    }
+
+    void saveState(Map<String, String> state) {
+        def props = new Properties()
+        state.each { k, v -> props.setProperty(k, v) }
+        getStateFile().withOutputStream {
+            props.store(it, null)
+        }
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/TaskStateHelper.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/TaskStateHelper.groovy
@@ -32,9 +32,9 @@ class TaskStateHelper {
         put([ "${key}" : value])
     }
 
-    public void put(Map<String, String> state) {
-        def map = get()
-        state.each { k, v -> map[k] = v}
+    public void put(Map<String, String> newState) {
+        def state = get()
+        newState.each { k, v -> state[k] = v}
         saveState(state)
     }
 

--- a/src/test/groovy/com/bmuschko/gradle/docker/utils/TaskStateHelperTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/utils/TaskStateHelperTest.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.docker.utils
+
+import org.gradle.api.Project
+import spock.lang.Specification
+
+class TaskStateHelperTest extends Specification {
+
+    def project = Mock(Project)
+
+    def "Saves task state"() {
+        project.buildDir >> createTempDir()
+        def stateHelper = new TaskStateHelper("saveStateTest", project)
+
+        when:
+        stateHelper.put("testKey", "testVal")
+
+        then:
+        new File("${project.buildDir}/docker/state/saveStateTest").exists()
+        new File("${project.buildDir}/docker/state/saveStateTest").text.contains("testKey=testVal")
+    }
+
+    def "Gets previously saved task state"() {
+        project.buildDir >> createTempDir()
+        def stateHelper = new TaskStateHelper("testStateTest", project)
+        new File("${project.buildDir}/docker/state/").mkdirs()
+        new File("${project.buildDir}/docker/state/testStateTest").write("testKeyForGet=1234567")
+
+        when:
+        def val = stateHelper.get("testKeyForGet")
+
+        then:
+        val == "1234567"
+    }
+
+    File createTempDir() {
+        def temp = File.createTempFile("TaskStateHelperTest", Long.toString(System.nanoTime()))
+        temp.delete()
+        temp.mkdir()
+        temp
+    }
+}


### PR DESCRIPTION
* helper class TaskStateHelper for persisting task state in property files
* doLast call to DockerBuildImage that saves image id to build dir
* upToDateWhen call to inspectImage remote api to verify if
  previously-built images still exists
* modification to AbstractDockerRemoteApiTask to support running in
  upToDateWhen check in the docker classpath

As an example for the performance gains on this, I tested this on a small web application with no code changes between runs.  In this specific example the time for `dockerBuildImage` went from `5701ms` to `646ms`.