### PR TITLE
Save exit-code of started container in property ext.exitCode on

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -122,7 +122,7 @@ The plugin provides the following custom task types for managing containers:
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerRestartContainer.html[DockerRestartContainer]           |Restarts the container for a given id.
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerStartContainer.html[DockerStartContainer]               |Starts the container for a given id.
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerStopContainer.html[DockerStopContainer]                 |Stops the container for a given id.
-|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainer.html[DockerWaitContainer]                 |Blocks until container for a given id stops, then returns the exit code.
+|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainer.html[DockerWaitContainer]                 |Blocks until container for a given id stops. Exit-Code can be retrieved with getExitCode().
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.html[DockerLogsContainer]                 |Copies the container output to the Gradle process standard out/err.
 |=======
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWaitContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWaitContainerFunctionalTest.groovy
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.docker
+
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
+
+@Requires({ TestPrecondition.DOCKER_SERVER_INFO_URL_REACHABLE })
+class DockerWaitContainerFunctionalTest extends AbstractFunctionalTest {
+    def "Wait for a container to finish and get the exit code"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerWaitContainer
+
+            task pullImage(type: DockerPullImage) {
+                repository = 'alpine'
+                tag = 'latest'
+            }
+
+            task createContainer(type: DockerCreateContainer){
+                dependsOn pullImage
+                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                cmd 'sh', '-c', 'exit 0'
+            }
+
+            task startContainer(type: DockerStartContainer){
+                dependsOn createContainer
+                targetContainerId {createContainer.getContainerId()}
+            }
+
+            task runContainers(type: DockerWaitContainer){
+                dependsOn startContainer
+                targetContainerId {startContainer.getContainerId()}
+                doLast{
+                    if(getExitCode() != 0) {
+                        println "Container failed with exit code \${getExitCode()}"
+                    } else {
+                        println "Container successful"
+                    }
+                }
+            }
+        """
+
+        expect:
+        BuildResult result = build('runContainers')
+        result.output.contains("Container successful")
+    }
+
+    def "Wait for a container to fail and get the exit code"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerWaitContainer
+
+            task pullImage(type: DockerPullImage) {
+                repository = 'alpine'
+                tag = 'latest'
+            }
+
+            task createContainer(type: DockerCreateContainer){
+                dependsOn pullImage
+                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                cmd 'sh', '-c', 'exit 1'
+            }
+
+            task startContainer(type: DockerStartContainer){
+                dependsOn createContainer
+                targetContainerId {createContainer.getContainerId()}
+            }
+
+            task runContainers(type: DockerWaitContainer){
+                dependsOn startContainer
+                targetContainerId {startContainer.getContainerId()}
+                doLast{
+                    if(getExitCode() != 0) {
+                        println "Container failed with exit code \${getExitCode()}"
+                    } else {
+                        println "Container successful"
+                    }
+                }
+            }
+        """
+
+        expect:
+        BuildResult result = build('runContainers')
+        result.output.contains("Container failed with exit code 1")
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainer.groovy
@@ -16,9 +16,18 @@
 package com.bmuschko.gradle.docker.tasks.container
 
 class DockerWaitContainer extends DockerExistingContainer {
+
+    protected int exitCode
+
+    DockerWaitContainer(){
+        ext.getExitCode = {exitCode}
+    }
+
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Waiting for container with ID '${getContainerId()}'."
-        dockerClient.waitContainerCmd(getContainerId()).exec()
+        def containerCommand = dockerClient.waitContainerCmd(getContainerId())
+        exitCode = containerCommand.exec()
+        logger.quiet "Container exited with code ${exitCode}"
     }
 }


### PR DESCRIPTION
The change allows to retrieve the exit code of the specified docker container.
The exit code is stored in the property ext.exitCode