### PR TITLE
Fix issue #128 DockerCreateContainer.exposedPorts should not be a Map

### DIFF
--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
@@ -4,6 +4,7 @@ import com.bmuschko.gradle.docker.AbstractIntegrationTest
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import com.bmuschko.gradle.docker.DockerRemoteApiPlugin
 import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
+import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
 import spock.lang.Unroll
 
 import java.lang.reflect.InvocationTargetException

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -17,6 +17,7 @@ package com.bmuschko.gradle.docker.utils
 
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
+import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
 
 interface ThreadContextClassLoader {
     /**
@@ -135,6 +136,15 @@ interface ThreadContextClassLoader {
      * @return Instance
      */
     def createExposedPorts(List<Object> exposedPorts)
+
+    /**
+     * Creates an array of instances of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/ExposedPort.java">ExposedPorts</a>
+     * from thread context classloader.
+     *
+     * @param exposedPorts Exposed ports
+     * @return An array of instances
+     */
+    def createExposedPortsArray(List<DockerCreateContainer.ExposedPort> exposedPorts)
 
     /**
      * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/PortBinding.java">PortBinding</a>


### PR DESCRIPTION
I think map it's a best representation of exposed ports. Simply:
```groovy
exposedPorts=[
   'tcp': [t_p1, t_p2, t_p3],
  'udp': [u_p1, u_p2, u_p3]
]
```