### PR TITLE
Correct the withVolumesFrom call on DockerCreateContainer task which needs to get a VolumesFrom[] array as the parameter

### DIFF
--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
@@ -259,6 +259,28 @@ class DockerThreadContextClassLoaderIntegrationTest extends AbstractIntegrationT
         instance.configs.size() == 2
     }
 
+    def "Can create class of type VolumesFrom"() {
+        when:
+        def instance = null
+
+        def volumes = ['volume-one', 'volume-two:ro', 'volume-three:rw'] as String[]
+
+        threadContextClassLoader.withClasspath(project.configurations.dockerJava.files, dockerClientConfiguration) {
+            instance = createVolumesFrom(volumes)
+        }
+
+        then:
+        noExceptionThrown()
+        instance
+        instance.size() == volumes.size()
+        instance[0].container == 'volume-one'
+        instance[0].accessMode.toString() == 'rw'
+        instance[1].container == 'volume-two'
+        instance[1].accessMode.toString() == 'ro'
+        instance[2].container == 'volume-three'
+        instance[2].accessMode.toString() == 'rw'
+    }
+
     private DockerRegistryCredentials createCredentials() {
         DockerRegistryCredentials credentials = new DockerRegistryCredentials()
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -222,7 +222,8 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
         }
 
         if(getVolumesFrom()) {
-            containerCommand.withVolumesFrom(getVolumesFrom())
+            def createdVolumes = threadContextClassLoader.createVolumesFrom(getVolumesFrom())
+            containerCommand.withVolumesFrom(createdVolumes)
         }
 
         if(getWorkingDir()) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -152,8 +152,8 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     @Override
     def createVolumesFrom(String[] volumes) {
         Class volumesClass = loadClass("${MODEL_PACKAGE}.VolumesFrom")
-        Constructor constructor = volumesClass.getConstructor(String)
-        volumes.collect { constructor.newInstance(it) }.toArray(Array.newInstance(volumesClass, 0))
+        Method parseMethod = volumesClass.getMethod('parse', String)
+        volumes.collect { parseMethod.invoke(null, it) }.toArray(Array.newInstance(volumesClass, 0))
     }
 
     /**

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -150,6 +150,16 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
      * {@inheritDoc}
      */
     @Override
+    def createVolumesFrom(String[] volumes) {
+        Class volumesClass = loadClass("${MODEL_PACKAGE}.VolumesFrom")
+        Constructor constructor = volumesClass.getConstructor(String)
+        volumes.collect { constructor.newInstance(it) }.toArray(Array.newInstance(volumesClass, 0))
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     def createLink(String link) {
         Class linkClass = loadClass("${MODEL_PACKAGE}.Link")
         Method method = linkClass.getMethod("parse", String)

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -73,6 +73,15 @@ interface ThreadContextClassLoader {
     def createVolumes(List<Object> volumes)
 
     /**
+     * Creates an array of instances of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/VolumesFrom.java">VolumesFrom</a>
+     * from thread context classloader.
+     *
+     * @param volume Container name
+     * @return Array of Instances
+     */
+    def createVolumesFrom(String[] volumes)
+
+    /**
      * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/Link.java">Link</a>
      * from thread context classloader.
      *


### PR DESCRIPTION
DockerCreateContainer volumesFrom field is a string array. Trying to use this field results in the following error:

```
No signature of method: com.github.dockerjava.core.command.CreateContainerCmdImpl.withVolumesFrom() is applicable for argument types: ([Ljava.lang.String;) values: [[transaction-service-mysql-data]]
  Possible solutions: withVolumesFrom([Lcom.github.dockerjava.api.model.VolumesFrom;), getVolumesFrom(), withVolumes([Lcom.github.dockerjava.api.model.Volume;)
```

This is due to the `CreateContainerCmdImpl.withVolumesFrom()` method requiring a VolumesFrom[] array instead.