### PR TITLE
Allow to define devices when creating a container

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/response/container/InspectContainerResponseHandler.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/response/container/InspectContainerResponseHandler.groovy
@@ -20,5 +20,10 @@ class InspectContainerResponseHandler implements ResponseHandler<String, Object>
         logger.quiet "ExposedPorts : $exposedPorts"
         logger.quiet "LogConfig : $container.hostConfig.logConfig.type.type"
         logger.quiet "RestartPolicy : $container.hostConfig.restartPolicy"
+        def devices = container.hostConfig.@devices ? 
+                container.hostConfig.devices.collect { 
+                    "${it.pathOnHost}:${it.pathInContainer}:${it.cGroupPermissions}" 
+                } : '[]'
+        logger.quiet "Devices : $devices"
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -142,6 +142,10 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
     @Input
     @Optional
     String restartPolicy
+    
+    @Input
+    @Optional
+    List<String> devices
 
     String containerId
 
@@ -301,7 +305,12 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
         if (getRestartPolicy()) {
             containerCommand.withRestartPolicy(threadContextClassLoader.createRestartPolicy(getRestartPolicy()))
         }
-        
+
+        if (getDevices()) {
+            def createdDevices = getDevices().collect { threadContextClassLoader.createDevice(it) }
+            containerCommand.withDevices(CollectionUtil.toArray(createdDevices))
+        }
+
         if(getTty()) {
             containerCommand.withTty(getTty())
         }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -365,7 +365,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         Class deviceClass = loadClass("${MODEL_PACKAGE}.Device")
         try {
             // The parse method is  available in newer Docker java library versions.
-            Method method = deviceClass.getMethod("parse", String.class)
+            Method method = deviceClass.getMethod("parse", String)
             method.invoke(null, deviceString)
         } catch (NoSuchMethodException) {
             // For older Docker java library versions we must parse the device string ourselves.
@@ -519,13 +519,12 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     
     private def parseDevice(String deviceString) {
         List<String> tokens = deviceString.tokenize(':')
-        int numberOfTokens = tokens.size()
 
         String permissions = 'rwm'
         String source = ''
         String destination = ''
         
-        switch(numberOfTokens) {
+        switch(tokens.size()) {
             case 3:
                 if (validDeviceMode(tokens[2])) {
                     permissions = tokens[2]
@@ -559,12 +558,12 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
             return false
         }
 
-        for (char ch in deviceMode) {
-            final String mode = String.valueOf(ch)
-            if (!validModes.get(mode)) {
+        for (mode in deviceMode) {
+            if (!validModes[mode]) {
                 return false // wrong mode
+            } else {
+                validModes[mode] = false
             }
-            validModes.put(mode, false)
         }
 
         return true

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ThreadContextClassLoader.groovy
@@ -203,6 +203,13 @@ interface ThreadContextClassLoader {
     def createRestartPolicy(String restartPolicy)
 
     /**
+     * Creates instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/api/model/Device.java">Device</a>
+     * @param  a string with serialized value which can be parsed by the Device.parse method
+     * @return Instance of Device
+     */
+    def createDevice(String device)
+
+    /**
      * Creates the callback instance of <a href="https://github.com/docker-java/docker-java/blob/master/src/main/java/com/github/dockerjava/core/command/BuildImageResultCallback.java">BuildImageResultCallback</a>
      * from thread context classloader.
      *


### PR DESCRIPTION
* To expose devices from the host system to a container.
* The docker-java library has support for a Device class to configure this.
* Extra devices property for DockerCreateContainer.
* Added code to dynamically load a Device class.

* Fixes #243