### PR TITLE
Implementation of reactive-stream 'onError' method/closure for all tasks.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ out
 *.iml 
 *.ipr
 *.iws
+/.nb-gradle/

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -208,6 +208,27 @@ task buildImage(type: DockerBuildImage) {
 }
 ----
 
+=== Reactive-Streams
+
+As needed, we will implement reactive methods as described in link:https://github.com/reactive-streams/reactive-streams-jvm[reactive-streams]. We implement these here as optional closures for all tasks. Currently the only supported method is `onError`.
+
+A typical use-case is when one wants to remove a container thay may/may-not be present. In the example below, we check the thrown exception to see if it contains the string 'No such container'. If it does we silently ignore the exception, otherwise we re-throw it.
+
+[source,groovy]
+----
+apply plugin: 'com.bmuschko.docker-remote-api'
+
+import com.bmuschko.gradle.docker.tasks.container.*
+
+task removeContainer(type: DockerRemoveContainer) {
+    targetContainerId { "container-that-does-not-exist" }
+    onError { exception ->
+        if (!exception.message.contains('No such container')) 
+            throw exception
+    }
+}
+----
+
 ==== Executing functional tests against a running container
 
 The following example code demonstrates how to build a Docker image from a Dockerfile, starts up a container for this

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerOnFailureFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerOnFailureFunctionalTest.groovy
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.docker
+
+import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
+
+@Requires({ TestPrecondition.DOCKER_SERVER_INFO_URL_REACHABLE })
+class DockerOnFailureFunctionalTest extends AbstractFunctionalTest {
+    
+    def "Catch exception on removal of non-existent container"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+
+            task removeNonExistentContainer(type: DockerRemoveContainer) {
+                removeVolumes = true
+                force = true
+                targetContainerId { "abcdefgh1234567890" }
+                onFailure { exception ->
+                    if (exception.message.contains("No such container")) {
+                       println "Caught Exception onFailure"
+                    } 
+                }
+            }
+
+            task workflow {
+                dependsOn removeNonExistentContainer
+            }
+        """
+
+        when:
+        BuildResult result = build('workflow')
+
+        then:
+        result.output.contains('Caught Exception onFailure')
+    }
+    
+    def "Re-throw exception on removal of non-existent container"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+
+            task removeNonExistentContainer(type: DockerRemoveContainer) {
+                removeVolumes = true
+                force = true
+                targetContainerId { "abcdefgh1234567890" }
+                onFailure { exception ->
+                    if (exception.message.contains("No such container")) {
+                       throw exception
+                    } 
+                }
+            }
+
+            task workflow {
+                dependsOn removeNonExistentContainer
+            }
+        """
+
+        expect:
+        BuildResult result = buildAndFail('workflow')
+    }
+}
+

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerOnFailureFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerOnFailureFunctionalTest.groovy
@@ -29,7 +29,7 @@ class DockerOnFailureFunctionalTest extends AbstractFunctionalTest {
                 removeVolumes = true
                 force = true
                 targetContainerId { "abcdefgh1234567890" }
-                onFailure { exception ->
+                onError { exception ->
                     if (exception.message.contains("No such container")) {
                        println "Caught Exception onFailure"
                     } 
@@ -56,7 +56,7 @@ class DockerOnFailureFunctionalTest extends AbstractFunctionalTest {
                 removeVolumes = true
                 force = true
                 targetContainerId { "abcdefgh1234567890" }
-                onFailure { exception ->
+                onError { exception ->
                     if (exception.message.contains("No such container")) {
                        throw exception
                     } 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -48,13 +48,25 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     @Input
     @Optional
     String apiVersion
+    
+    @Input
+    @Optional
+    Closure onFailure
 
     ThreadContextClassLoader threadContextClassLoader
 
     @TaskAction
     void start() {
-        runInDockerClassPath { dockerClient ->
-            runRemoteCommand(dockerClient)
+        try {
+            runInDockerClassPath { dockerClient ->
+                runRemoteCommand(dockerClient)
+            }
+        } catch (Exception possibleException) {
+            if (onFailure) {
+                onFailure(possibleException)
+            } else {
+                throw possibleException
+            }
         }
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -49,9 +49,12 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     @Optional
     String apiVersion
     
+    /**
+     * Closure to handle the possibly throw exception
+     */
     @Input
     @Optional
-    Closure onFailure
+    Closure onError
 
     ThreadContextClassLoader threadContextClassLoader
 
@@ -62,8 +65,8 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
                 runRemoteCommand(dockerClient)
             }
         } catch (Exception possibleException) {
-            if (onFailure) {
-                onFailure(possibleException)
+            if (onError) {
+                onError(possibleException)
             } else {
                 throw possibleException
             }


### PR DESCRIPTION
@orzeh if you have time for a review I'd appreciate it. This is a simplified take on #153 to provide an `onError` closure for all tasks to take advantage of. The idea is to implement those methods from [reactive-streams-jvm](https://github.com/reactive-streams/reactive-streams-jvm/#2-subscriber-code) that make sense.