### PR TITLE
Check if directory exists before trying to create it

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -97,7 +97,7 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
                     throw new GradleException("Failed deleting previously existing file at ${hostDestination.path}")
 
         } else {
-            if (!hostDestination.parentFile.mkdirs())
+            if (!hostDestination.parentFile.exists() && !hostDestination.parentFile.mkdirs())
                 throw new GradleException("Failed creating parent directory for ${hostDestination.path}")
         }
 


### PR DESCRIPTION
mkdirs returns false if it doesn't need to create any directories.

I suggest we check if the path exists first so that we don't end up throwing any exception if the directory already exists