### PR TITLE
Add networkAliases option to DockerCreateContainer

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -47,7 +47,7 @@ abstract class AbstractFunctionalTest extends Specification {
         setupDockerServerUrl()
         setupDockerCertPath()
         setupDockerPrivateRegistryUrl()
-        
+
         buildFile << """
             task dockerVersion(type: com.bmuschko.gradle.docker.tasks.DockerVersion)
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -115,6 +115,10 @@ abstract class AbstractFunctionalTest extends Specification {
         generateRandomUUID()
     }
 
+    protected String createUniqueNetworkName() {
+        generateRandomUUID()
+    }
+
     private String generateRandomUUID() {
         UUID.randomUUID().toString().replaceAll('-', '')
     }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -281,7 +281,7 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
         String uniqueContainerName = createUniqueContainerName()
 
         // required for task `copyFileFromContainerToHostDir`
-        File hostPathDir = new File(getProjectDir(),"copy-file-host-dir")
+        File hostPathDir = new File(getProjectDir(), "copy-file-host-dir")
         if (!hostPathDir.mkdirs())
             throw new GradleException("Could not successfully create hostPathDir @ ${hostPathDir.path}")
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -102,6 +102,10 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
 
     @Input
     @Optional
+    String[] networkAliases
+
+    @Input
+    @Optional
     String image
 
     @Input
@@ -250,6 +254,10 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
 
         if(getNetworkMode()) {
             containerCommand.withNetworkMode(getNetworkMode())
+        }
+
+        if(getNetworkAliases()) {
+            containerCommand.withAliases(getNetworkAliases())
         }
 
         if(getImage()) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -19,7 +19,6 @@ import com.bmuschko.gradle.docker.tasks.AbstractDockerRemoteApiTask
 import com.bmuschko.gradle.docker.utils.CollectionUtil
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
 
 class DockerCreateContainer extends AbstractDockerRemoteApiTask {


### PR DESCRIPTION
Allow assigning network aliases to containers, enabling network access inside the network via these set domain names.
https://docs.docker.com/engine/userguide/networking/configure-dns/

```groovy
project.task('createDockerContainer', type: DockerCreateContainer) {
    // ...
    networkMode = 'some-network'
    networkAliases = ['some-alias']
}
```

I'm assuming this doesn't require an additional test case since we're just delegating to docker-java (networkMode for instance isn't tested either).