### PR TITLE
The first instruction of a Dockerfile has to be FROM except for Docker later than 17.05

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -47,8 +47,10 @@ class Dockerfile extends DefaultTask {
             throw new IllegalStateException('Please specify instructions for your Dockerfile')
         }
 
-        if(!(getInstructions()[0].keyword == 'FROM')) {
-            throw new IllegalStateException('The first instruction of a Dockerfile has to be FROM')
+        def fromPos = getInstructions().findIndexOf { it.keyword == 'FROM' }
+        def othersPos = getInstructions().findIndexOf { it.keyword != 'ARG' && it.keyword != 'FROM' }
+        if(fromPos < 0 || (othersPos >= 0 && fromPos > othersPos)) {
+            throw new IllegalStateException('The first instruction of a Dockerfile has to be FROM (or ARG for Docker later than 17.05)')
         }
     }
 


### PR DESCRIPTION
https://github.com/bmuschko/gradle-docker-plugin/blob/master/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy#L50

is no longer valid since [docker 17.05+](https://github.com/moby/moby/releases/tag/v17.05.0-ce)
> Allow using build-time args (ARG) in FROM https://github.com/docker/docker/pull/31352

So: while 
```
task dockerFile(type: Dockerfile) {
    arg 'from=alpine'
    from '\$from'
}
```
is not valid until 17.05, later on it works.

I just hacked some ugly code ... mainly rebasing `Dockerfile` on `AbstractDockerRemoteApiTask`, implementing `runRemoteCommand()`, 🤞 cross the fingers that this `@TaskAction` runs before `Dockerfile.create()`, parsing the version in ugly 3 lines 

Feel free to blame ... but perhaps someone could get me on track how to get the version correctly or does have another idea how we should handle this issue.