### PR TITLE
	Added support for force parameter on docker image removal

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
@@ -15,6 +15,7 @@ class DockerRemoveImageFunctionalTest extends AbstractFunctionalTest {
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.image.Dockerfile
             import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerListImages
             import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
 
             task dockerfile(type: Dockerfile) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
@@ -1,0 +1,87 @@
+package com.bmuschko.gradle.docker.tasks.image
+
+import com.bmuschko.gradle.docker.AbstractFunctionalTest
+import com.bmuschko.gradle.docker.TestPrecondition
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
+
+import static org.gradle.testkit.runner.TaskOutcome.SKIPPED
+import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
+
+//@Requires({ TestPrecondition.DOCKER_SERVER_INFO_URL_REACHABLE })
+class DockerRemoveImageFunctionalTest extends AbstractFunctionalTest {
+
+    def "can remove image"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
+
+            task dockerfile(type: Dockerfile) {
+                from 'ubuntu:12.04'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+            }
+            
+            task removeImage(type: DockerRemoveImage) {
+                dependsOn buildImage
+                targetImageId { buildImage.getImageId() }
+            }
+        """
+
+        when:
+        BuildResult result = build('removeImage')
+
+        then:
+        result.output.contains("Removing image with ID")
+    }
+
+    def "can remove image tagged in multiple repositories"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerTagImage
+
+            task dockerfile(type: Dockerfile) {
+                from 'ubuntu:12.04'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+            }
+            
+            task tagImage(type: DockerTagImage) {
+                dependsOn buildImage
+                repository = "repository"
+                tag = "tag2"
+                targetImageId { buildImage.getImageId() }
+            }
+            
+            task tagImageSecondTime(type: DockerTagImage) {
+                dependsOn tagImage
+                repository = "repository"
+                tag = "tag2"
+                targetImageId { buildImage.getImageId() }
+            }
+            
+            task removeImage(type: DockerRemoveImage) {
+                dependsOn tagImageSecondTime
+                force = true
+                targetImageId { buildImage.getImageId() }
+            }
+        """
+
+        when:
+        BuildResult result = build('removeImage')
+
+        then:
+        result.output.contains("Removing image with ID")
+    }
+
+
+}

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
@@ -30,19 +30,26 @@ class DockerRemoveImageFunctionalTest extends AbstractFunctionalTest {
                 dependsOn buildImage
                 targetImageId { buildImage.getImageId() }
             }
+            
+            task removeImageAndCheckRemoval(type: DockerListImages) {
+				dependsOn removeImage
+    			showAll = true
+    			filters = '{"dangling":["true"]}'
+			}
         """
 
         when:
-        BuildResult result = build('removeImage')
+        BuildResult result = build('removeImageAndCheckRemoval')
 
         then:
-        result.output.contains("Removing image with ID")
+        !result.output.contains("repository")
     }
 
     def "can remove image tagged in multiple repositories"() {
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.image.Dockerfile
             import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerListImages
             import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
             import com.bmuschko.gradle.docker.tasks.image.DockerTagImage
 
@@ -74,13 +81,20 @@ class DockerRemoveImageFunctionalTest extends AbstractFunctionalTest {
                 force = true
                 targetImageId { buildImage.getImageId() }
             }
+
+			task removeImageAndCheckRemoval(type: DockerListImages) {
+				dependsOn removeImage
+    			showAll = true
+    			filters = '{"dangling":["true"]}'
+			}
+            
         """
 
         when:
-        BuildResult result = build('removeImage')
+        BuildResult result = build('removeImageAndCheckRemoval')
 
         then:
-        result.output.contains("Removing image with ID")
+        !result.output.contains("repository")
     }
 
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
@@ -8,7 +8,7 @@ import spock.lang.Requires
 import static org.gradle.testkit.runner.TaskOutcome.SKIPPED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
-//@Requires({ TestPrecondition.DOCKER_SERVER_INFO_URL_REACHABLE })
+@Requires({ TestPrecondition.DOCKER_SERVER_INFO_URL_REACHABLE })
 class DockerRemoveImageFunctionalTest extends AbstractFunctionalTest {
 
     def "can remove image"() {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.groovy
@@ -20,9 +20,6 @@ import org.gradle.api.tasks.Optional
 
 class DockerRemoveImage extends DockerExistingImage {
 
-	/**
-     * Forces removal.
-     */
     @Input
     @Optional
     Boolean force

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.groovy
@@ -15,10 +15,27 @@
  */
 package com.bmuschko.gradle.docker.tasks.image
 
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
 class DockerRemoveImage extends DockerExistingImage {
+
+	/**
+     * Forces removal.
+     */
+    @Input
+    @Optional
+    Boolean force
+
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Removing image with ID '${getImageId()}'."
-        dockerClient.removeImageCmd(getImageId()).exec()
+        def removeImageCmd = dockerClient.removeImageCmd(getImageId())
+        
+        if(getForce()) {
+            removeImageCmd.withForce(getForce())
+        }
+        
+        removeImageCmd.exec()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.groovy
@@ -29,10 +29,7 @@ class DockerRemoveImage extends DockerExistingImage {
         logger.quiet "Removing image with ID '${getImageId()}'."
         def removeImageCmd = dockerClient.removeImageCmd(getImageId())
         
-        if(getForce()) {
-            removeImageCmd.withForce(getForce())
-        }
-        
+        removeImageCmd.withForce(getForce())
         removeImageCmd.exec()
     }
 }


### PR DESCRIPTION
When an image is tagged in multiple repositories, image removal can only be done if the force parameter is provided.