### PR TITLE
Some test additions to Issue 357+433

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -36,13 +36,26 @@ abstract class AbstractFunctionalTest extends Specification {
 
     def setup() {
         projectDir = temporaryFolder.root
+        setupBuildfile()
+
+        when:
+            BuildResult result = build('dockerVersion')
+
+        then:
+            result.output.contains('Retrieving Docker version.')
+    }
+
+    protected void setupBuildfile() {
+        if (buildFile) {
+            buildFile.delete()
+        }
         buildFile = temporaryFolder.newFile('build.gradle')
 
         buildFile << """
             plugins {
                 id 'com.bmuschko.docker-remote-api'
             }
-			
+
             repositories {
                 mavenCentral()
             }
@@ -55,12 +68,6 @@ abstract class AbstractFunctionalTest extends Specification {
         buildFile << """
             task dockerVersion(type: com.bmuschko.gradle.docker.tasks.DockerVersion)
         """
-
-        when:
-        BuildResult result = build('dockerVersion')
-
-        then:
-        result.output.contains('Retrieving Docker version.')
     }
 
     private void setupDockerServerUrl() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -1,6 +1,7 @@
 package com.bmuschko.gradle.docker
 
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
 class DockerJavaApplicationPluginFunctionalTest extends AbstractFunctionalTest {
@@ -26,6 +27,68 @@ ENTRYPOINT ["/${projectName}-1.0/bin/${projectName}"]
 EXPOSE 8080
 """
         result.output.contains('Author           : ')
+    }
+
+    def "Can build image for Java application with default configuration and changes on changed application package"() {
+        String projectName = temporaryFolder.root.name
+        createJettyMainClass()
+        writeBasicSetupToBuildFile()
+        writeCustomTasksToBuildFile()
+
+        when:
+        BuildResult result = build('dockerBuildImage')
+
+        then:
+        File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
+        File distTarFile = new File(projectDir, "build/distributions/${projectName}-1.0.tar")
+        distTarFile.exists()
+        long distTarFileLastTouched = distTarFile.lastModified()
+        dockerfile.exists()
+        dockerfile.text ==
+"""FROM java
+MAINTAINER ${System.getProperty('user.name')}
+ADD ${projectName}-1.0.tar /
+ENTRYPOINT ["/${projectName}-1.0/bin/${projectName}"]
+EXPOSE 8080
+"""
+
+        when:
+        result = build('dockerBuildImage')
+
+        then:
+        TaskOutcome.UP_TO_DATE == result.tasks.find{it.path == ":dockerBuildImage"}.outcome
+
+        when:
+        temporaryFolder.newFile('file1.txt')
+        temporaryFolder.newFile('file2.txt')
+        buildFile << """
+        distTar {
+            from '${temporaryFolder}/file1.txt'
+            from '${temporaryFolder}/file2.txt'
+        }
+        """
+        result = build('dockerBuildImage')
+
+        then:
+        result.tasks.each { println "$it.path $it.outcome" }
+
+        distTarFileLastTouched < distTarFile.lastModified()
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerBuildImage"}.outcome
+
+        when:
+        buildFile << "version = 1.1"
+        build('dockerBuildImage')
+
+        then:
+        dockerfile.exists()
+        dockerfile.text ==
+"""FROM java
+MAINTAINER ${System.getProperty('user.name')}
+ADD ${projectName}-1.1.tar /
+ENTRYPOINT ["/${projectName}-1.1/bin/${projectName}"]
+EXPOSE 8080
+"""
+
     }
 
     def "Can create image for Java application with user-driven configuration"() {


### PR DESCRIPTION
addressing discussion in #357 and fix #433 

added some more regression tests
- [x] open question: is `dockerFile() { outputs.upToDateWhen { moon.inZenith } }` a valid use case now the base issue is fixed by #433 ?
