### PR TITLE
Added `simple-docker-plugin` with tests and docco

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -39,6 +39,7 @@ The JAR file comes with two plugins:
 |Plugin Id                            |Automatically applies          |Type                                                                                                                                                        |Description
 |com.bmuschko.docker-remote-api       |-                              |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.html[DockerRemoteApiPlugin]             |Provides custom tasks for interacting with Docker via its remote API.
 |com.bmuschko.docker-java-application |com.bmuschko.docker-remote-api |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.html[DockerJavaApplicationPlugin] |Creates and pushes a Docker image for a Java application.
+|com.bmuschko.simple-docker-plugin |com.bmuschko.docker-java-application |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/SimpleDockerApplicationPlugin.html[SimpleDockerApplicationPlugin] |Provides a wrapper on top of the docker-java-application to simplify the packaging of docker images for simple Java applications.
 |=======
 
 == Remote API plugin
@@ -331,6 +332,83 @@ docker {
     }
 }
 ----
+
+
+== Simple Docker Application Plugin
+
+The plugin `com.bmuschko.docker-simple-plugin` is a highly opinonated plugin for projects applying the link:http://www.gradle.org/docs/current/userguide/application_plugin.html[application plugin].
+Under the covers the plugin preconfigures tasks for creating, tagging and pushing Docker images for your Java application.
+
+The plugin assumes a certain structure of the docker image and he way the docker repo is organized, following the way the `application` plugin creates directories and packages the application in a tarball: the packaged tarball is typically named `appliationName-M.n.tar` (where `applicationName` is the name of the application from the build file, and the `M` major and `m` minor are components of the version declared in the same build file). The tarball structure is typically:
+
+* `applicationName-version/` -- top level directory
+* `applicationName-version/lib/` -- directory containing all the jars/dependencies
+* `applicationName-version/bin/` -- directory containing the application jar plus the generated startup scripts
+
+Based on this, the plugin assumes the following structure of the docker image:
+
+* `/applicationName-version/` -- top level directory in the docker image where everything will be deployed
+* `/applicationName-version/bin/` -- the `bin` directory created by the `application` plugin in the tarball
+* `/applicationName-version/lib/` -- the `lib` directory created by the `application` plugin
+
+The plugin also assumes that every such docker image deployed to the docker repository will be tagged with the version number and the image name will be set to be `project-group/applicationName`.
+
+This default behaviour is tweakable via an exposed extension. To use the plugin, include the following code snippet in your build script:
+
+[source,groovy]
+----
+apply plugin: 'com.bmuschko.docker-simple-plugin'
+----
+
+=== Extension properties
+
+The plugin defines the following extension properties in the `simpleDockerConfig` closure:
+
+[options="header"]
+|=======
+|Property name     |Type            |Description
+|`maintainerEmail` |String          |Email for the maintainer of the docker image.
+|`dockerUrl`       |String          |URL to communicate with the docker daemon.
+|`dockerBase`      |String          |Docker base image to build your image on.
+|`dockerImage`     |Closure         |Closure executed when building the Dockerfile. Allows you to add files to the image, execute commands etc.
+|`tagVersion`      |Closure<String> | If not supplied, assumed to be `{<project.version>}`. The result of this closure will be used to set the tag on the docker image when pushing it to the repo.
+|=======
+
+
+=== Usage example
+
+* Using default docker image structure and project version as tagging:
+[source,groovy]
+----
+apply plugin: 'com.bmuschko.docker-simple-plugin'
+//...
+simpleDockerConfig {
+        maintainerEmail = 'maintainer.email@liviutudor.com'
+        dockerUrl = 'http://docker.host.com:12345'
+        dockerBase = 'openjdk:8'
+    }
+}
+----
+
+* Adding customization to the image and change the taggin:
+[source,groovy]
+----
+apply plugin: 'com.bmuschko.docker-simple-plugin'
+//...
+simpleDockerConfig {
+        maintainerEmail = 'another.email@liviutudor.com'
+        dockerUrl = 'http://another.docker.host.com:98765'
+        dockerBase = 'openjdk:8'
+        dockerImage = {
+            addFile 'file.txt', '/some/path'
+            //...
+        }
+        tagVersion = { 'my-version-to-use' }
+    }
+}
+----
+
+
 
 == FAQ
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.bmuschko'
-version = '3.0.3'
+version = '3.1.0.1.1'
 
 apply plugin: 'groovy'
 apply plugin: 'idea'
