### PR TITLE
Issue #237 Java system properties are not taken into account

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ bin
 out 
 .gradle
 .vagrant
+classes
 
 # OS generated files #
 ######################

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -8,7 +8,7 @@ image:https://d3oypxn00j2a10.cloudfront.net/0.12.6/img/nav/docker-logo-loggedout
 
 Gradle plugin for managing link:https://www.docker.io/[Docker] images and containers using via its
 link:http://docs.docker.io/reference/api/docker_remote_api/[remote API]. The heavy lifting of communicating with the
-Docker remote API is handled by the link:https://github.com/docker-java/docker-java[Docker Java library]. Please
+Docker remote API is handled by the {dockerJavaLink}. Please
 refer to the library's documentation for more information on the supported Docker's client API and Docker server version.
 
 *This plugin requires Gradle >= 2.5 to work properly.*
@@ -132,6 +132,13 @@ The plugin defines the following extension properties in the `docker` closure:
 |`certPath`      |File      |null                     |The path to certificates for communicating with link:https://docs.docker.com/articles/https/[Docker over SSL].
 |`apiVersion`    |String    |null                     |The remote API version. For most cases this can be left null.
 |=======
+
+[WARNING]
+====
+Default value of `docker.url` property is deprecated.
+It will be replaced to `unix:///var/run/docker.sock` in upcoming releases.
+Please adjust your build scripts accordingly.
+====
 
 Image pull or push operations against the public Docker Hub registry or a private registry may require authentication.
 You can provide those credentials in the `registryCredentials` closure:

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -1,4 +1,7 @@
-Gradle Docker plugin
+= Gradle Docker plugin
+:dockerJavaUrl: https://github.com/docker-java/docker-java
+:dockerJavaLink: {dockerJavaUrl}[Docker Java library]
+:dockerJavaCfgLink: {dockerJavaUrl}#configuration[Docker Java library]
 ====================
 
 image:https://d3oypxn00j2a10.cloudfront.net/0.12.6/img/nav/docker-logo-loggedout.png[Docker Logo]
@@ -142,10 +145,28 @@ You can provide those credentials in the `registryCredentials` closure:
 |`email`         |String    |null                        |The registry email address.
 |=======
 
+=== Extension properties override
 
-==== Extension examples
+Properties defined within `docker` closure are providing flexible fallback mechanism
+allowing to reuse _the same build script_ on various environments with different `Docker Engine` settings,
+e.g. on CI servers, on Windows/Linux/Mac envs etc.
 
-===== Working with a TLS-enabled Docker instance
+Fallback tries to retrieve values from various source in following order
+(with higher precedence on top of the list)
+
+. Project properties, i.e. passed via command line with `-P` flag or defined in build script.
+. Java system variables, i.e. passed via command line with `-D` flag.
+. Environment variables.
+. Properties of currently executed `Docker` task.
+. `docker` closure defined on project or top project level.
+. Fallback to {dockerJavaLink} values.
+
+When overriding via project properties, system variables and environment properties -
+property names are following {dockerJavaCfgLink} conventions.
+
+=== Extension examples
+
+==== Working with a TLS-enabled Docker instance
 
 Starting with Docker version 1.3, TLS is enabled by default. Please consult the Docker documentation link:https://docs.docker.com/articles/https/["Running Docker
 with https"] to set up your certificate. The following example demonstrates how to configure the plugin to use those certificates.
@@ -166,7 +187,7 @@ docker {
 }
 ----
 
-===== Working with a Docker instance without TLS
+==== Working with a Docker instance without TLS
 
 The following example assumes that you disabled TLS on your Docker instance. You can do so by setting `DOCKER_TLS=no` in the file
  `/var/lib/boot2docker/profile`. Additionally, this code snippet shows how to set the user credentials.
@@ -178,7 +199,31 @@ docker {
 }
 ----
 
-=== Usage examples
+==== Overriding `docker` extension properties via command line
+
+Assuming we're having `build.gradle` with empty `docker` closure, we could do following
+
+Override Docker Engine location via project property::
++
+  $ gradle -PDOCKER_HOST=tcp://localhost:9999 dockerBuildImage <1>
++
+<1> tcp://locahost:9999 will be used
+
+Override Docker Engine location via environment varaible::
++
+  $ export DOCKER_HOST=tcp://locahost:5555
+  $ gradle dockerBuildImage <1>
++
+<1> tcp://locahost:5555 will be used
+
+Precedence rules for property override::
++
+  $ export DOCKER_HOST=tcp://locahost:5555
+  $ gradle -PDOCKER_HOST=tcp://localhost:9999 dockerBuildImage <1>
++
+<1> tcp://locahost:9999 will be used, since project properties have precedence over environment variables
+
+=== Task usage examples
 
 The following usage examples demonstrate code for common use cases. More scenarios can be found in the link:https://github.com/bmuschko/gradle-docker-plugin/blob/master/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy[functional tests].
 

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group: 'org.codehaus.groovy'
     }
