### PR TITLE
Issue #415 - multiple ENVs are not set the same way as like single ENV instructions

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
@@ -116,8 +116,8 @@ RUN echo deb http://archive.ubuntu.com/ubuntu precise universe >> /etc/apt/sourc
 CMD ["echo", "some", "command"]
 EXPOSE 8080 14500
 ENV ENV_VAR_KEY envVarVal
-ENV "ENV_VAR_A"="val_a"
-ENV "ENV_VAR_B"="val_b" "ENV_VAR_C"="val_c"
+ENV ENV_VAR_A=val_a
+ENV ENV_VAR_B=val_b ENV_VAR_C=val_c
 ADD http://mirrors.jenkins-ci.org/war/1.563/jenkins.war /opt/jenkins.war
 COPY http://hsql.sourceforge.net/m2-repo/com/h2database/h2/1.4.184/h2-1.4.184.jar /opt/h2.jar
 ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]
@@ -125,7 +125,7 @@ VOLUME ["/jenkins", "/myApp"]
 USER root
 WORKDIR /tmp
 ONBUILD RUN echo "Hello World"
-LABEL "version"="1.0"
+LABEL version=1.0
 """
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -43,11 +43,11 @@ class Dockerfile extends DefaultTask {
     }
 
     private void verifyValidInstructions() {
-        if (getInstructions().empty) {
+        if(getInstructions().empty) {
             throw new IllegalStateException('Please specify instructions for your Dockerfile')
         }
 
-        if (!(getInstructions()[0].keyword == 'FROM')) {
+        if(!(getInstructions()[0].keyword == 'FROM')) {
             throw new IllegalStateException('The first instruction of a Dockerfile has to be FROM')
         }
     }
@@ -75,9 +75,11 @@ class Dockerfile extends DefaultTask {
      * Example:
      *
      * <pre>
-     * task createDockerfile(type: Dockerfile) {*     instruction 'FROM ubuntu:14.04'
+     * task createDockerfile(type: Dockerfile) {
+     *     instruction 'FROM ubuntu:14.04'
      *     instruction 'MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"'
-     *}* </pre>
+     * }
+     * </pre>
      *
      * @param instruction Instruction as String
      */
@@ -91,7 +93,11 @@ class Dockerfile extends DefaultTask {
      * Example:
      *
      * <pre>
-     * task createDockerfile(type: Dockerfile) {*     instruction { 'FROM ubuntu:14.04' }*     instruction { 'MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"' }*}* </pre>
+     * task createDockerfile(type: Dockerfile) {
+     *     instruction { 'FROM ubuntu:14.04' }
+     *     instruction { 'MAINTAINER Benjamin Muschko "benjamin.muschko@gmail.com"' }
+     * }
+     * </pre>
      *
      * @param instruction Instruction as Closure
      */
@@ -404,7 +410,6 @@ class Dockerfile extends DefaultTask {
 
     static interface Instruction {
         String getKeyword()
-
         String build()
     }
 
@@ -421,9 +426,10 @@ class Dockerfile extends DefaultTask {
 
         @Override
         String getKeyword() {
-            if (instruction instanceof String) {
+            if(instruction instanceof String) {
                 parseKeyword(instruction)
-            } else if (instruction instanceof Closure) {
+            }
+            else if(instruction instanceof Closure) {
                 parseKeyword(instruction())
             }
         }
@@ -434,9 +440,10 @@ class Dockerfile extends DefaultTask {
 
         @Override
         String build() {
-            if (instruction instanceof String) {
-                instruction
-            } else if (instruction instanceof Closure) {
+            if(instruction instanceof String) {
+               instruction
+            }
+            else if(instruction instanceof Closure) {
                 instruction()
             }
         }
@@ -455,9 +462,10 @@ class Dockerfile extends DefaultTask {
 
         @Override
         String build() {
-            if (command instanceof String) {
+            if(command instanceof String) {
                 "$keyword $command"
-            } else if (command instanceof Closure) {
+            }
+            else if(command instanceof Closure) {
                 "$keyword ${command()}"
             }
         }
@@ -476,14 +484,16 @@ class Dockerfile extends DefaultTask {
 
         @Override
         String build() {
-            if (command instanceof String[]) {
+            if(command instanceof String[]) {
                 keyword + ' ["' + command.join('", "') + '"]'
-            } else if (command instanceof Closure) {
+            }
+            else if(command instanceof Closure) {
                 def evaluatedCommand = command()
 
-                if (evaluatedCommand instanceof String) {
+                if(evaluatedCommand instanceof String) {
                     keyword + ' ["' + evaluatedCommand + '"]'
-                } else {
+                }
+                else {
                     keyword + ' ["' + command().join('", "') + '"]'
                 }
             }
@@ -541,10 +551,11 @@ class Dockerfile extends DefaultTask {
         String build() {
             if (command instanceof Map<String, String>) {
                 "$keyword ${joiner.join(command)}"
-            } else if (command instanceof Closure) {
+            }
+            else if(command instanceof Closure) {
                 def evaluatedCommand = command()
 
-                if (evaluatedCommand instanceof Map) {
+                if(evaluatedCommand instanceof Map) {
                     "$keyword ${joiner.join(evaluatedCommand)}"
                 }
             }
@@ -567,9 +578,10 @@ class Dockerfile extends DefaultTask {
 
         @Override
         String build() {
-            if (src instanceof String && dest instanceof String) {
+            if(src instanceof String && dest instanceof String) {
                 "$keyword $src $dest"
-            } else if (src instanceof Closure && dest instanceof Closure) {
+            }
+            else if(src instanceof Closure && dest instanceof Closure) {
                 "$keyword ${src()} ${dest()}"
             }
         }
@@ -621,7 +633,7 @@ class Dockerfile extends DefaultTask {
     }
 
     static class RunCommandInstruction extends StringCommandInstruction {
-        RunCommandInstruction(String command) {
+       RunCommandInstruction(String command) {
             super(command)
         }
 
@@ -668,14 +680,16 @@ class Dockerfile extends DefaultTask {
 
         @Override
         String build() {
-            if (ports instanceof Integer[]) {
+            if(ports instanceof Integer[]) {
                 "$keyword ${ports.join(' ')}"
-            } else if (ports instanceof Closure) {
+            }
+            else if(ports instanceof Closure) {
                 def evaluatedPorts = ports()
 
-                if (evaluatedPorts instanceof String || evaluatedPorts instanceof Integer) {
+                if(evaluatedPorts instanceof String || evaluatedPorts instanceof Integer) {
                     "$keyword ${evaluatedPorts}"
-                } else {
+                }
+                else {
                     "$keyword ${evaluatedPorts.join(' ')}"
                 }
             }
@@ -848,7 +862,6 @@ class Dockerfile extends DefaultTask {
         void defaultCommand(String... command) {
             instructions << new DefaultCommandInstruction(command)
         }
-
         void defaultCommand(Closure command) {
             instructions << new DefaultCommandInstruction(command)
         }
@@ -856,7 +869,6 @@ class Dockerfile extends DefaultTask {
         void entryPoint(String... entryPoint) {
             instructions << new EntryPointInstruction(entryPoint)
         }
-
         void entryPoint(Closure entryPoint) {
             instructions << new EntryPointInstruction(entryPoint)
         }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -507,7 +507,7 @@ class Dockerfile extends DefaultTask {
     static class MultiItemJoiner implements ItemJoiner {
         @Override
         String join(Map map) {
-            map.inject([]) { result, entry -> result << "\"$entry.key\"=\"$entry.value\"" }.join(' ')
+            map.inject([]) { result, entry -> result << "$entry.key=$entry.value" }.join(' ')
         }
     }
 

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -27,6 +27,8 @@ class DockerfileTest extends Specification {
         new ExposePortInstruction(8080, 9090)                                           | 'EXPOSE'        | 'EXPOSE 8080 9090'
         new ExposePortInstruction({ [8080, 9090] })                                     | 'EXPOSE'        | 'EXPOSE 8080 9090'
         new EnvironmentVariableInstruction('OS', 'Linux')                               | 'ENV'           | 'ENV OS Linux'
+        // TODO: negative test:
+        // new EnvironmentVariableInstruction('', 'Linux')                                 | 'ENV'           | InvalidCharacterException.class
         new EnvironmentVariableInstruction('OS', '"Linux"')                             | 'ENV'           | 'ENV OS "Linux"'
         new EnvironmentVariableInstruction('OS', 'Linux or Windows')                    | 'ENV'           | 'ENV OS Linux or Windows'
         new EnvironmentVariableInstruction('long', '''Multiple line env 
@@ -58,7 +60,7 @@ with linebreaks in between\""
         new OnBuildInstruction({ 'ENV JAVA_HOME /usr/java' })                           | 'ONBUILD'       | 'ONBUILD ENV JAVA_HOME /usr/java'
         new LabelInstruction(['group': 'artificial' ])                                  | 'LABEL'         | 'LABEL group=artificial'
         new LabelInstruction(['description': 'Single label' ])                          | 'LABEL'         | 'LABEL description="Single label"'
-        // TODO: negative test:
+        // TODO:
         // new LabelInstruction(['"un subscribe"': 'true' ])                               | 'LABEL'         | 'LABEL "un subscribe"=true'
         new LabelInstruction({ ['description': 'Single label' ] })                      | 'LABEL'         | 'LABEL description="Single label"'
         new LabelInstruction(['description': 'Multiple labels', 'version': '1.0' ])     | 'LABEL'         | 'LABEL description="Multiple labels" version=1.0'

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -25,7 +25,7 @@ class DockerfileTest extends Specification {
             actual = instructionInstance.build()
         }
         catch(Exception e) {
-            LOG.info "exception catched with message `${e.message}`"
+            LOG.info "Exception caught with message `${e.message}`"
             if(!expectedBuiltInstruction.equals(e.class)) {
                 LOG.log(Level.WARNING, e.stackTrace?.join('\n\t'))
             }

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -2,13 +2,38 @@ package com.bmuschko.gradle.docker.tasks.image
 
 import spock.lang.Specification
 
+import java.util.logging.Level
+import java.util.logging.Logger
+
 import static com.bmuschko.gradle.docker.tasks.image.Dockerfile.*
 
 class DockerfileTest extends Specification {
+    private static Logger LOG = Logger.getLogger(DockerfileTest.class.getCanonicalName());
     def "Instruction String representation is built correctly"() {
+
         expect:
+        LOG.fine "testing " + [
+            instruction: instructionInstance.class,
+            becomes: [
+                keyword: expectedKeyword,
+                withBuildText: expectedBuiltInstruction,
+            ]
+        ]
+
+        def actual
+        try {
+            actual = instructionInstance.build()
+        }
+        catch(Exception e) {
+            LOG.info "exception catched with message `${e.message}`"
+            if(!expectedBuiltInstruction.equals(e.class)) {
+                LOG.log(Level.WARNING, e.stackTrace?.join('\n\t'))
+            }
+            actual = e.class
+        }
+
         instructionInstance.keyword == expectedKeyword
-        instructionInstance.build() == expectedBuiltInstruction
+        actual == expectedBuiltInstruction
 
         where:
         instructionInstance                                                             | expectedKeyword | expectedBuiltInstruction
@@ -27,8 +52,8 @@ class DockerfileTest extends Specification {
         new ExposePortInstruction(8080, 9090)                                           | 'EXPOSE'        | 'EXPOSE 8080 9090'
         new ExposePortInstruction({ [8080, 9090] })                                     | 'EXPOSE'        | 'EXPOSE 8080 9090'
         new EnvironmentVariableInstruction('OS', 'Linux')                               | 'ENV'           | 'ENV OS Linux'
-        // TODO: negative test:
-        // new EnvironmentVariableInstruction('', 'Linux')                                 | 'ENV'           | InvalidCharacterException.class
+        new EnvironmentVariableInstruction('', 'Linux')                                 | 'ENV'           | IllegalArgumentException.class
+        new EnvironmentVariableInstruction(' ', 'Linux')                                | 'ENV'           | IllegalArgumentException.class
         new EnvironmentVariableInstruction('OS', '"Linux"')                             | 'ENV'           | 'ENV OS "Linux"'
         new EnvironmentVariableInstruction('OS', 'Linux or Windows')                    | 'ENV'           | 'ENV OS Linux or Windows'
         new EnvironmentVariableInstruction('long', '''Multiple line env 
@@ -38,6 +63,8 @@ with linebreaks in between"
         new EnvironmentVariableInstruction(['long': '''Multiple line env 
 with linebreaks in between'''])                                                         | 'ENV'           | "ENV long=\"Multiple line env \\\n\
 with linebreaks in between\""
+        new EnvironmentVariableInstruction({ })                                         | 'ENV'           | IllegalArgumentException.class
+        new EnvironmentVariableInstruction({ 'OS LINUX' })                              | 'ENV'           | IllegalArgumentException.class
         new EnvironmentVariableInstruction({ ['OS': 'Linux'] })                         | 'ENV'           | 'ENV OS=Linux'
         new EnvironmentVariableInstruction(['OS': 'Linux', 'TZ': 'UTC'])                | 'ENV'           | 'ENV OS=Linux TZ=UTC'
         new EnvironmentVariableInstruction({ ['OS': 'Linux', 'TZ': 'UTC'] })            | 'ENV'           | 'ENV OS=Linux TZ=UTC'
@@ -60,13 +87,12 @@ with linebreaks in between\""
         new OnBuildInstruction({ 'ENV JAVA_HOME /usr/java' })                           | 'ONBUILD'       | 'ONBUILD ENV JAVA_HOME /usr/java'
         new LabelInstruction(['group': 'artificial' ])                                  | 'LABEL'         | 'LABEL group=artificial'
         new LabelInstruction(['description': 'Single label' ])                          | 'LABEL'         | 'LABEL description="Single label"'
-        // TODO:
-        // new LabelInstruction(['"un subscribe"': 'true' ])                               | 'LABEL'         | 'LABEL "un subscribe"=true'
+        new LabelInstruction(['"un subscribe"': 'true' ])                               | 'LABEL'         | 'LABEL "un subscribe"=true'
         new LabelInstruction({ ['description': 'Single label' ] })                      | 'LABEL'         | 'LABEL description="Single label"'
         new LabelInstruction(['description': 'Multiple labels', 'version': '1.0' ])     | 'LABEL'         | 'LABEL description="Multiple labels" version=1.0'
         new LabelInstruction({ ['description': 'Multiple labels', 'version': '1.0' ] }) | 'LABEL'         | 'LABEL description="Multiple labels" version=1.0'
         new LabelInstruction({ ['long': '''Multiple lines labels 
-with linebreaks in between''' ] }) | 'LABEL'      | "LABEL long=\"Multiple lines labels \\\n\
+with linebreaks in between''' ] })                                                      | 'LABEL'         | "LABEL long=\"Multiple lines labels \\\n\
 with linebreaks in between\""
     }
 }

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -7,47 +7,64 @@ import static com.bmuschko.gradle.docker.tasks.image.Dockerfile.*
 class DockerfileTest extends Specification {
     def "Instruction String representation is built correctly"() {
         expect:
-        instructionInstance.keyword == keyword
-        instructionInstance.build() == builtInstruction
+        instructionInstance.keyword == expectedKeyword
+        instructionInstance.build() == expectedBuiltInstruction
 
         where:
-        instructionInstance                                                             | keyword      | builtInstruction
-        new GenericInstruction('FROM ubuntu:14.04')                                     | 'FROM'       | 'FROM ubuntu:14.04'
-        new GenericInstruction({ 'FROM ubuntu:14.04' })                                 | 'FROM'       | 'FROM ubuntu:14.04'
-        new FromInstruction('ubuntu:14.04')                                             | 'FROM'       | 'FROM ubuntu:14.04'
-        new FromInstruction({ 'ubuntu:14.04' })                                         | 'FROM'       | 'FROM ubuntu:14.04'
-        new MaintainerInstruction('John Doe "john.doe@gmail.com"')                      | 'MAINTAINER' | 'MAINTAINER John Doe "john.doe@gmail.com"'
-        new MaintainerInstruction({ 'John Doe "john.doe@gmail.com"' })                  | 'MAINTAINER' | 'MAINTAINER John Doe "john.doe@gmail.com"'
-        new RunCommandInstruction('apt-get update && apt-get clean')                    | 'RUN'        | 'RUN apt-get update && apt-get clean'
-        new RunCommandInstruction({ 'apt-get update && apt-get clean' })                | 'RUN'        | 'RUN apt-get update && apt-get clean'
-        new DefaultCommandInstruction('ping google.com')                                | 'CMD'        | 'CMD ["ping google.com"]'
-        new DefaultCommandInstruction({ 'ping google.com' })                            | 'CMD'        | 'CMD ["ping google.com"]'
-        new ExposePortInstruction(8080)                                                 | 'EXPOSE'     | 'EXPOSE 8080'
-        new ExposePortInstruction({ 8080 })                                             | 'EXPOSE'     | 'EXPOSE 8080'
-        new ExposePortInstruction(8080, 9090)                                           | 'EXPOSE'     | 'EXPOSE 8080 9090'
-        new ExposePortInstruction({ [8080, 9090] })                                     | 'EXPOSE'     | 'EXPOSE 8080 9090'
-        new EnvironmentVariableInstruction('OS', 'Linux')                               | 'ENV'        | 'ENV OS Linux'
-        new EnvironmentVariableInstruction(['OS': 'Linux'])                             | 'ENV'        | 'ENV "OS"="Linux"'
-        new EnvironmentVariableInstruction({ ['OS': 'Linux'] })                         | 'ENV'        | 'ENV "OS"="Linux"'
-        new EnvironmentVariableInstruction(['OS': 'Linux', 'TZ': 'UTC'])                | 'ENV'        | 'ENV "OS"="Linux" "TZ"="UTC"'
-        new EnvironmentVariableInstruction({ ['OS': 'Linux', 'TZ': 'UTC'] })            | 'ENV'        | 'ENV "OS"="Linux" "TZ"="UTC"'
-        new AddFileInstruction('config.xml', '/test')                                   | 'ADD'        | 'ADD config.xml /test'
-        new AddFileInstruction({ 'config.xml' }, { '/test' })                           | 'ADD'        | 'ADD config.xml /test'
-        new CopyFileInstruction('config.xml', '/test')                                  | 'COPY'       | 'COPY config.xml /test'
-        new CopyFileInstruction({ 'config.xml' }, { '/test' })                          | 'COPY'       | 'COPY config.xml /test'
-        new EntryPointInstruction('java', '-jar', '/opt/jenkins.war')                   | 'ENTRYPOINT' | 'ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]'
-        new EntryPointInstruction({ ['java', '-jar', '/opt/jenkins.war'] })             | 'ENTRYPOINT' | 'ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]'
-        new VolumeInstruction('/jenkins')                                               | 'VOLUME'     | 'VOLUME ["/jenkins"]'
-        new VolumeInstruction({ '/jenkins' })                                           | 'VOLUME'     | 'VOLUME ["/jenkins"]'
-        new UserInstruction('ENV JAVA_HOME /usr/java')                                  | 'USER'       | 'USER ENV JAVA_HOME /usr/java'
-        new UserInstruction({ 'ENV JAVA_HOME /usr/java' })                              | 'USER'       | 'USER ENV JAVA_HOME /usr/java'
-        new WorkDirInstruction('/some/dir')                                             | 'WORKDIR'    | 'WORKDIR /some/dir'
-        new WorkDirInstruction({ '/some/dir' })                                         | 'WORKDIR'    | 'WORKDIR /some/dir'
-        new OnBuildInstruction('ENV JAVA_HOME /usr/java')                               | 'ONBUILD'    | 'ONBUILD ENV JAVA_HOME /usr/java'
-        new OnBuildInstruction({ 'ENV JAVA_HOME /usr/java' })                           | 'ONBUILD'    | 'ONBUILD ENV JAVA_HOME /usr/java'
-        new LabelInstruction(['description': 'Single label' ])                          | 'LABEL'      | 'LABEL "description"="Single label"'
-        new LabelInstruction({ ['description': 'Single label' ] })                      | 'LABEL'      | 'LABEL "description"="Single label"'
-        new LabelInstruction(['description': 'Multiple labels', 'version': '1.0' ])     | 'LABEL'      | 'LABEL "description"="Multiple labels" "version"="1.0"'
-        new LabelInstruction({ ['description': 'Multiple labels', 'version': '1.0' ] }) | 'LABEL'      | 'LABEL "description"="Multiple labels" "version"="1.0"'
+        instructionInstance                                                             | expectedKeyword | expectedBuiltInstruction
+        new GenericInstruction('FROM ubuntu:14.04')                                     | 'FROM'          | 'FROM ubuntu:14.04'
+        new GenericInstruction({ 'FROM ubuntu:14.04' })                                 | 'FROM'          | 'FROM ubuntu:14.04'
+        new FromInstruction('ubuntu:14.04')                                             | 'FROM'          | 'FROM ubuntu:14.04'
+        new FromInstruction({ 'ubuntu:14.04' })                                         | 'FROM'          | 'FROM ubuntu:14.04'
+        new MaintainerInstruction('John Doe "john.doe@gmail.com"')                      | 'MAINTAINER'    | 'MAINTAINER John Doe "john.doe@gmail.com"'
+        new MaintainerInstruction({ 'John Doe "john.doe@gmail.com"' })                  | 'MAINTAINER'    | 'MAINTAINER John Doe "john.doe@gmail.com"'
+        new RunCommandInstruction('apt-get update && apt-get clean')                    | 'RUN'           | 'RUN apt-get update && apt-get clean'
+        new RunCommandInstruction({ 'apt-get update && apt-get clean' })                | 'RUN'           | 'RUN apt-get update && apt-get clean'
+        new DefaultCommandInstruction('ping google.com')                                | 'CMD'           | 'CMD ["ping google.com"]'
+        new DefaultCommandInstruction({ 'ping google.com' })                            | 'CMD'           | 'CMD ["ping google.com"]'
+        new ExposePortInstruction(8080)                                                 | 'EXPOSE'        | 'EXPOSE 8080'
+        new ExposePortInstruction({ 8080 })                                             | 'EXPOSE'        | 'EXPOSE 8080'
+        new ExposePortInstruction(8080, 9090)                                           | 'EXPOSE'        | 'EXPOSE 8080 9090'
+        new ExposePortInstruction({ [8080, 9090] })                                     | 'EXPOSE'        | 'EXPOSE 8080 9090'
+        new EnvironmentVariableInstruction('OS', 'Linux')                               | 'ENV'           | 'ENV OS Linux'
+        new EnvironmentVariableInstruction('OS', '"Linux"')                             | 'ENV'           | 'ENV OS "Linux"'
+        new EnvironmentVariableInstruction('OS', 'Linux or Windows')                    | 'ENV'           | 'ENV OS Linux or Windows'
+        new EnvironmentVariableInstruction('long', '''Multiple line env 
+with linebreaks in between''')                                                          | 'ENV'           | "ENV long Multiple line env \\\n\
+with linebreaks in between"
+        new EnvironmentVariableInstruction(['OS': 'Linux'])                             | 'ENV'           | 'ENV OS=Linux'
+        new EnvironmentVariableInstruction(['long': '''Multiple line env 
+with linebreaks in between'''])                                                         | 'ENV'           | "ENV long=\"Multiple line env \\\n\
+with linebreaks in between\""
+        new EnvironmentVariableInstruction({ ['OS': 'Linux'] })                         | 'ENV'           | 'ENV OS=Linux'
+        new EnvironmentVariableInstruction(['OS': 'Linux', 'TZ': 'UTC'])                | 'ENV'           | 'ENV OS=Linux TZ=UTC'
+        new EnvironmentVariableInstruction({ ['OS': 'Linux', 'TZ': 'UTC'] })            | 'ENV'           | 'ENV OS=Linux TZ=UTC'
+        new EnvironmentVariableInstruction({ ['OS': 'Linux', 'CRON': '* 5 * * *'] })    | 'ENV'           | 'ENV OS=Linux CRON="* 5 * * *"'
+        new EnvironmentVariableInstruction({ ['OS': 'Linux', 'CRON': '"* 5 * * *"'] })  | 'ENV'           | 'ENV OS=Linux CRON="* 5 * * *"'
+        new EnvironmentVariableInstruction({ ['PASSION': 'vanilla " flavour'] })        | 'ENV'           | 'ENV PASSION="vanilla \\" flavour"'
+        new AddFileInstruction('config.xml', '/test')                                   | 'ADD'           | 'ADD config.xml /test'
+        new AddFileInstruction({ 'config.xml' }, { '/test' })                           | 'ADD'           | 'ADD config.xml /test'
+        new CopyFileInstruction('config.xml', '/test')                                  | 'COPY'          | 'COPY config.xml /test'
+        new CopyFileInstruction({ 'config.xml' }, { '/test' })                          | 'COPY'          | 'COPY config.xml /test'
+        new EntryPointInstruction('java', '-jar', '/opt/jenkins.war')                   | 'ENTRYPOINT'    | 'ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]'
+        new EntryPointInstruction({ ['java', '-jar', '/opt/jenkins.war'] })             | 'ENTRYPOINT'    | 'ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]'
+        new VolumeInstruction('/jenkins')                                               | 'VOLUME'        | 'VOLUME ["/jenkins"]'
+        new VolumeInstruction({ '/jenkins' })                                           | 'VOLUME'        | 'VOLUME ["/jenkins"]'
+        new UserInstruction('ENV JAVA_HOME /usr/java')                                  | 'USER'          | 'USER ENV JAVA_HOME /usr/java'
+        new UserInstruction({ 'ENV JAVA_HOME /usr/java' })                              | 'USER'          | 'USER ENV JAVA_HOME /usr/java'
+        new WorkDirInstruction('/some/dir')                                             | 'WORKDIR'       | 'WORKDIR /some/dir'
+        new WorkDirInstruction({ '/some/dir' })                                         | 'WORKDIR'       | 'WORKDIR /some/dir'
+        new OnBuildInstruction('ENV JAVA_HOME /usr/java')                               | 'ONBUILD'       | 'ONBUILD ENV JAVA_HOME /usr/java'
+        new OnBuildInstruction({ 'ENV JAVA_HOME /usr/java' })                           | 'ONBUILD'       | 'ONBUILD ENV JAVA_HOME /usr/java'
+        new LabelInstruction(['group': 'artificial' ])                                  | 'LABEL'         | 'LABEL group=artificial'
+        new LabelInstruction(['description': 'Single label' ])                          | 'LABEL'         | 'LABEL description="Single label"'
+        // TODO: negative test:
+        // new LabelInstruction(['"un subscribe"': 'true' ])                               | 'LABEL'         | 'LABEL "un subscribe"=true'
+        new LabelInstruction({ ['description': 'Single label' ] })                      | 'LABEL'         | 'LABEL description="Single label"'
+        new LabelInstruction(['description': 'Multiple labels', 'version': '1.0' ])     | 'LABEL'         | 'LABEL description="Multiple labels" version=1.0'
+        new LabelInstruction({ ['description': 'Multiple labels', 'version': '1.0' ] }) | 'LABEL'         | 'LABEL description="Multiple labels" version=1.0'
+        new LabelInstruction({ ['long': '''Multiple lines labels 
+with linebreaks in between''' ] }) | 'LABEL'      | "LABEL long=\"Multiple lines labels \\\n\
+with linebreaks in between\""
     }
 }


### PR DESCRIPTION
Issue https://github.com/bmuschko/gradle-docker-plugin/issues/415

> When
> ```groov
> dockerfile(Type:Dockerfile) {
>     environmentVariable "foo" "bar"
> }
> ```
> 
> we get 
> ```Dockerfile
> ENV FOO bar
> ```
> 
> but with
> ```groov
> dockerfile(Type:Dockerfile) {
>     environmentVariable [ "foo":"bar" ]
> }
> ```
> 
> we get 
> ```Dockerfile
> ENV "FOO"="bar"
> ```

referring to https://docs.docker.com/engine/reference/builder/#env

- [x] for consistency with the SIngleItemJoiner the code should not always add these quotes

1. single `ENV <key> <value>`  instruction
- [x] 1.a) simple case with a simple word value without any linebreaks. Special Chars (quotes) doesn't matter and are passed as defined
- [ ] 1.b) if value contains a linebreak: ❓undefined if it has to be quoted or (current assumption) one the newline has to be escaped
2. multiple `ENV <key>=<value>[ <key>=<value>]*` instructions behaves a bit different
- [x] 2.a) simple case with a simple word value without linebreaks. Special Chars (quotes) have to be escaped only if the value is enwrapped in quotes due to spaces
- [x] 2.b) if value contains a linebreak or space: the value has to be quoted, linebreak is escaped / translated into a single \
- [x] 3. ❓undefined if keys are allowed to contain whitespaces, I assume not but quotes are allowed
  * as per [definition in Windows](https://msdn.microsoft.com/en-us/library/windows/desktop/ms682653(v=vs.85).aspx):
    > The name of an environment variable cannot include an equal sign (=).
    …
    > The maximum size of a user-defined environment variable is 32,767 characters. There is no technical limitation on the size of the environment block.
    …
    > The environment block is an array of null-terminated Unicode strings. The list ends with two nulls (\0\0).
   * which matches the statements from the [open group](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html)(via [so](https://stackoverflow.com/a/2821183/529977))
     > … names shall not contain the character '='.
     > … the value shall be composed of characters from the portable character set (except NUL and as indicated below).
     > Environment variable names … consist solely of uppercase letters, digits, and the '_' (underscore) from the characters defined in [Portable Character Set](http://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap06.html#tagtcjh_3) and do not begin with a digit. Other characters may be permitted by an implementation; applications shall tolerate the presence of such names.

- [x] 4. this applies to ENV and LABEL

some constraints: 
- [x] if user already quotes the string, we must not repeat this