@@ -21,6 +21,7 @@ dependencies {
     testCompile('org.spockframework:spock-core:1.0-groovy-2.4') {
         exclude group: 'org.codehaus.groovy'
     }
+    testCompile 'cglib:cglib-nodep:3.2.2'
 }
 
 ext.compatibilityVersion = '1.6'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 group = 'com.bmuschko'
-version = '3.1.0.1.1'
+version = '3.0.3'
 
 apply plugin: 'groovy'
 apply plugin: 'idea'

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/SimpleDockerApplicationPluginTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/SimpleDockerApplicationPluginTest.groovy
@@ -1,0 +1,177 @@
+package com.bmuschko.gradle.docker
+
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+import org.gradle.api.Project
+import org.gradle.api.internal.file.UnionFileCollection
+import org.gradle.testfixtures.ProjectBuilder
+
+class SimpleDockerApplicationPluginTest extends AbstractIntegrationTest {
+    Project project
+
+    def setup() {
+        project = ProjectBuilder.builder().withProjectDir(projectDir).build()
+    }
+
+    def "createAllTasks creates the dockerfile task, buildImage and pushAllImages"() {
+        def x = Spy(SimpleDockerApplicationPlugin)
+
+        when:
+        x.createAllTasks project
+
+        then:
+        1 * x.taskCreateDockerfile(project) >> {}
+        1 * x.taskBuildImage(project) >> {}
+        1 * x.taskPushImage(project) >> {}
+    }
+
+    def "taskBuildImage creates the task and set it to depend on createDockerfile"() {
+        def x = new SimpleDockerApplicationPlugin()
+        project.extensions.create("simpleDockerConfig", SimpleDockerConfig)
+        project.configure(project) {
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+
+        def mockParent = Mock(File, constructorArgs: ['/fake/parent'])
+
+        def mockFile = Stub(File, constructorArgs: ['/fake/path']) {
+            getParentFile() >> mockParent
+        }
+        def dockerFileTask = project.tasks.create('createDockerfile', Dockerfile)
+        dockerFileTask.destFile = mockFile
+
+        when:
+        x.taskBuildImage(project)
+        def task = project.tasks['buildImage']
+
+        then:
+        task.dependsOn.size() == 2
+        task.dependsOn.find({ it.hasProperty('name') && it.name == 'createDockerfile' })
+        task.inputDir.is(mockParent)
+    }
+
+    def "taskCreateDockerfile uses the property from SimpleDockerConfig and sets entry point and sets up right dependencies"() {
+        def x = new SimpleDockerApplicationPlugin()
+        project.extensions.create("simpleDockerConfig", SimpleDockerConfig)
+        project.configure(project) {
+            apply plugin: 'application'
+            apply plugin: 'distribution'
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+        project.applicationName = 'xyz'
+
+        project.simpleDockerConfig.dockerBase = 'base docker'
+        project.simpleDockerConfig.maintainerEmail = 'some email'
+        String appLatest = "/${project.applicationName}-latest"
+        String appDir = "/${project.applicationName}-${project.version}"
+
+        when:
+        def task = x.taskCreateDockerfile(project)
+
+        then:
+        task.dependsOn.find { !(it instanceof UnionFileCollection) && (it.name == 'distTar') }
+        task.dependsOn.find { !(it instanceof UnionFileCollection) && (it.name == 'dockerCopyDistResources') }
+        task.destFile.absolutePath.contains('/build/docker/Dockerfile')
+        task.instructions.find { it instanceof Dockerfile.FromInstruction && it.command == 'base docker' }
+        task.instructions.find { it instanceof Dockerfile.MaintainerInstruction && it.command == 'some email' }
+        task.instructions.find { it instanceof Dockerfile.FileInstruction && (it.src == project.distTar.archiveName && it.dest == '/') }
+        task.instructions.find { it instanceof Dockerfile.RunCommandInstruction && it.command == "ln -s '${appDir}' '${appLatest}'" }
+        task.instructions.find { it instanceof Dockerfile.EntryPointInstruction && it.command == ["${appLatest}/bin/xyz"] }
+    }
+
+    def "taskCreateDockerfile also invokes the dockerImage closure if set"() {
+        def x = new SimpleDockerApplicationPlugin()
+        project.extensions.create("simpleDockerConfig", SimpleDockerConfig)
+        project.configure(project) {
+            apply plugin: 'application'
+            apply plugin: 'distribution'
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+        project.applicationName = 'xyz'
+
+        project.simpleDockerConfig.dockerBase = 'base docker'
+        project.simpleDockerConfig.maintainerEmail = 'some email'
+        def calls = 0
+        project.simpleDockerConfig.dockerImage = { project, task ->
+            calls++
+        }
+        String appLatest = "/${project.applicationName}-latest"
+        String appDir = "/${project.applicationName}-${project.version}"
+
+        when:
+        def task = x.taskCreateDockerfile(project)
+
+        then:
+        task.dependsOn.find { !(it instanceof UnionFileCollection) && (it.name == 'distTar') }
+        task.dependsOn.find { !(it instanceof UnionFileCollection) && (it.name == 'dockerCopyDistResources') }
+        task.destFile.absolutePath.contains('/build/docker/Dockerfile')
+        task.instructions.find { it instanceof Dockerfile.FromInstruction && it.command == 'base docker' }
+        task.instructions.find { it instanceof Dockerfile.MaintainerInstruction && it.command == 'some email' }
+        task.instructions.find { it instanceof Dockerfile.FileInstruction && (it.src == project.distTar.archiveName && it.dest == '/') }
+        task.instructions.find { it instanceof Dockerfile.RunCommandInstruction && it.command == "ln -s '${appDir}' '${appLatest}'" }
+        task.instructions.find { it instanceof Dockerfile.EntryPointInstruction && it.command == ["${appLatest}/bin/xyz"] }
+        calls == 1
+    }
+
+    def "taskPushImage creates task for tag and for push"() {
+        def repoUrl = 'xyz.com:7001'
+        def x = new SimpleDockerApplicationPlugin()
+        project.extensions.create("simpleDockerConfig", SimpleDockerConfig)
+        project.configure(project) {
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+        project.tasks.create 'buildImage'
+        project.version = 'a.b.c'
+        project.simpleDockerConfig.dockerRepo = repoUrl
+
+        when:
+        x.taskPushImage project
+        def tagTest = project.tasks['dockerTagImage']
+        def pushTest = project.tasks['pushImage']
+
+        then:
+        tagTest
+        tagTest.dependsOn.size() == 2
+        tagTest.dependsOn.find({ it.hasProperty('name') && it.name == 'buildImage' })
+        tagTest.repository == repoUrl
+        tagTest.getTag() == 'a.b.c'
+
+        pushTest
+        pushTest.dependsOn.size() == 2
+        pushTest.dependsOn.find({ it.hasProperty('name') && it.name == 'dockerTagImage' })
+    }
+
+    def "taskPushImage uses the version closure if supplied"() {
+        def repoUrl = 'xyz.com:7001'
+        def x = new SimpleDockerApplicationPlugin()
+        project.extensions.create("simpleDockerConfig", SimpleDockerConfig)
+        project.configure(project) {
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+        project.tasks.create 'buildImage'
+        project.version = 'a.b.c'
+        project.simpleDockerConfig.dockerRepo = repoUrl
+        def calls = 0
+        project.simpleDockerConfig.tagVersion = {
+            calls++
+            'x.y.z'
+        }
+
+        when:
+        x.taskPushImage project
+        def tagTest = project.tasks['dockerTagImage']
+        def pushTest = project.tasks['pushImage']
+
+        then:
+        calls == 1
+        
+        tagTest
+        tagTest.dependsOn.size() == 2
+        tagTest.dependsOn.find({ it.hasProperty('name') && it.name == 'buildImage' })
+        tagTest.repository == repoUrl
+        tagTest.getTag() == 'x.y.z'
+
+        pushTest
+        pushTest.dependsOn.size() == 2
+        pushTest.dependsOn.find({ it.hasProperty('name') && it.name == 'dockerTagImage' })
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/SimpleDockerApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/SimpleDockerApplicationPlugin.groovy
@@ -1,0 +1,157 @@
+package com.bmuschko.gradle.docker
+
+import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
+import com.bmuschko.gradle.docker.tasks.image.DockerTagImage
+import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.Task
+
+/**
+ * Plugin that is meant to provide a very simple approach to packaging an application into a docker image.
+ * It offers a simple interface to performing the following steps:
+ * <ol>
+ *  <li>Create the image (and allows to easily add files and execute commands)</li>
+ *  <li>Tag the image in the docker repo (and allows to supply your own tag)</li>
+ *  <li>Push the image to the docker repo</li>
+ * </ol>
+ *
+ * @author liviutudor
+ */
+class SimpleDockerApplicationPlugin implements Plugin<Project> {
+    void apply(Project project) {
+        project.extensions.create("simpleDockerConfig", SimpleDockerConfig)
+        def dockerConfig = project.simpleDockerConfig
+
+        project.configure(project) {
+            apply plugin: 'com.bmuschko.docker-java-application'
+        }
+
+        project.afterEvaluate {
+            project.docker {
+                url = dockerConfig.dockerUrl
+                javaApplication {
+                    baseImage = dockerConfig.dockerBase
+                    maintainer = dockerConfig.maintainerEmail
+                }
+            }
+
+            createAllTasks project
+        }
+    }
+
+    protected void createAllTasks(Project project) {
+        taskCreateDockerfile project
+        taskBuildImage project
+        taskPushImage project
+    }
+
+    protected Task taskCreateDockerfile(Project project) {
+        String appLatest = "/${project.applicationName}-latest"
+        String appDir = "/${project.applicationName}-${project.version}"
+        project.tasks.create(name: 'createDockerfile', type: Dockerfile) { task ->
+            destFile = project.file(project.simpleDockerConfig.dockerFile)
+            dependsOn project.tasks['distTar']
+            dependsOn project.tasks['dockerCopyDistResources']
+            from "${project.simpleDockerConfig.dockerBase}"
+            maintainer project.simpleDockerConfig.maintainerEmail
+
+            addFile "${project.distTar.archiveName}", '/'
+            runCommand "ln -s '${appDir}' '${appLatest}'"
+            entryPoint "${appDir}/bin/${project.applicationName}"
+            if (project.simpleDockerConfig.dockerImage) {
+                project.simpleDockerConfig.dockerImage.delegate = task
+                project.simpleDockerConfig.dockerImage(project, task)
+            }
+        }
+    }
+
+    protected Task taskBuildImage(Project project) {
+        project.tasks.create(name: 'buildImage', type: DockerBuildImage) {
+            dependsOn project.tasks['createDockerfile']
+            inputDir = project.tasks['createDockerfile'].destFile.parentFile
+        }
+    }
+
+    protected void taskPushImage(Project project) {
+        SimpleDockerConfig dockerConfig = project.simpleDockerConfig
+
+        if (dockerConfig.tagVersion) {
+            dockerConfig.tagVersion.delegate = project
+            taggingVersion = dockerConfig.tagVersion(project)
+        } else {
+            taggingVersion = "${project.version}".toString()
+        }
+
+        project.tasks.create(name: "dockerTagImage", type: DockerTagImage) { task ->
+            dependsOn project.tasks['buildImage']
+            targetImageId { project.buildImage.imageId }
+            repository = dockerConfig.dockerRepo
+            task.conventionMapping.tag = { taggingVersion }
+            force = true
+        }
+
+        project.tasks.create(name: "pushImage", type: DockerPushImage) { task ->
+            dependsOn project.tasks["dockerTagImage"]
+            task.conventionMapping.imageName = { project.tasks["dockerTagImage"].getRepository() }
+            task.conventionMapping.tag = { project.tasks["dockerTagImage"].getTag() }
+            printlng "*** tag = " + project.tasks["dockerTagImage"].getTag()
+        }
+    }
+}
+
+/**
+ * Simple bean used for holding configuration information for the {@link SimpleDockerApplicationPlugin}.
+ *
+ * @author liviutudor
+ */
+class SimpleDockerConfig {
+    /**
+     * Email address of the maintainer of the docker image.
+     */
+    def String maintainerEmail
+
+    /**
+     * Docker daemon url.
+     */
+    def String dockerUrl
+
+    /**
+     * Docker base image.
+     */
+    def String dockerBase
+
+    /**
+     * Docker repository URL.
+     */
+    def String dockerRepo
+
+    /**
+     * Closure to execute when building the docker image.
+     * If you need any other files or symlinks or commands to be executed, specify them here.
+     * If not set (or set to <code>null</code>) then no extra commands will be added to the Dockerfile.
+     */
+    def Closure dockerImage
+
+    /**
+     * Closure used to set the tag on the docker image.
+     * Typically the code will set the tag to be the application version.
+     * This closure allows you to define the tagging for the application version.
+     * If not set, the application version will be set, as per above.
+     */
+    def Closure<String> tagVersion
+
+
+    @Override
+    public String toString() {
+        return "SimpleDockerConfig{" +
+                "maintainerEmail='" + maintainerEmail + '\'' +
+                ", dockerUrl='" + dockerUrl + '\'' +
+                ", dockerBase='" + dockerBase + '\'' +
+                ", dockerRepo='" + dockerRepo + '\'' +
+                ", dockerImage=" + dockerImage +
+                ", tagVersion=" + tagVersion +
+                '}';
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/SimpleDockerApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/SimpleDockerApplicationPlugin.groovy
@@ -51,7 +51,7 @@ class SimpleDockerApplicationPlugin implements Plugin<Project> {
         String appLatest = "/${project.applicationName}-latest"
         String appDir = "/${project.applicationName}-${project.version}"
         project.tasks.create(name: 'createDockerfile', type: Dockerfile) { task ->
-            destFile = project.file(project.simpleDockerConfig.dockerFile)
+            destFile = project.file('./build/docker/Dockerfile')
             dependsOn project.tasks['distTar']
             dependsOn project.tasks['dockerCopyDistResources']
             from "${project.simpleDockerConfig.dockerBase}"
@@ -59,7 +59,7 @@ class SimpleDockerApplicationPlugin implements Plugin<Project> {
 
             addFile "${project.distTar.archiveName}", '/'
             runCommand "ln -s '${appDir}' '${appLatest}'"
-            entryPoint "${appDir}/bin/${project.applicationName}"
+            entryPoint "${appLatest}/bin/${project.applicationName}"
             if (project.simpleDockerConfig.dockerImage) {
                 project.simpleDockerConfig.dockerImage.delegate = task
                 project.simpleDockerConfig.dockerImage(project, task)
@@ -77,6 +77,7 @@ class SimpleDockerApplicationPlugin implements Plugin<Project> {
     protected void taskPushImage(Project project) {
         SimpleDockerConfig dockerConfig = project.simpleDockerConfig
 
+        String taggingVersion = ""
         if (dockerConfig.tagVersion) {
             dockerConfig.tagVersion.delegate = project
             taggingVersion = dockerConfig.tagVersion(project)
@@ -96,7 +97,6 @@ class SimpleDockerApplicationPlugin implements Plugin<Project> {
             dependsOn project.tasks["dockerTagImage"]
             task.conventionMapping.imageName = { project.tasks["dockerTagImage"].getRepository() }
             task.conventionMapping.tag = { project.tasks["dockerTagImage"].getTag() }
-            printlng "*** tag = " + project.tasks["dockerTagImage"].getTag()
         }
     }
 }

--- a/src/main/resources/META-INF/gradle-plugins/com.bmuschko.docker-simple-plugin.properties
+++ b/src/main/resources/META-INF/gradle-plugins/com.bmuschko.docker-simple-plugin.properties
@@ -1,0 +1,16 @@
+#
+# Copyright 2014 the original author or authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+implementation-class=com.bmuschko.gradle.docker.SimpleDockerApplicationPlugin


### PR DESCRIPTION
I'm providing in this pull request to offer a simple plugin on top of the existing ones which offers a very simple approach to building and publishing a docker image for a java application.
The plugin simply creates all the tasks for creating a docker image for a java application and allows for some simple customization which I found myself to use all the time (version/tag as well as adding files to a docker image). It reduces the boilerplate code needed for creating this to just a couple of lines.
There are details in the docco but happy to answer any questions.
