### PR TITLE
Issue #123 - Support for docker step reports for DockerBuildImage

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -25,6 +25,7 @@ task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
         BuildResult result = build('buildImage')
 
         then:
+        !result.standardOutput.contains('Step 1 : FROM ubuntu:12.04')
         result.standardOutput.contains('Created image with ID')
     }
 
@@ -39,11 +40,11 @@ task dockerFile(type: Dockerfile) {
 
 task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
     inputDir = file("build/docker")
-    printStream = true
 }
 """
         when:
-        BuildResult result = build('buildImage')
+        BuildResult result = build('buildImage', '-i')
+        println result.standardOutput
 
         then:
         result.standardOutput.contains('Step 1 : FROM ubuntu:12.04')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -23,7 +23,6 @@ task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
 """
         when:
         BuildResult result = build('buildImage')
-        println result.standardOutput
 
         then:
         result.standardOutput.contains('Created image with ID')
@@ -45,7 +44,6 @@ task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
 """
         when:
         BuildResult result = build('buildImage')
-        println result.standardOutput
 
         then:
         result.standardOutput.contains('Step 1 : FROM ubuntu:12.04')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -1,0 +1,55 @@
+package com.bmuschko.gradle.docker.tasks.image
+
+import com.bmuschko.gradle.docker.AbstractFunctionalTest
+import com.bmuschko.gradle.docker.TestPrecondition
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
+
+@Requires({ TestPrecondition.DOCKER_SERVER_INFO_URL_REACHABLE })
+class DockerBuildImageFunctionalTest extends AbstractFunctionalTest {
+
+    def "Can build image"() {
+        buildFile << """
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+task dockerFile(type: Dockerfile) {
+    from 'ubuntu:12.04'
+}
+
+task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
+    inputDir = file("build/docker")
+}
+"""
+        when:
+        BuildResult result = build('buildImage')
+        println result.standardOutput
+
+        then:
+        result.standardOutput.contains('Created image with ID')
+    }
+
+    def "Can build image and print stream"() {
+        buildFile << """
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+task dockerFile(type: Dockerfile) {
+    from 'ubuntu:12.04'
+}
+
+task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
+    inputDir = file("build/docker")
+    printStream = true
+}
+"""
+        when:
+        BuildResult result = build('buildImage')
+        println result.standardOutput
+
+        then:
+        result.standardOutput.contains('Step 1 : FROM ubuntu:12.04')
+        result.standardOutput.contains('Created image with ID')
+    }
+
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -54,6 +54,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
             config.defaultDependencies { dependencies ->
                 dependencies.add(project.dependencies.create("com.github.docker-java:docker-java:$DockerRemoteApiPlugin.DOCKER_JAVA_DEFAULT_VERSION"))
                 dependencies.add(project.dependencies.create('org.slf4j:slf4j-simple:1.7.5'))
+                dependencies.add(project.dependencies.create('cglib:cglib:3.2.0'))
             }
 
             group = DEFAULT_TASK_GROUP

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -58,6 +58,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     @Optional
     Boolean pull
 
+    @Input
+    @Optional
+    Boolean printStream
+
     /**
      * The target Docker registry credentials for building image.
      */
@@ -113,7 +117,11 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             buildImageCmd.withBuildAuthConfigs(authConfigurations)
         }
 
-        def response = buildImageCmd.exec(threadContextClassLoader.createBuildImageResultCallback())
+        def callback = threadContextClassLoader.createBuildImageResultCallback()
+        if (printStream) {
+            callback = threadContextClassLoader.createPrintStreamProxyCallback(callback)
+        }
+        def response = buildImageCmd.exec(callback)
         imageId = response.awaitImageId()
         logger.quiet "Created image with ID '$imageId'."
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -118,9 +118,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
         }
 
         def callback = threadContextClassLoader.createBuildImageResultCallback()
-        if (printStream) {
-            callback = threadContextClassLoader.createPrintStreamProxyCallback(callback)
-        }
+        callback = threadContextClassLoader.createPrintStreamProxyCallback(logger, callback)
         def response = buildImageCmd.exec(callback)
         imageId = response.awaitImageId()
         logger.quiet "Created image with ID '$imageId'."

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -310,6 +310,25 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         createCallback("${COMMAND_PACKAGE}.PullImageResultCallback")
     }
 
+    @Override
+    def createPrintStreamProxyCallback(delegate) {
+        Class enhancerClass = loadClass('net.sf.cglib.proxy.Enhancer')
+        def enhancer = enhancerClass.getConstructor().newInstance()
+        enhancer.setSuperclass(delegate.getClass())
+        enhancer.setCallback([
+
+                invoke: {Object proxy, Method method, Object[] args ->
+                    if ("onNext" == method.name) {
+                        println args[0].stream
+                    }
+                    method.invoke(delegate, args)
+                }
+
+        ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
+
+        enhancer.create()
+    }
+
     private Object createCallback(String className) {
         Class callbackClass = loadClass(className)
         Constructor constructor = callbackClass.getConstructor()

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -17,6 +17,7 @@ package com.bmuschko.gradle.docker.utils
 
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
+import org.slf4j.Logger
 
 import java.lang.reflect.Array
 import java.lang.reflect.Constructor
@@ -311,7 +312,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     }
 
     @Override
-    def createPrintStreamProxyCallback(delegate) {
+    def createPrintStreamProxyCallback(Logger logger, delegate) {
         Class enhancerClass = loadClass('net.sf.cglib.proxy.Enhancer')
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(delegate.getClass())
@@ -319,7 +320,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
 
                 invoke: {Object proxy, Method method, Object[] args ->
                     if ("onNext" == method.name) {
-                        println args[0].stream
+                        logger.info(args[0].stream)
                     }
                     method.invoke(delegate, args)
                 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -207,4 +207,13 @@ interface ThreadContextClassLoader {
      * @return Callback instance
      */
     def createPullImageResultCallback()
+
+    /**
+     * Creates a proxy that delegates its calls to a given callback. Whenever the <code>onNext</code> method is called, the
+     * proxy will print the stream returned by docker to standard output.
+     *
+     * @param delegate the callback the proxy will delegate to
+     * @return proxy instance
+     */
+    def createPrintStreamProxyCallback(delegate)
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -17,6 +17,7 @@ package com.bmuschko.gradle.docker.utils
 
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
+import org.slf4j.Logger
 
 interface ThreadContextClassLoader {
     /**
@@ -210,10 +211,11 @@ interface ThreadContextClassLoader {
 
     /**
      * Creates a proxy that delegates its calls to a given callback. Whenever the <code>onNext</code> method is called, the
-     * proxy will print the stream returned by docker to standard output.
+     * proxy will print the stream returned by docker to the given logger.
      *
+     * @param logger instance stream messages will be printed to
      * @param delegate the callback the proxy will delegate to
      * @return proxy instance
      */
-    def createPrintStreamProxyCallback(delegate)
+    def createPrintStreamProxyCallback(Logger logger, delegate)
 }


### PR DESCRIPTION
I've managed to implement using cglib. It feels a little awkward, but it works. I created a `printStream` option to turn printing the stream on and off. I'd vote to have it on by default, but I left it off to keep the current behaviour. I created a `createPrintStreamProxyCallback` on `ThreadContextClassLoader` that can be used to implement the same behaviour for other async tasks. If you like this implementation I can work on that afterwards.