### PR TITLE
Demo of execution handler using closures

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -41,11 +41,11 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     File certPath
 
     /**
-     * The default response handler
+     * The default execution handler
      */
     @Input
     @Optional
-    Closure responseHandler
+    Closure executionHandler
 
     ThreadContextClassLoader threadContextClassLoader
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -41,11 +41,11 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     File certPath
 
     /**
-     * The default execution handler
+     * Response handler is given 2 objects: response and exception
      */
     @Input
     @Optional
-    Closure executionHandler
+    Closure responseHandler
 
     ThreadContextClassLoader threadContextClassLoader
 
@@ -68,4 +68,20 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     }
 
     abstract void runRemoteCommand(dockerClient)
+
+    public void executeCommand(def command) {
+        def possibleResponse
+        Exception possibleException
+        try {
+            possibleResponse = command.exec()
+        } catch (Exception e) {
+            possibleException = e
+        }
+
+        if(getResponseHandler()) {
+            getResponseHandler()(possibleResponse, possibleException)
+        } else {
+            if (possibleException) throw possibleException
+        }
+    }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -40,6 +40,13 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     @Optional
     File certPath
 
+    /**
+     * The default response handler
+     */
+    @Input
+    @Optional
+    Closure responseHandler
+
     ThreadContextClassLoader threadContextClassLoader
 
     @TaskAction

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
@@ -21,13 +21,15 @@ class DockerInspectContainer extends DockerExistingContainer {
     void runRemoteCommand(dockerClient) {
         logger.quiet "Inspecting container with ID '${getContainerId()}'."
         def command = dockerClient.inspectContainerCmd(getContainerId())
-        configureExecutionHandler()(command)
+        configureResponseHandler()
+        executeCommand(command)
     }
 
-    private Closure configureExecutionHandler() {
-        if(!getExecutionHandler()) {
-            setExecutionHandler { command ->
-                def container = command.exec()
+    private void configureResponseHandler() {
+        if(!getResponseHandler()) {
+            responseHandler { container, exception ->
+                if (exception) throw exception
+
                 logger.quiet "Image ID    : $container.imageId"
                 logger.quiet "Name        : $container.name"
                 logger.quiet "Links       : $container.hostConfig.links"
@@ -37,6 +39,5 @@ class DockerInspectContainer extends DockerExistingContainer {
                 logger.quiet "ExposedPorts : $exposedPorts"
             }
         }
-        getExecutionHandler()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
@@ -15,20 +15,28 @@
  */
 package com.bmuschko.gradle.docker.tasks.container
 
-import com.bmuschko.gradle.docker.response.ResponseHandler
-import com.bmuschko.gradle.docker.response.container.InspectContainerResponseHandler
-
 class DockerInspectContainer extends DockerExistingContainer {
-    private ResponseHandler<Void, Object> responseHandler = new InspectContainerResponseHandler()
 
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Inspecting container with ID '${getContainerId()}'."
-        def container = dockerClient.inspectContainerCmd(getContainerId()).exec()
-        responseHandler.handle(container)
+        def command = dockerClient.inspectContainerCmd(getContainerId())
+        configureResponseHandler()(command)
     }
 
-    void setResponseHandler(ResponseHandler<Void, Object> responseHandler) {
-        this.responseHandler = responseHandler
+    private Closure configureResponseHandler() {
+        if(!getResponseHandler()) {
+            setResponseHandler { command ->
+                def container = command.exec()
+                logger.quiet "Image ID    : $container.imageId"
+                logger.quiet "Name        : $container.name"
+                logger.quiet "Links       : $container.hostConfig.links"
+                logger.quiet "Volumes     : $container.volumes"
+                logger.quiet "VolumesFrom : $container.hostConfig.volumesFrom"
+                String exposedPorts = container.config?.@exposedPorts ? container.config.exposedPorts : '[]'
+                logger.quiet "ExposedPorts : $exposedPorts"
+            }
+        }
+        getResponseHandler()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.groovy
@@ -21,12 +21,12 @@ class DockerInspectContainer extends DockerExistingContainer {
     void runRemoteCommand(dockerClient) {
         logger.quiet "Inspecting container with ID '${getContainerId()}'."
         def command = dockerClient.inspectContainerCmd(getContainerId())
-        configureResponseHandler()(command)
+        configureExecutionHandler()(command)
     }
 
-    private Closure configureResponseHandler() {
-        if(!getResponseHandler()) {
-            setResponseHandler { command ->
+    private Closure configureExecutionHandler() {
+        if(!getExecutionHandler()) {
+            setExecutionHandler { command ->
                 def container = command.exec()
                 logger.quiet "Image ID    : $container.imageId"
                 logger.quiet "Name        : $container.name"
@@ -37,6 +37,6 @@ class DockerInspectContainer extends DockerExistingContainer {
                 logger.quiet "ExposedPorts : $exposedPorts"
             }
         }
-        getResponseHandler()
+        getExecutionHandler()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerKillContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerKillContainer.groovy
@@ -20,15 +20,6 @@ class DockerKillContainer extends DockerExistingContainer {
     void runRemoteCommand(dockerClient) {
         logger.quiet "Killing container with ID '${getContainerId()}'."
         def command = dockerClient.killContainerCmd(getContainerId())
-        configureExecutionHandler()(command)
-    }
-
-    private Closure configureExecutionHandler() {
-        if(!getExecutionHandler()) {
-            setExecutionHandler { command ->
-                command.exec()
-            }
-        }
-        getExecutionHandler()
+        executeCommand(command)
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerKillContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerKillContainer.groovy
@@ -20,15 +20,15 @@ class DockerKillContainer extends DockerExistingContainer {
     void runRemoteCommand(dockerClient) {
         logger.quiet "Killing container with ID '${getContainerId()}'."
         def command = dockerClient.killContainerCmd(getContainerId())
-        configureResponseHandler()(command)
+        configureExecutionHandler()(command)
     }
 
-    private Closure configureResponseHandler() {
-        if(!getResponseHandler()) {
-            setResponseHandler { command ->
+    private Closure configureExecutionHandler() {
+        if(!getExecutionHandler()) {
+            setExecutionHandler { command ->
                 command.exec()
             }
         }
-        getResponseHandler()
+        getExecutionHandler()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerKillContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerKillContainer.groovy
@@ -19,6 +19,16 @@ class DockerKillContainer extends DockerExistingContainer {
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Killing container with ID '${getContainerId()}'."
-        dockerClient.killContainerCmd(getContainerId()).exec()
+        def command = dockerClient.killContainerCmd(getContainerId())
+        configureResponseHandler()(command)
+    }
+
+    private Closure configureResponseHandler() {
+        if(!getResponseHandler()) {
+            setResponseHandler { command ->
+                command.exec()
+            }
+        }
+        getResponseHandler()
     }
 }


### PR DESCRIPTION
A demo for using closures as an exposable "execution handler" for downstream users. The idea is that users, by far and large, will not be using these but instead using the OOTB version. Should they want to use their own closure they will be responsible for implementing the contract already in place by the given task. A couple things to note:
1. We do not set the executionHandler closure by default thereby allowing users to supply their own.
2. All applicable tasks will now have a corresponding 'configureExecutionHandler()' method that will check if the executionHandler has been set by the user and if not, set our own relative to what the given task requires. Follows the semantics already set by the plugin.

Downstream users could then do something like the snippet below. This will allow the DockerCreateContainer task to succeed should a previous container with that name already exist. Users could then implement something similar for the DockerRemoveContainer task so they don't fail should a container not exist but instead just output that the container is not there or just the exception message like I've done below.

@bmuschko thoughts? I've obviously only done this in a handful of places so as to just get the point across. 

```
task createContainer(type: com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer) {
    targetImageId { "hello-world:latest" }
    containerName = "cdancy-test"
    executionHandler { command ->
        try {
            def container = command.exec()
            logger.quiet "OVERRIDE: Created container with ID '$container.id'."
            container.id
        } catch (Exception e) {
            logger.quiet("Found an exception: " + e.message)
        }
    }
}
```

EDIT: changed name of responseHandler to executionHandler
