### PR TITLE
Fix publishing JavaDoc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ jobs:
       script: skip
       deploy:
         provider: script
-        script: ./gradlew -s assemble bintrayUpload gitPublishPush
+        script: ./gradlew -s assemble bintrayUpload gitPublishPush -Dorg.ajoberstar.grgit.auth.username=bmuschko -Dorg.ajoberstar.grgit.auth.password=$GH_TOKEN
         on:
           tags: true
 

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -14,13 +14,13 @@ The [`gradle-git-publish`](https://github.com/ajoberstar/gradle-git-publish) Gra
 [Travis CI](https://travis-ci.com) service is used as our current [CI/CD](https://en.wikipedia.org/wiki/CI/CD) server. Build and deploy jobs are configured in [.travis.yml](.travis.yml) file. Please refer its [documentation](https://docs.travis-ci.com/) for more details.
 
 ## Bintray
-[Bintray](https://bintray.com) service is used to publish plugin versions. With [BintrayPlugin](https://github.com/bintray/gradle-bintray-plugin) artifacts are uploaded to a remote reposiotry. Plugin configuration is in the [gradle/publishing.gradle](gradle/publishing.gradle) file.
+[Bintray](https://bintray.com) service is used to publish plugin versions. With [BintrayPlugin](https://github.com/bintray/gradle-bintray-plugin) artifacts are uploaded to a remote repository. Plugin configuration is in the [gradle/publishing.gradle](gradle/publishing.gradle) file.
 
 # Workflow
 The release process is automated to some extent. The following steps describe the workflow.
 1. Developer updates `README.md` and `RELEASE_NOTES.md` with new planned version.
 2. Developer commits all changes in local working copy.
-3. Developer triggers new version release using the following command: `$ ./gradlew release -Prelease.stage=final -Prelease.scope=[SCOPE]`, where `[SCOPE]` can be one of: `major`, `minor`, `patch` and determines which part of the version string `<major>.<minor>.<patch>` will be increased.
+3. Developer triggers new version release using the following command: `$ ./gradlew release -Prelease.stage=final`. `release` task will use the default value for `release.scope` parameter which is `patch`. It is defined in the [`gradle.properties`](gradle.properties) file. If necessary, developer can override it by executing the following command: `$ ./gradlew release -Prelease.stage=final -Prelease.scope=[SCOPE]`, where `[SCOPE]` can be one of: `major`, `minor`, `patch`, and determines which part of the version string `<major>.<minor>.<patch>` will be increased.
 4. Gradle executes a build on developer's machine which calculates new version string, creates new tag with it and pushes to the `origin`.
 5. When Gradle build is finished, developer's work is done and the rest of the release process is automated.
 6. After push to the `origin`, Travis detects new tag and triggers a build.

--- a/doc/RELEASE.md
+++ b/doc/RELEASE.md
@@ -7,6 +7,9 @@ The release process uses some external libraries and services described in detai
 ## gradle-git
 The [`gradle-git`](https://github.com/ajoberstar/gradle-git) Gradle plugin is used to automatically determine the project version. `org.ajoberstar.release-opinion` is applied in the main [build.gradle](build.gradle#L15) and configured in [gradle/release.gradle](gradle/release.gradle#L16). Please refer to the plugin [documentation](https://github.com/ajoberstar/gradle-git/wiki/Release%20Plugins#how-do-i-use-the-opinion-plugin) for more details.
 
+## gradle-git-publish
+The [`gradle-git-publish`](https://github.com/ajoberstar/gradle-git-publish) Gradle plugin is used to publish the documentation to `gh-pages` branch. It is applied and configured in the [gradle/documentation.gradle](gradle/documentation.gradle) file.
+
 ## Travis CI
 [Travis CI](https://travis-ci.com) service is used as our current [CI/CD](https://en.wikipedia.org/wiki/CI/CD) server. Build and deploy jobs are configured in [.travis.yml](.travis.yml) file. Please refer its [documentation](https://docs.travis-ci.com/) for more details.
 
@@ -22,7 +25,7 @@ The release process is automated to some extent. The following steps describe th
 5. When Gradle build is finished, developer's work is done and the rest of the release process is automated.
 6. After push to the `origin`, Travis detects new tag and triggers a build.
 7. Travis [is instructed](.travis.yml#L23) to execute [release stage](https://docs.travis-ci.com/user/build-stages/) when on Git tag.
-8. In this stage [Gradle script](.travis.yml#L21) assembles plugin binaries (with new version) and uploads them to Bintray (credentials are stored as [secure variables](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) in Travis). Also JavaDoc is published to `gh-pages` branch.
+8. In this stage [Gradle script](.travis.yml#L21) assembles plugin binaries (with new version) and uploads them to Bintray (credentials are stored as [secure variables](https://docs.travis-ci.com/user/environment-variables/#Defining-Variables-in-Repository-Settings) in Travis). Also JavaDoc is published to `gh-pages` branch (GitHub username and [access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) are also stored as secure variables).
 
 # Useful links
 * [Semantic Versioning](http://semver.org/)

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,1 @@
+release.scope=patch

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,8 @@
+# Can take the form of either `major`, `minor`, or `patch`
 release.scope=patch
+
+# Defined here for documentation purposes. When ready 
+# to do a release the user should pass this along on 
+# the command line for a 1 time execution.
+#
+# release.stage=final

--- a/gradle/documentation.gradle
+++ b/gradle/documentation.gradle
@@ -11,7 +11,7 @@ buildscript {
 apply plugin: org.ajoberstar.gradle.git.publish.GitPublishPlugin
 
 gitPublish {
-    repoUri = 'git@github.com:bmuschko/gradle-docker-plugin.git'
+    repoUri = 'https://github.com/bmuschko/gradle-docker-plugin.git'
     branch = 'gh-pages'
     
     contents {

--- a/gradle/release.gradle
+++ b/gradle/release.gradle
@@ -11,10 +11,9 @@ buildscript {
     }
 }
 
-ext.repo = Grgit.open(rootDir)
+apply plugin: org.ajoberstar.gradle.git.base.GrgitPlugin
 
 release {
-    grgit = Grgit.open(rootDir)
     versionStrategy Strategies.FINAL
     defaultVersionStrategy = Strategies.SNAPSHOT
 


### PR DESCRIPTION
This PR should allow to publish JavaDoc to `gh-pages` branch from Travis job.

@bmuschko can you define those two secure variables in Travis:
* `GRGIT_USER=bmuschko`
* `GRGIT_PASS=[GITHUB_TOKEN]`

and create GitHub [access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) with `public_repo` scope so Travis can push to this repository?