### PR TITLE
Improve README. Add missing '/' in default registryCredentials

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -146,7 +146,7 @@ You can provide those credentials in the `registryCredentials` closure:
 [options="header"]
 |=======
 |Property name   |Type      |Default value               |Description
-|`url`           |String    |https://index.docker.io/v1  |The registry URL.
+|`url`           |String    |https://index.docker.io/v1/ |The registry URL.
 |`username`      |String    |null                        |The registry username.
 |`password`      |String    |null                        |The registry password.
 |`email`         |String    |null                        |The registry email address.
@@ -168,7 +168,7 @@ docker {
     certPath = new File(System.properties['user.home'], '.boot2docker/certs/boot2docker-vm')
 
     registryCredentials {
-        url = 'https://index.docker.io/v1'
+        url = 'https://index.docker.io/v1/'
         username = 'bmuschko'
         password = 'pwd'
         email = 'benjamin.muschko@gmail.com'


### PR DESCRIPTION
Default links in documentation were missing the closing slash. It should be: 'https://index.docker.io/v1/' as in gradle-docker-plugin/src/main/groovy/com/bmuschko/gradle/docker/DockerRegistryCredentials.groovy