### PR TITLE
Rework plugin to support single dockerClient with isolated ClassLoader

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -42,13 +42,20 @@ abstract class AbstractFunctionalTest extends Specification {
                 .collect { "'$it'" }
                 .join(", ")
 
-        // Add the logic under test to the test build
+        // Add the logic under test to the test build. 
+        //
+        // We are adding known versions of dependencies that will break the plugin 
+        // should they leak into our custom classloader. Should our custom classloader
+        // be configured correctly adding these to the buildscript classpath should
+        // cause no issue.
         buildFile << """
             buildscript {
                 repositories {
                     mavenCentral()
                 }
                 dependencies {
+                    classpath 'org.bouncycastle:bcpkix-jdk15on:1.47'
+                	classpath 'xml-apis:xml-apis:2.0.2'
                     classpath files($pluginClasspath)
                 }
             }
@@ -56,10 +63,6 @@ abstract class AbstractFunctionalTest extends Specification {
 
         buildFile << """
             apply plugin: com.bmuschko.gradle.docker.DockerRemoteApiPlugin
-
-            repositories {
-                mavenCentral()
-            }
         """
 
         setupDockerServerUrl()

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -45,6 +45,9 @@ abstract class AbstractFunctionalTest extends Specification {
         // Add the logic under test to the test build
         buildFile << """
             buildscript {
+                repositories {
+                    mavenCentral()
+                }
                 dependencies {
                     classpath files($pluginClasspath)
                 }

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -9,6 +9,10 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
 
     def setup() {
         project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+
+        project.repositories {
+            mavenCentral()
+        }
     }
 
     def "Does not create tasks out-of-the-box when application plugin is not applied"() {

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
@@ -4,7 +4,6 @@ import com.bmuschko.gradle.docker.AbstractIntegrationTest
 import com.bmuschko.gradle.docker.DockerExtension
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import com.bmuschko.gradle.docker.DockerRemoteApiPlugin
-import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import spock.lang.Shared

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -46,26 +46,20 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
     }
 
     private void configureAbstractDockerTask(Project project, DockerExtension extension) {
-        ThreadContextClassLoader dockerClassLoader = new DockerThreadContextClassLoader()
-
+        ThreadContextClassLoader dockerClassLoader = new DockerThreadContextClassLoader(extension, configurePluginClassPath(project))
         project.tasks.withType(AbstractDockerRemoteApiTask) {
-            Configuration config = project.configurations[DOCKER_JAVA_CONFIGURATION_NAME]
-
-            config.defaultDependencies { dependencies ->
-                dependencies.add(project.dependencies.create("com.github.docker-java:docker-java:$DockerRemoteApiPlugin.DOCKER_JAVA_DEFAULT_VERSION"))
-                dependencies.add(project.dependencies.create('org.slf4j:slf4j-simple:1.7.5'))
-                dependencies.add(project.dependencies.create('cglib:cglib:3.2.0'))
-            }
-
             group = DEFAULT_TASK_GROUP
             threadContextClassLoader = dockerClassLoader
-
-            conventionMapping.with {
-                classpath = { config }
-                url = { extension.url }
-                certPath = { extension.certPath }
-            }
         }
+    }
+
+    private Set<File> configurePluginClassPath(Project project) {
+        project.repositories.addAll(project.buildscript.repositories.collect())
+        project.configurations.getByName(DOCKER_JAVA_CONFIGURATION_NAME).defaultDependencies { dependencies ->
+            dependencies.add(project.dependencies.create("com.github.docker-java:docker-java:$DockerRemoteApiPlugin.DOCKER_JAVA_DEFAULT_VERSION"))
+            dependencies.add(project.dependencies.create('org.slf4j:slf4j-simple:1.7.5'))
+            dependencies.add(project.dependencies.create('cglib:cglib:3.2.0'))
+        }.files
     }
 
     private void configureRegistryAwareTasks(Project project, DockerExtension extension) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -21,24 +21,6 @@ import org.gradle.api.file.FileCollection
 import org.gradle.api.tasks.*
 
 abstract class AbstractDockerRemoteApiTask extends DefaultTask {
-    /**
-     * Classpath for Docker Java libraries.
-     */
-    @InputFiles
-    FileCollection classpath
-
-    /**
-     * Docker remote API server URL. Defaults to "http://localhost:2375".
-     */
-    @Input
-    String url = 'http://localhost:2375'
-
-    /**
-     * Path to the <a href="https://docs.docker.com/articles/https/">Docker certificate and key</a>.
-     */
-    @InputDirectory
-    @Optional
-    File certPath
 
     ThreadContextClassLoader threadContextClassLoader
 
@@ -50,14 +32,7 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     }
 
     void runInDockerClassPath(Closure closure) {
-        threadContextClassLoader.withClasspath(getClasspath().files, createDockerClientConfig(), closure)
-    }
-
-    private DockerClientConfiguration createDockerClientConfig() {
-        DockerClientConfiguration dockerClientConfig = new DockerClientConfiguration()
-        dockerClientConfig.url = getUrl()
-        dockerClientConfig.certPath = getCertPath()
-        dockerClientConfig
+        threadContextClassLoader.withClosure(closure)
     }
 
     abstract void runRemoteCommand(dockerClient)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClientConfiguration.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClientConfiguration.groovy
@@ -1,6 +1,0 @@
-package com.bmuschko.gradle.docker.tasks
-
-class DockerClientConfiguration {
-    String url
-    File certPath
-}

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -15,6 +15,7 @@
  */
 package com.bmuschko.gradle.docker.utils
 
+import com.bmuschko.gradle.docker.DockerExtension
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
 import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
@@ -29,22 +30,27 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     public static final String MODEL_PACKAGE = 'com.github.dockerjava.api.model'
     public static final String COMMAND_PACKAGE = 'com.github.dockerjava.core.command'
 
+    private final DockerExtension dockerExtension
+    private final Set<File> classpath
+    private def dockerClient
+
+    public DockerThreadContextClassLoader(DockerExtension dockerExtension, Set<File> classpath) {
+        this.dockerExtension = dockerExtension
+        this.classpath = classpath
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
-    void withClasspath(Set<File> classpathFiles, DockerClientConfiguration dockerClientConfiguration, Closure closure) {
-        ClassLoader originalClassLoader = getClass().classLoader
+    void withClosure(Closure closure) {
+        if (!dockerClient) {
+            dockerClient = getDockerClient()
+        }
 
-        try {
-            Thread.currentThread().contextClassLoader = createClassLoader(classpathFiles)
-            closure.resolveStrategy = Closure.DELEGATE_FIRST
-            closure.delegate = this
-            closure(getDockerClient(dockerClientConfiguration))
-        }
-        finally {
-            Thread.currentThread().contextClassLoader = originalClassLoader
-        }
+        closure.resolveStrategy = Closure.DELEGATE_FIRST
+        closure.delegate = this
+        closure(dockerClient)
     }
 
     /**
@@ -73,21 +79,22 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
      * @param dockerClientConfiguration Docker client configuration
      * @return DockerClient instance
      */
-    private getDockerClient(DockerClientConfiguration dockerClientConfiguration) {
-        // Create configuration
-        Class dockerClientConfigClass = loadClass('com.github.dockerjava.core.DockerClientConfig')
+    private getDockerClient() {
+
+        ClassLoader classLoader = createClassLoader(classpath)
+        Class dockerClientConfigClass = loadClass(classLoader, 'com.github.dockerjava.core.DockerClientConfig')
         Method dockerClientConfigMethod = dockerClientConfigClass.getMethod('createDefaultConfigBuilder')
         def dockerClientConfigBuilder = dockerClientConfigMethod.invoke(null)
-        dockerClientConfigBuilder.withUri(dockerClientConfiguration.url)
+        dockerClientConfigBuilder.withUri(dockerExtension.url)
 
-        if(dockerClientConfiguration.certPath) {
-            dockerClientConfigBuilder.withDockerCertPath(dockerClientConfiguration.certPath.canonicalPath)
+        if(dockerExtension.certPath) {
+            dockerClientConfigBuilder.withDockerCertPath(dockerExtension.certPath.canonicalPath)
         }
 
         def dockerClientConfig = dockerClientConfigBuilder.build()
 
         // Create client
-        Class dockerClientBuilderClass = loadClass('com.github.dockerjava.core.DockerClientBuilder')
+        Class dockerClientBuilderClass = loadClass(classLoader, 'com.github.dockerjava.core.DockerClientBuilder')
         Method method = dockerClientBuilderClass.getMethod('getInstance', dockerClientConfigClass)
         def dockerClientBuilder = method.invoke(null, dockerClientConfig)
         dockerClientBuilder.build()
@@ -98,7 +105,11 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
      */
     @Override
     Class loadClass(String className) {
-        Thread.currentThread().contextClassLoader.loadClass(className)
+        dockerClient.class.classLoader.loadClass(className)
+    }
+
+    Class loadClass(ClassLoader classLoader, String className) {
+        classLoader.loadClass(className)
     }
 
     /**

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -17,7 +17,6 @@ package com.bmuschko.gradle.docker.utils
 
 import com.bmuschko.gradle.docker.DockerExtension
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
-import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
 import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
 import org.gradle.api.GradleException
 import org.gradle.api.logging.Logger
@@ -74,9 +73,8 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     }
 
     /**
-     * Creates DockerClient from ClassLoader.
+     * Creates DockerClient with custom ClassLoader
      *
-     * @param dockerClientConfiguration Docker client configuration
      * @return DockerClient instance
      */
     private getDockerClient() {

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -43,13 +43,9 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
      */
     @Override
     void withClosure(Closure closure) {
-        if (!dockerClient) {
-            dockerClient = getDockerClient()
-        }
-
         closure.resolveStrategy = Closure.DELEGATE_FIRST
         closure.delegate = this
-        closure(dockerClient)
+        closure(getDockerClient())
     }
 
     /**
@@ -72,12 +68,20 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         files.collect { file -> file.toURI().toURL() } as URL[]
     }
 
+	public getDockerClient() {
+		dockerClient = dockerClient ?: createDockerClient()
+		if (!dockerExtension.url.toString().equals(dockerClient.@dockerClientConfig.@uri.toString())) {
+			dockerClient = createDockerClient()
+		} 
+		dockerClient
+	}
+	
     /**
      * Creates DockerClient with custom ClassLoader
      *
      * @return DockerClient instance
      */
-    private getDockerClient() {
+    private createDockerClient() {
 
         ClassLoader classLoader = createClassLoader(classpath)
         Class dockerClientConfigClass = loadClass(classLoader, 'com.github.dockerjava.core.DockerClientConfig')

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -16,7 +16,6 @@
 package com.bmuschko.gradle.docker.utils
 
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
-import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
 import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
 import org.gradle.api.logging.Logger
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -22,16 +22,14 @@ import org.gradle.api.logging.Logger
 
 interface ThreadContextClassLoader {
     /**
-     * Performs the closure with thread context classloader.
+     * Performs the closure within the dockerClient classloader
      *
-     * @param classpathFiles Classpath files
-     * @param dockerClientConfiguration Docker client configuration
      * @param closure the given closure
      */
-    void withClasspath(Set<File> classpathFiles, DockerClientConfiguration dockerClientConfiguration, Closure closure)
+    void withClosure(Closure closure)
 
     /**
-     * Loads class with given name from thread context classloader.
+     * Loads class with given name from dockerClient classloader.
      *
      * @param className Class name
      * @return Class


### PR DESCRIPTION
Addresses #175 . Some notes:

1) Single instance of dockerClient is created and used across the board.
2) Custom ClassLoader impl is simplified immensely.
3) DockerClientConfig is removed as it's no longer needed. And which leads me to...
4) url/certpath/classpath are removed from AbstractDockerTask. The last was required as part of this fix but are the first 2 (url and certpath) really being used on tasks? I think this is something that is common across all tasks and thus should stay in DockerExtension only.
5) All functional tests pass.

@bmuschko thoughts and review?
