### PR TITLE
Rebase #PR-141 / Issue #123 - Support for docker step reports for DockerBuildImage

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -1,0 +1,54 @@
+package com.bmuschko.gradle.docker.tasks.image
+
+import com.bmuschko.gradle.docker.AbstractFunctionalTest
+import com.bmuschko.gradle.docker.TestPrecondition
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
+
+@Requires({ TestPrecondition.DOCKER_SERVER_INFO_URL_REACHABLE })
+class DockerBuildImageFunctionalTest extends AbstractFunctionalTest {
+
+    def "Can build image"() {
+        buildFile << """
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+task dockerFile(type: Dockerfile) {
+    from 'ubuntu:12.04'
+}
+
+task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
+    inputDir = file("build/docker")
+}
+"""
+        when:
+        BuildResult result = build('buildImage')
+
+        then:
+        !result.standardOutput.contains('Step 1 : FROM ubuntu:12.04')
+        result.standardOutput.contains('Created image with ID')
+    }
+
+    def "Can build image and print stream"() {
+        buildFile << """
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+task dockerFile(type: Dockerfile) {
+    from 'ubuntu:12.04'
+}
+
+task buildImage(type: DockerBuildImage, dependsOn: dockerFile) {
+    inputDir = file("build/docker")
+}
+"""
+        when:
+        BuildResult result = build('buildImage', '-i')
+        println result.standardOutput
+
+        then:
+        result.standardOutput.contains('Step 1 : FROM ubuntu:12.04')
+        result.standardOutput.contains('Created image with ID')
+    }
+
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -54,6 +54,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
             config.defaultDependencies { dependencies ->
                 dependencies.add(project.dependencies.create("com.github.docker-java:docker-java:$DockerRemoteApiPlugin.DOCKER_JAVA_DEFAULT_VERSION"))
                 dependencies.add(project.dependencies.create('org.slf4j:slf4j-simple:1.7.5'))
+                dependencies.add(project.dependencies.create('cglib:cglib:3.2.0'))
             }
 
             group = DEFAULT_TASK_GROUP

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -113,7 +113,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             buildImageCmd.withBuildAuthConfigs(authConfigurations)
         }
 
-        def response = buildImageCmd.exec(threadContextClassLoader.createBuildImageResultCallback())
+        def response = buildImageCmd.exec(threadContextClassLoader.createBuildImageResultCallback(logger))
         imageId = response.awaitImageId()
         logger.quiet "Created image with ID '$imageId'."
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -18,6 +18,7 @@ package com.bmuschko.gradle.docker.utils
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
 import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+import org.gradle.api.logging.Logger
 
 interface ThreadContextClassLoader {
     /**
@@ -198,9 +199,10 @@ interface ThreadContextClassLoader {
      * Creates the callback instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/core/command/BuildImageResultCallback.java">BuildImageResultCallback</a>
      * from thread context classloader.
      *
+     * @param logger The logger instance which docker stream items will be printed to
      * @return Callback instance
      */
-    def createBuildImageResultCallback()
+    def createBuildImageResultCallback(Logger logger)
 
     /**
      * Creates the callback instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/core/command/PushImageResultCallback.java">PushImageResultCallback</a>


### PR DESCRIPTION
Rebased #141 against master.

I also changed `createBuildImageResultCallback` to receive a logger parameter, instead of having an extra method to create the proxy callback.