### PR TITLE
Bump docker-java to 3.0.5

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.file.FileCollection
  */
 class DockerRemoteApiPlugin implements Plugin<Project> {
     public static final String DOCKER_JAVA_CONFIGURATION_NAME = 'dockerJava'
-    public static final String DOCKER_JAVA_DEFAULT_VERSION = '3.0.2'
+    public static final String DOCKER_JAVA_DEFAULT_VERSION = '3.0.5'
     public static final String EXTENSION_NAME = 'docker'
     public static final String DEFAULT_TASK_GROUP = 'Docker'
 


### PR DESCRIPTION
Fixes #238.

Ensure compatibility with recent (>= 1.12.x) versions of docker by bumping docker-java to 3.0.5. As of https://github.com/docker-java/docker-java/commit/7af8f8f4eacb13bd4de09dfaf14b8dffc63d733c the following error is fixed:
```
{"message":"starting container with HostConfig was deprecated since v1.10 and removed in v1.12"}
```