### PR TITLE
Print error messages received from Docker engine when build fails

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLogsContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLogsContainerFunctionalTest.groovy
@@ -172,5 +172,18 @@ class DockerLogsContainerFunctionalTest extends AbstractFunctionalTest {
         File outputFile = new File("${projectDir.path}/log-sink.txt")
         outputFile.exists() && outputFile.text.contains("Hello World")
     }
+
+    def "prints error message when obtaining logs fails"() {
+        buildFile << """
+            task logContainer(type: DockerLogsContainer) {
+                dependsOn startContainer
+                targetContainerId { "not_existimg_container" }
+            }
+        """
+
+        expect:
+        BuildResult result = buildAndFail('workflow')
+        result.output.contains("No such container: not_existimg_container")
+    }
 }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.logging.Logger
 
 import java.lang.reflect.Array
 import java.lang.reflect.Constructor
+import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
 class DockerThreadContextClassLoader implements ThreadContextClassLoader {
@@ -425,7 +426,11 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                                 break
                         }
                     }
-                    method.invoke(delegate, args)
+                    try {
+                        method.invoke(delegate, args)
+                    } catch(InvocationTargetException e) {
+                        throw e.cause
+                    }
                 }
 
         ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
@@ -458,7 +463,11 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                                 break
                         }
                     }
-                    method.invoke(delegate, args)
+                    try {
+                        method.invoke(delegate, args)
+                    } catch (InvocationTargetException e) {
+                        throw e.cause
+                    }
                 }
 
         ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
@@ -496,7 +505,11 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                         if (possibleStream)
                             logger.quiet(possibleStream.trim())
                     }
-                    method.invoke(delegate, args)
+                    try {
+                        method.invoke(delegate, args)
+                    } catch(InvocationTargetException e) {
+                        throw e.cause
+                    }
                 }
 
         ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))


### PR DESCRIPTION
CGLIB proxies created in DockerThreadContextClassLoader catch InvocationTagretException and throw underlying exception, which contain error message from Docker engine. 
Fix #264