### PR TITLE
Allow to build image with multiple tags

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -37,10 +37,19 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     File dockerFile
 
     /**
-     * Tag for image.
+     * Tags for image.
      */
     @Input
     @Optional
+    Set<String> tags = []
+
+    /**
+     * Tag for image.
+     * @deprecated use {@link #tags}
+     */
+    @Input
+    @Optional
+    @Deprecated
     String tag
 
     @Input
@@ -95,9 +104,13 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             buildImageCmd = dockerClient.buildImageCmd(getInputDir())
         }
 
-        if (getTag()) {
+        if(getTag()) {
             logger.quiet "Using tag '${getTag()}' for image."
             buildImageCmd.withTag(getTag())
+        } else if (getTags()) {
+            def tagListString = getTags().collect {"'${it}'"}.join(", ")
+            logger.quiet "Using tags ${tagListString} for image."
+            buildImageCmd.withTags(getTags())
         }
 
         if (getNoCache()) {


### PR DESCRIPTION
Adds `tags` property to `DockerBuildImage` task and deprecates `tag` property.
To preserve backward compatibility if `tag` is defined, `tags` are ignored.
Fix #286