### PR TITLE
Plugin does not set withDockerTlsVerify(true) where required

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -104,6 +104,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         dockerClientConfigBuilder.withDockerHost(dockerUrl)
 
         if (dockerCertPath) {
+            dockerClientConfigBuilder.withDockerTlsVerify(true)
             dockerClientConfigBuilder.withDockerCertPath(dockerCertPath.canonicalPath)
         } else {
             dockerClientConfigBuilder.withDockerTlsVerify(false)


### PR DESCRIPTION
Using Docker Machine on OS X, even if I set the `url` and the `certPath` correctly for the plugin (same values as shown by running `docker-machine env`), my `dockerBuildImage` task fails with an exception like the one shown at the bottom.  After much troubleshooting, I discovered that the minimal environmental change needed to get it to work is to run this command before doing the `gradle dockerBuildImage`:

    export DOCKER_TLS_VERIFY="1"

The present pull request ensures that the plugin always sets the corresponding option on the Docker client.  I've verified locally that with this change, my build succeeds when just setting the `url` and `certPath`.

Software versions I'm using:

* `gradle-docker-plugin`: 3.0.0
* Docker version 1.11.1, build 5604cbe
* docker-machine version 0.7.0, build a650a40
* Mac OS X 10.10.4, BuildVersion: 14E46

The following is the exception.  I think the cause for this is that it tries to connect to a TLS-enabled remote but in non-TLS mode, and it gets all confusticated:

```
[dockerjava-jaxrs-async-0] ERROR com.github.dockerjava.core.async.ResultCallbackTemplate - Error during callback
org.apache.http.client.ClientProtocolException
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:188)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:72)
	at com.github.dockerjava.jaxrs.connector.ApacheConnector.apply(ApacheConnector.java:437)
	at org.glassfish.jersey.client.ClientRuntime.invoke(ClientRuntime.java:246)
	at org.glassfish.jersey.client.JerseyInvocation$2.call(JerseyInvocation.java:683)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:315)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:297)
	at org.glassfish.jersey.internal.Errors.process(Errors.java:228)
	at org.glassfish.jersey.process.internal.RequestScope.runInScope(RequestScope.java:424)
	at org.glassfish.jersey.client.JerseyInvocation.invoke(JerseyInvocation.java:679)
	at org.glassfish.jersey.client.JerseyInvocation$Builder.method(JerseyInvocation.java:435)
	at org.glassfish.jersey.client.JerseyInvocation$Builder.post(JerseyInvocation.java:338)
	at com.github.dockerjava.jaxrs.async.POSTCallbackNotifier.response(POSTCallbackNotifier.java:29)
	at com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier.call(AbstractCallbackNotifier.java:50)
	at com.github.dockerjava.jaxrs.async.AbstractCallbackNotifier.call(AbstractCallbackNotifier.java:24)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
	at java.lang.Thread.run(Thread.java:744)
Caused by: org.apache.http.client.NonRepeatableRequestException: Cannot retry request with a non-repeatable request entity
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:102)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:108)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:186)
	... 18 more
Caused by: java.net.SocketException: Broken pipe
	at java.net.SocketOutputStream.socketWrite0(Native Method)
	at java.net.SocketOutputStream.socketWrite(SocketOutputStream.java:109)
	at java.net.SocketOutputStream.write(SocketOutputStream.java:153)
	at org.apache.http.impl.io.SessionOutputBufferImpl.streamWrite(SessionOutputBufferImpl.java:123)
	at org.apache.http.impl.io.SessionOutputBufferImpl.flushBuffer(SessionOutputBufferImpl.java:135)
	at org.apache.http.impl.io.SessionOutputBufferImpl.write(SessionOutputBufferImpl.java:164)
	at org.apache.http.impl.io.SessionOutputBufferImpl.write(SessionOutputBufferImpl.java:175)
	at org.apache.http.impl.io.SessionOutputBufferImpl.writeLine(SessionOutputBufferImpl.java:213)
	at org.apache.http.impl.io.ChunkedOutputStream.flushCacheWithAppend(ChunkedOutputStream.java:125)
	at org.apache.http.impl.io.ChunkedOutputStream.write(ChunkedOutputStream.java:181)
	at org.glassfish.jersey.message.internal.CommittingOutputStream.write(CommittingOutputStream.java:229)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$UnCloseableOutputStream.write(WriterInterceptorExecutor.java:299)
	at org.glassfish.jersey.message.internal.ReaderWriter.writeTo(ReaderWriter.java:114)
	at org.glassfish.jersey.message.internal.AbstractMessageReaderWriterProvider.writeTo(AbstractMessageReaderWriterProvider.java:77)
	at org.glassfish.jersey.message.internal.InputStreamProvider.writeTo(InputStreamProvider.java:105)
	at org.glassfish.jersey.message.internal.InputStreamProvider.writeTo(InputStreamProvider.java:60)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.invokeWriteTo(WriterInterceptorExecutor.java:265)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor$TerminalWriterInterceptor.aroundWriteTo(WriterInterceptorExecutor.java:250)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:162)
	at com.github.dockerjava.jaxrs.filter.LoggingFilter.aroundWriteTo(LoggingFilter.java:300)
	at org.glassfish.jersey.message.internal.WriterInterceptorExecutor.proceed(WriterInterceptorExecutor.java:162)
	at org.glassfish.jersey.message.internal.MessageBodyFactory.writeTo(MessageBodyFactory.java:1154)
	at org.glassfish.jersey.client.ClientRequest.writeEntity(ClientRequest.java:503)
	at com.github.dockerjava.jaxrs.connector.ApacheConnector$2.writeTo(ApacheConnector.java:572)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.apache.http.impl.execchain.RequestEntityExecHandler.invoke(RequestEntityExecHandler.java:77)
	at com.sun.proxy.$Proxy639.writeTo(Unknown Source)
	at org.apache.http.impl.DefaultBHttpClientConnection.sendRequestEntity(DefaultBHttpClientConnection.java:155)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:483)
	at org.apache.http.impl.conn.CPoolProxy.invoke(CPoolProxy.java:138)
	at com.sun.proxy.$Proxy640.sendRequestEntity(Unknown Source)
	at org.apache.http.protocol.HttpRequestExecutor.doSendRequest(HttpRequestExecutor.java:236)
	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:121)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:253)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:194)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:85)
	... 20 more
:dockerBuildImage FAILED
```