### PR TITLE
updated the docker java version from 2.1.0 . It has a bug where the Rep…

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -28,7 +28,7 @@ import org.gradle.api.artifacts.Configuration
  */
 class DockerRemoteApiPlugin implements Plugin<Project> {
     public static final String DOCKER_JAVA_CONFIGURATION_NAME = 'dockerJava'
-    public static final String DOCKER_JAVA_DEFAULT_VERSION = '2.1.0'
+    public static final String DOCKER_JAVA_DEFAULT_VERSION = '2.1.1'
     public static final String EXTENSION_NAME = 'docker'
     public static final String DEFAULT_TASK_GROUP = 'Docker'
 


### PR DESCRIPTION
…onse item is missing fields. THis causes (at least) a pull request to fail with unknown field exceptions

see https://github.com/docker-java/docker-java/commit/1d38e935efe47c2b316b083358af78f141c68d27