### PR TITLE
Expose method imageId for DockerPullImage task to better fall inline …

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerCopyFileToContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerCopyFileToContainerFunctionalTest.groovy
@@ -41,7 +41,7 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['echo', 'Hello World']
             }
 
@@ -98,7 +98,7 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['echo', 'Hello World']
             }
 
@@ -146,7 +146,7 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['echo', 'Hello World']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
@@ -36,7 +36,7 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['sleep','10']
             }
 
@@ -88,7 +88,7 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['sleep','10']
             }
 
@@ -104,10 +104,10 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
         """
 
         when:
-        	build('workflow')
+            build('workflow')
         	
        	then:
-       		Exception ex = thrown()
-			ex.message.contains('is not running')
+            Exception ex = thrown()
+            ex.message.contains('is not running')
     }
 }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerInspectExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerInspectExecContainerFunctionalTest.groovy
@@ -24,7 +24,7 @@ class DockerInspectExecContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['sleep','10']
             }
 
@@ -77,7 +77,7 @@ class DockerInspectExecContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['sleep','10']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLogsContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLogsContainerFunctionalTest.groovy
@@ -34,7 +34,7 @@ class DockerLogsContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository+":"+pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ['/bin/sh','-c','echo -e "Hello World\\n  indent"']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerReactiveMethodsFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerReactiveMethodsFunctionalTest.groovy
@@ -112,7 +112,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId { pullImage.repository+":"+pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd = ["/bin/sh","-c","echo Hello World"]
             }
 
@@ -366,7 +366,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractFunctionalTest {
 
             task inspectImage(type: DockerInspectImage) {
                 dependsOn pullImage
-                targetImageId { 'alpine:3.4' }
+                targetImageId { pullImage.getImageId() }
                 
                 onNext { image ->
                     logger.quiet 'Cmd:        ' + image.config.cmd

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWaitContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWaitContainerFunctionalTest.groovy
@@ -33,7 +33,7 @@ class DockerWaitContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer){
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd 'sh', '-c', 'exit 0'
             }
 
@@ -74,7 +74,7 @@ class DockerWaitContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer){
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd 'sh', '-c', 'exit 1'
             }
 
@@ -115,7 +115,7 @@ class DockerWaitContainerFunctionalTest extends AbstractFunctionalTest {
 
             task createContainer(type: DockerCreateContainer){
                 dependsOn pullImage
-                targetImageId { pullImage.repository + ":" + pullImage.tag }
+                targetImageId { pullImage.getImageId() }
                 cmd 'sh', '-c', 'sleep 15'
             }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
@@ -42,7 +42,7 @@ class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCre
     @Nested
     @Optional
     DockerRegistryCredentials registryCredentials
-
+    
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Pulling repository '${getRepository()}'."
@@ -59,5 +59,9 @@ class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCre
 
         def response = pullImageCmd.exec(threadContextClassLoader.createPullImageResultCallback(onNext))
         response.awaitSuccess()
+    }
+    
+    public String getImageId() {
+        tag?.trim() ? "${repository}:${tag}" : repository
     }
 }


### PR DESCRIPTION
…with DockerBuildImage expectations.

The previous way (which still works) to grab the imageId from the `DockerPullImage` task was to do something like:

    targetImageId { pullImage.repository + ":" + pullImage.tag }

Now developers can do:

    targetImageId { pullImage.getImageId() }

This shortens things up immensely especially if you have long verbose task names (like we do here ;)). This better falls inline with developers expectations having used the `DockerBuildImage` task.