### PR TITLE
Extension variable for docker remote api version.

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
@@ -21,6 +21,7 @@ class DockerExtension {
     String url = 'http://localhost:2375'
     File certPath
     DockerRegistryCredentials registryCredentials
+    String apiVersion
 
     void registryCredentials(Closure closure) {
         registryCredentials = new DockerRegistryCredentials()

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -64,6 +64,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
                 classpath = { config }
                 url = { extension.url }
                 certPath = { extension.certPath }
+                apiVersion = { extension.apiVersion }
             }
         }
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -40,6 +40,13 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     @Optional
     File certPath
 
+    /**
+     * The docker remote api version
+     */
+    @Input
+    @Optional
+    String apiVersion
+
     ThreadContextClassLoader threadContextClassLoader
 
     @TaskAction
@@ -57,6 +64,7 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
         DockerClientConfiguration dockerClientConfig = new DockerClientConfiguration()
         dockerClientConfig.url = getUrl()
         dockerClientConfig.certPath = getCertPath()
+        dockerClientConfig.apiVersion = getApiVersion()
         dockerClientConfig
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClientConfiguration.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClientConfiguration.groovy
@@ -3,4 +3,5 @@ package com.bmuschko.gradle.docker.tasks
 class DockerClientConfiguration {
     String url
     File certPath
+    String apiVersion
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -84,6 +84,10 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
             dockerClientConfigBuilder.withDockerCertPath(dockerClientConfiguration.certPath.canonicalPath)
         }
 
+        if(dockerClientConfiguration.apiVersion) {
+            dockerClientConfigBuilder.withVersion(dockerClientConfiguration.apiVersion)
+        }
+
         def dockerClientConfig = dockerClientConfigBuilder.build()
 
         // Create client


### PR DESCRIPTION
Provide a way to set the docker remote api version on the underlying docker-java library.
The default version seems to be UNKNOWN_VERSION, which usually is ok, but if you are
talking to a v2 registry, the api version is used as a proxy to determine how to send
authentication headers.  If unset, v2 registry authentication will fail.  See also
https://github.com/docker-java/docker-java/issues/506