### PR TITLE
Fixing docker-java api compatibility issue.

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -54,7 +54,7 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
 
     @Input
     @Optional
-    Long memoryLimit
+    Long memory
 
     @Input
     @Optional
@@ -204,8 +204,8 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
             containerCommand.withStdInOnce(getStdinOnce())
         }
 
-        if(getMemoryLimit()) {
-            containerCommand.withMemoryLimit(getMemoryLimit())
+        if(getMemory()) {
+            containerCommand.withMemory(getMemory())
         }
 
         if(getMemorySwap()) {


### PR DESCRIPTION
Right now specifying a memory limit on a container is broken (and apparently has been for some time). See https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/core/command/CreateContainerCmdImpl.java#L789.

This change addresses the compatibility issue and also renames the associated plugin config property, bringing it back into line with the naming used by the [Docker Remote Api](https://docs.docker.com/engine/reference/api/docker_remote_api_v1.24/).

This change was tested on my own project against docker-java 3.0.0.