### PR TITLE
FIX for ISSUE-134

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -288,7 +288,7 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
             task copyFileFromContainer(type: DockerCopyFileFromContainer) {
                 dependsOn createContainer
                 targetContainerId { createContainer.getContainerId() }
-                hostPath = project.file("$projectDir/copy-file-dir/shebang.tar")
+                hostPath = "$projectDir/copy-file-dir/shebang.tar"
                 remotePath = "/bin/sh"
                 compressed = true
             }
@@ -302,7 +302,7 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
         BuildResult result = build('workflow')
 
         then:
-        new File(projectDir, "$projectDir/copy-file-dir/shebang.tar").exists()
+        new File("$projectDir/copy-file-dir/shebang.tar").exists()
     }
 
     private File createDockerfile(File imageDir) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -293,8 +293,15 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
                 compressed = true
             }
 
-            task workflow {
+            task copyDirFromContainer(type: DockerCopyFileFromContainer) {
                 dependsOn copyFileFromContainer
+                targetContainerId { createContainer.getContainerId() }
+                hostPath = "$projectDir/copy-dir"
+                remotePath = "/var/log"
+            }
+
+            task workflow {
+                dependsOn copyDirFromContainer
             }
         """
 
@@ -302,7 +309,8 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
         BuildResult result = build('workflow')
 
         then:
-        new File("$projectDir/copy-file-dir/shebang.tar").exists()
+        new File("$projectDir/copy-file-dir/shebang.tar").exists() &&
+                new File("$projectDir/copy-dir").exists()
     }
 
     private File createDockerfile(File imageDir) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -288,8 +288,9 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
             task copyFileFromContainer(type: DockerCopyFileFromContainer) {
                 dependsOn createContainer
                 targetContainerId { createContainer.getContainerId() }
-                hostPath = project.file("$buildDir/fileCopiedFromContainer.tgz")
-                resource = "/var/log"
+                hostPath = project.file("$projectDir/copy-file-dir/shebang.tar")
+                resource = "/bin/sh"
+                compressed = true
             }
 
             task workflow {
@@ -301,7 +302,7 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
         BuildResult result = build('workflow')
 
         then:
-        new File(projectDir, 'build/fileCopiedFromContainer.tgz').exists()
+        new File(projectDir, "$projectDir/copy-file-dir/shebang.tar").exists()
     }
 
     private File createDockerfile(File imageDir) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -289,7 +289,7 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
                 dependsOn createContainer
                 targetContainerId { createContainer.getContainerId() }
                 hostPath = project.file("$projectDir/copy-file-dir/shebang.tar")
-                resource = "/bin/sh"
+                remotePath = "/bin/sh"
                 compressed = true
             }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -33,8 +33,8 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
      * Path, either regular file or directory, on host. If file does not exist
      * a regular file will be created with its name.
      *
-     * If regular file output will be of type tgz. If directory then output
-     * will be untarred into directory.
+     * If regular file then hostPath will be of type tgz. If directory then output
+     * will be untarred into hostPath.
      */
     @Input
     @OutputFile

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -17,13 +17,10 @@ package com.bmuschko.gradle.docker.tasks.container
 
 import groovy.io.FileType
 import org.gradle.api.GradleException
-import org.gradle.api.file.FileCopyDetails
-import org.gradle.api.file.RelativePath
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 
 class DockerCopyFileFromContainer extends DockerExistingContainer {
-
     /**
      * Path inside container
      */
@@ -66,7 +63,7 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
         try {
 
             tarStream = containerCommand.exec()
-            def hostDestination = project.file(hostPath)
+            def hostDestination = new File(hostPath)
 
             // if compressed leave file as is otherwise untar
             if (compressed) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -15,66 +15,144 @@
  */
 package com.bmuschko.gradle.docker.tasks.container
 
+import groovy.io.FileType
+import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputFile
-
-import java.util.zip.GZIPOutputStream
 
 class DockerCopyFileFromContainer extends DockerExistingContainer {
 
-    /**
-     * Path, either regular file or directory, inside container.
-     */
     @Input
     String resource
 
-    /**
-     * Path, either regular file or directory, on host. If file does not exist
-     * a regular file will be created with its name.
-     *
-     * If regular file then hostPath will be of type tgz. If directory then output
-     * will be untarred into hostPath.
-     */
     @Input
-    @OutputFile
-    File hostPath
+    @Optional
+    File hostPath = project.projectDir
+
+    @Input
+    @Optional
+    Boolean compressed = Boolean.FALSE
 
     @Override
     void runRemoteCommand(dockerClient) {
         def containerCommand = dockerClient.copyFileFromContainerCmd(getContainerId(), getResource())
         logger.quiet "Copying '${getResource()}' from container with ID '${getContainerId()}' to '${getHostPath()}'."
 
-        // create path (non-directory) if it does not already exist
-        if (!hostPath.exists()) {
-            hostPath.parentFile.mkdirs()
-            hostPath.createNewFile()
-        }
-
-        def input = containerCommand.exec()
+        def input
         def tempFile
+        def tempDir
         try {
-            def workingFile = hostPath.isFile() ? hostPath : File.createTempFile(UUID.randomUUID().toString(), ".tgz")
-            workingFile.withOutputStream { owner.compressFile(it, input) }
-            if (hostPath.isDirectory()) {
+
+            /*
+                1.) Tar stream is handed back which can contain N number of files. Because
+                of this, we will explode into temp directory first, as we don't know
+                how many files are to receive.
+            */
+            input = containerCommand.exec()
+            tempFile = File.createTempFile(UUID.randomUUID().toString(), ".tar")
+            tempFile.withOutputStream { it << input }
+
+
+            // 2.) if compressed leave file as is otherwise untar
+            if (compressed) {
+
+                println "in compressed..."
+                println "temp file at ${tempFile.absolutePath}"
+
+                // ensure file ends with '.tar' if we are responsible for naming it
+                def fileName = new File(resource).name
+                def compressedFileName = (hostPath.exists() && hostPath.isDirectory()) ?
+                        (fileName.endsWith(".tar") ? fileName : fileName + ".tar") :
+                        hostPath.name
+
+                def compressedFileLocation = (hostPath.exists() && hostPath.isDirectory()) ?
+                        hostPath :
+                        hostPath.parentFile
+
+                println "compressedName ${compressedFileName}"
+                println "compressedLocation ${compressedFileLocation.absolutePath}"
+
+
+                if (hostPath.exists()) {
+                    if (!hostPath.isDirectory()) { hostPath.delete() }
+                } else {
+                    hostPath.parentFile.mkdirs()
+                }
+
                 project.copy {
-                    into hostPath
-                    from project.tarTree(workingFile)
+                    into compressedFileLocation
+                    from tempFile
+                    rename { compressedFileName }
+                }
+            } else {
+
+                // copy raw contents of tar into tempDir
+                tempDir = File.createTempDir()
+                project.copy {
+                    into tempDir
+                    from project.tarTree(tempFile)
+                }
+
+                /*
+                    3.) At this point we have 3 possibilities:
+
+                        a.) 0 files were found in which case we do nothing
+
+                        b.) 1 regular file was found
+
+                        c.) N regular files were found
+
+                */
+                def fileCount = 0
+                tempDir.eachFileRecurse(FileType.FILES) { fileCount++ }
+                if (fileCount == 0) {
+
+                    println "Nothing to copy."
+
+                } else if (fileCount == 1) {
+
+                    // ensure regular file does not exist as we don't want clobbering
+                    if (hostPath.exists() && !hostPath.isDirectory()) {
+                        hostPath.delete()
+                    }
+
+                    // create parent files of hostPath should they not exist
+                    if (!hostPath.exists()) {
+                        hostPath.parentFile.mkdirs()
+                    }
+
+                    if (hostPath.isDirectory()) {
+                        project.copy {
+                            into hostPath
+                            from tempDir.listFiles().last()
+                        }
+                    } else {
+                        project.copy {
+                            into hostPath.parentFile
+                            from tempDir.listFiles().last()
+                            rename { hostPath.name }
+                        }
+                    }
+                } else {
+
+                    // delete regular file should it exist
+                    if (hostPath.exists() && !hostPath.isDirectory()) {
+                        hostPath.delete()
+                    }
+                    if (!hostPath.exists()) {
+                        hostPath.mkdirs()
+                    }
+                    project.copy {
+                        into hostPath
+                        from tempDir
+                    }
                 }
             }
         } finally {
             input?.close()
             tempFile?.delete()
+            tempDir?.delete()
         }
-    }
 
-    protected compressFile(OutputStream outputStream, InputStream inputStream) {
-        GZIPOutputStream gzipOut
-        try {
-            gzipOut = new GZIPOutputStream(outputStream)
-            gzipOut << inputStream
-        } finally {
-            gzipOut?.close()
-        }
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -28,10 +28,10 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
      * Path inside container
      */
     @Input
-    String resource
+    String remotePath
 
     /**
-     * Path on disk to write resource to or into.
+     * Path on host to write remotePath to or into.
      *
      * If hostPath does not exist it will be created relative to
      * what we need it to be (e.g. regular file or directory).
@@ -55,8 +55,8 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
 
     @Override
     void runRemoteCommand(dockerClient) {
-        def containerCommand = dockerClient.copyFileFromContainerCmd(getContainerId(), getResource())
-        logger.quiet "Copying '${getResource()}' from container with ID '${getContainerId()}' to '${getHostPath()}'."
+        def containerCommand = dockerClient.copyFileFromContainerCmd(getContainerId(), getRemotePath())
+        logger.quiet "Copying '${getRemotePath()}' from container with ID '${getContainerId()}' to '${getHostPath()}'."
 
         def tarStream
         try {
@@ -82,7 +82,7 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
         // If user supplied an existing directory then we are responsible for naming and so
         // will ensure file ends with '.tar'. If user supplied a regular file then use
         // whichever name was passed in.
-        def fileName = new File(resource).name
+        def fileName = new File(getRemotePath()).name
         def compressedFileName = (hostPath.exists() && hostPath.isDirectory()) ?
                 (fileName.endsWith(".tar") ?: fileName + ".tar") :
                 hostPath.name


### PR DESCRIPTION
Refactor is intended to make DockerCopyFileFromContainer behave exactly like "docker cp". Because the API call to docker cp returns a tar stream I think it best, in keeping with the semantics of the docker remote API and what users would expect, to also write out ONLY the tar file to disk, and not gzip it, assuming the user requested so. 