+    testCompile 'com.github.stefanbirkner:system-rules:1.16.0'
 }
 
 ext.compatibilityVersion = '1.6'

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/ConfigOverrideOrder.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/ConfigOverrideOrder.groovy
@@ -9,7 +9,7 @@ import static com.bmuschko.gradle.docker.utils.DockerThreadContextClassLoader.*
 enum ConfigOverrideOrder {
     DEFAULT {
         @Override
-        String dockerUrlValue() { "unix:///var/run/docker.sock" }
+        String dockerUrlValue() { 'tcp://localhost:2375' }
 
         @Override
         String dockerCertPathValue() { null }

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/ConfigOverrideOrder.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/ConfigOverrideOrder.groovy
@@ -1,0 +1,119 @@
+package com.bmuschko.gradle.docker.utils
+
+import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
+import org.gradle.api.Project
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+
+import static com.bmuschko.gradle.docker.utils.DockerThreadContextClassLoader.*
+
+enum ConfigOverrideOrder {
+    DEFAULT {
+        @Override
+        String dockerUrlValue() { "unix:///var/run/docker.sock" }
+
+        @Override
+        String dockerCertPathValue() { null }
+
+        @Override
+        String dockerApiVersionValue() { "0.0" }
+
+        @Override
+        void apply(Project project, DockerClientConfiguration dockerClientConfiguration, EnvironmentVariables envVars) {
+            dockerClientConfiguration.url = null
+            dockerClientConfiguration.certPath = null
+            dockerClientConfiguration.apiVersion = null
+        }
+    }, EXTENSION_PROP{
+        @Override
+        String dockerUrlValue() { "tcp://extension.host" }
+
+        @Override
+        String dockerCertPathValue() { "extension.path" }
+
+        @Override
+        String dockerApiVersionValue() { "111.4" }
+
+        @Override
+        void apply(Project project, DockerClientConfiguration dockerClientConfiguration, EnvironmentVariables envVars) {
+            project.docker {
+                url = dockerUrlValue()
+                certPath = newFolder(project)
+                apiVersion = dockerApiVersionValue()
+            }
+        }
+    }, TASK_PROP{
+        @Override
+        String dockerUrlValue() { "tcp://task.host" }
+
+        @Override
+        String dockerCertPathValue() { "task.path"}
+
+        @Override
+        String dockerApiVersionValue() { "111.5" }
+
+        @Override
+        void apply(Project project, DockerClientConfiguration taskConfig, EnvironmentVariables envVars) {
+            taskConfig.url = dockerUrlValue()
+            taskConfig.certPath = newFolder(project)
+            taskConfig.apiVersion = dockerApiVersionValue()
+        }
+    }, ENV_PROP {
+        @Override
+        String dockerUrlValue() { "tcp://env.property.host" }
+
+        @Override
+        String dockerCertPathValue() { "env.property.path" }
+
+        @Override
+        String dockerApiVersionValue() { "111.1" }
+
+        @Override
+        void apply(Project project, DockerClientConfiguration dockerClientConfiguration, EnvironmentVariables envVars) {
+            envVars.set(DOCKER_HOST_PROPERTY_NAME, dockerUrlValue())
+            envVars.set(DOCKER_CERT_PATH_PROPERTY_NAME, newFolder(project).absolutePath)
+            envVars.set(DOCKER_API_VERSION_PROPERTY_NAME, dockerApiVersionValue())
+        }
+    }, SYSTEM_PROP {
+        @Override
+        String dockerUrlValue() { "tcp://system.property.host" }
+
+        @Override
+        String dockerCertPathValue() { "system.property.path" }
+
+        @Override
+        String dockerApiVersionValue() { "111.2" }
+
+        @Override
+        void apply(Project project, DockerClientConfiguration dockerClientConfiguration, EnvironmentVariables envVars) {
+            System.setProperty(DOCKER_HOST_PROPERTY_NAME, dockerUrlValue())
+            System.setProperty(DOCKER_CERT_PATH_PROPERTY_NAME, newFolder(project).absolutePath)
+            System.setProperty(DOCKER_API_VERSION_PROPERTY_NAME, dockerApiVersionValue())
+        }
+    }, PROJECT_PROP {
+        @Override
+        String dockerUrlValue() { "tcp://project.property.host" }
+
+        @Override
+        String dockerCertPathValue() { "project.property.path" }
+
+        @Override
+        String dockerApiVersionValue() { "111.3" }
+
+        @Override
+        void apply(Project project, DockerClientConfiguration dockerClientConfiguration, EnvironmentVariables envVars) {
+            project.ext[DOCKER_HOST_PROPERTY_NAME] = dockerUrlValue()
+            project.ext[DOCKER_CERT_PATH_PROPERTY_NAME] = newFolder(project).absolutePath
+            project.ext[DOCKER_API_VERSION_PROPERTY_NAME] = dockerApiVersionValue()
+        }
+    }
+
+    File newFolder(Project project) { new File(project.projectDir, dockerCertPathValue()) }
+
+    abstract String dockerUrlValue()
+
+    abstract String dockerCertPathValue()
+
+    abstract String dockerApiVersionValue()
+
+    abstract void apply(Project project, DockerClientConfiguration dockerClientConfiguration, EnvironmentVariables envVars)
+}

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderConfigOverrideIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderConfigOverrideIntegrationTest.groovy
@@ -1,0 +1,74 @@
+package com.bmuschko.gradle.docker.utils
+
+import com.bmuschko.gradle.docker.AbstractIntegrationTest
+import com.bmuschko.gradle.docker.DockerExtension
+import com.bmuschko.gradle.docker.DockerRemoteApiPlugin
+import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration
+import org.gradle.api.Project
+import org.gradle.testfixtures.ProjectBuilder
+import org.junit.Rule
+import org.junit.contrib.java.lang.system.EnvironmentVariables
+import org.junit.contrib.java.lang.system.RestoreSystemProperties
+import spock.lang.Unroll
+
+class DockerThreadContextClassLoaderConfigOverrideIntegrationTest extends AbstractIntegrationTest {
+
+    @Rule
+    EnvironmentVariables envVars = new EnvironmentVariables()
+
+    @Rule
+    RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties()
+
+    DockerClientConfiguration dockerClientConfiguration = new DockerClientConfiguration()
+
+    Project project
+
+    ThreadContextClassLoader threadContextClassLoader
+
+    DockerExtension dockerExtension
+
+    def setup() {
+        project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+        project.repositories {
+            jcenter()
+        }
+        project.apply(plugin: DockerRemoteApiPlugin)
+
+        dockerExtension = project.extensions.findByType(DockerExtension)
+        threadContextClassLoader = new DockerThreadContextClassLoader(project, dockerExtension)
+    }
+
+    private void createFakeCetPathFolders() {
+        ConfigOverrideOrder.values()
+            .collect { it.dockerCertPathValue() }
+            .findAll { it != null }
+            .each { temporaryFolder.newFolder(it)
+        }
+    }
+
+    @Unroll
+    def "when override by #config"() {
+        given: "create fake folders for cert paths"
+        createFakeCetPathFolders()
+        and: ""
+        def actual
+
+        ConfigOverrideOrder.values().takeWhile { it <= config }
+            .each { it.apply(project, dockerClientConfiguration, envVars) }
+
+        when:
+        threadContextClassLoader.withClasspath(project.configurations.dockerJava.files, dockerClientConfiguration) { dockerClient ->
+            actual = dockerClient.dockerClientConfig
+        }
+
+        then: "docker url is properly overridden"
+        actual.dockerHost.toString() == config.dockerUrlValue()
+        and: "docker cert path is properly overridden"
+        actual.sslConfig == null || actual.sslConfig.dockerCertPath.endsWith(config.dockerCertPathValue())
+        and: "docker api version is properly overridden"
+        actual.apiVersion.version == config.dockerApiVersionValue()
+
+        where:
+        config << ConfigOverrideOrder.values()
+    }
+}

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
@@ -14,20 +14,21 @@ import java.lang.reflect.InvocationTargetException
 
 class DockerThreadContextClassLoaderIntegrationTest extends AbstractIntegrationTest {
     DockerExtension dockerExtension = new DockerExtension()
-    ThreadContextClassLoader threadContextClassLoader = new DockerThreadContextClassLoader(dockerExtension)
     DockerClientConfiguration dockerClientConfiguration = new DockerClientConfiguration(url: 'tcp://localhost:2375')
 
-    @Shared
+    ThreadContextClassLoader threadContextClassLoader
+
     Project project
 
-    def setupSpec() {
-        project = ProjectBuilder.builder().build()
+    def setup() {
+        project = ProjectBuilder.builder().withProjectDir(projectDir).build()
 
         project.repositories {
             mavenCentral()
         }
 
         project.apply(plugin: DockerRemoteApiPlugin)
+        threadContextClassLoader = new DockerThreadContextClassLoader(project, dockerExtension)
     }
 
     def "Can create class of type Volume"() {

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.file.FileCollection
 
 class DockerExtension {
     FileCollection classpath
-    String url = 'http://localhost:2375'
+    String url
     File certPath
     String apiVersion
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
@@ -19,7 +19,7 @@ import org.gradle.api.file.FileCollection
 
 class DockerExtension {
     FileCollection classpath
-    String url
+    String url = 'http://localhost:2375'
     File certPath
     String apiVersion
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -63,7 +63,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
     }
 
     private void configureAbstractDockerTask(Project project, DockerExtension extension) {
-        ThreadContextClassLoader dockerClassLoader = new DockerThreadContextClassLoader(extension)
+        ThreadContextClassLoader dockerClassLoader = new DockerThreadContextClassLoader(project, extension)
         project.tasks.withType(AbstractDockerRemoteApiTask) {
             group = DEFAULT_TASK_GROUP
             threadContextClassLoader = dockerClassLoader

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -35,9 +35,9 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     public static final String MODEL_PACKAGE = 'com.github.dockerjava.api.model'
     public static final String COMMAND_PACKAGE = 'com.github.dockerjava.core.command'
 
-    private DockerExtension dockerExtension
+    private final DockerExtension dockerExtension
 
-    private Project project
+    private final Project project
 
     public DockerThreadContextClassLoader(Project project, DockerExtension dockerExtension) {
         this.project = project
@@ -66,10 +66,13 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         }
     }
 
+
+    private String getConfigPropertyWithFallback(String key) {
+        project.properties.getOrDefault(key, System.getProperty(key, System.getenv(key)))
+    }
+
     private String getDockerHostUrl(DockerClientConfiguration taskConfig) {
-        String url = project.properties.getOrDefault(DOCKER_HOST_PROPERTY_NAME,
-            System.getProperty(DOCKER_HOST_PROPERTY_NAME, System.getenv(DOCKER_HOST_PROPERTY_NAME)))
-        url = url ?: (taskConfig.url ?: dockerExtension.url)
+        String url = getConfigPropertyWithFallback(DOCKER_HOST_PROPERTY_NAME) ?: (taskConfig.url ?: dockerExtension.url)
         if (url) {
             url = url.toLowerCase().startsWith("http") ? "tcp${url.substring(url.indexOf(":"))}" : url
         }
@@ -77,14 +80,12 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     }
 
     private File getCertPath(DockerClientConfiguration taskConfig) {
-        String certPath = project.properties.getOrDefault(DOCKER_CERT_PATH_PROPERTY_NAME,
-            System.getProperty(DOCKER_CERT_PATH_PROPERTY_NAME, System.getenv(DOCKER_CERT_PATH_PROPERTY_NAME)))
+        String certPath = getConfigPropertyWithFallback(DOCKER_CERT_PATH_PROPERTY_NAME)
         certPath ? new File(certPath) : (taskConfig.certPath ?: dockerExtension.certPath)
     }
 
     private String getApiVersion(DockerClientConfiguration taskConfig) {
-        String apiVersion = project.properties.getOrDefault(DOCKER_API_VERSION_PROPERTY_NAME,
-            System.getProperty(DOCKER_API_VERSION_PROPERTY_NAME, System.getenv(DOCKER_API_VERSION_PROPERTY_NAME)))
+        String apiVersion = getConfigPropertyWithFallback(DOCKER_API_VERSION_PROPERTY_NAME)
         apiVersion ?: (taskConfig.apiVersion ?: dockerExtension.apiVersion)
     }
 


### PR DESCRIPTION
- added dependency on `JUnit System Rule` testing framework
- fallback chain for `dockerUrl`, `dockerCertPath` and `apiVersion` properties override and integrationg tests for API properties override
- DockerExtension doesn't populate `dockerUrl`, thus falling back to `Java Docker Library` defaults
- README adjustments

resolves #237