### PR TITLE
Ensure all tests clean up after themselves #383

### DIFF
--- a/gradle/functional-test.gradle
+++ b/gradle/functional-test.gradle
@@ -30,6 +30,7 @@ check.dependsOn functionalTest
 
 dependencies {
     functionalTestCompile 'commons-lang:commons-lang:2.6'
+    functionalTestCompile 'com.github.docker-java:docker-java:3.0.12'
 }
 
 gradlePlugin {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -262,6 +262,7 @@ EXPOSE 8080
     def "Can create image for Java application and push to private registry"() {
         createJettyMainClass()
         writeBasicSetupToBuildFile()
+        startDockerRegistryContainer()
         buildFile << """
             applicationName = 'javaapp'
 
@@ -287,6 +288,7 @@ ENTRYPOINT ["/javaapp-1.0/bin/javaapp"]
 EXPOSE 8080
 """
         noExceptionThrown()
+        removeDockerRegistryContainer()
     }
 
     private void createJettyMainClass() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerReactiveMethodsFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerReactiveMethodsFunctionalTest.groovy
@@ -424,6 +424,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractFunctionalTest {
         File dockerFileLocation = new File(getProjectDir(), 'build/private-reg-reactive/Dockerfile')
         if (!dockerFileLocation.parentFile.exists() && !dockerFileLocation.parentFile.mkdirs())
             throw new GradleException("Could not successfully create dockerFileLocation @ ${dockerFileLocation.path}")
+        startDockerRegistryContainer()
 
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.image.Dockerfile
@@ -460,6 +461,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractFunctionalTest {
         expect:
         BuildResult result = build('workflow')
         result.output.contains("Pushed")
+        removeDockerRegistryContainer()
     }
 
     def "should call onComplete when task finished without errors"() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -569,7 +569,7 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
                 dependsOn buildImage, createNetwork
                 targetImageId { buildImage.getImageId() }
                 containerName = "${uniqueContainerName}"
-                networkMode = createNetwork.getNetworkId()
+                network = createNetwork.getNetworkId()
                 networkAliases = ["some-alias"]
                 cmd = ['/bin/sh']
             }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -101,7 +101,7 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
 
     @Input
     @Optional
-    String networkMode
+    String network
 
     @Input
     @Optional
@@ -269,8 +269,8 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
             containerCommand.withDns(getDns())
         }
 
-        if(getNetworkMode()) {
-            containerCommand.withNetworkMode(getNetworkMode())
+        if(getNetwork()) {
+            containerCommand.withNetworkMode(getNetwork())
         }
 
         if(getNetworkAliases()) {


### PR DESCRIPTION
Hi Guys, I did a little bit of work for the #383 issue. So basically now after you run the functional tests all the created docker images and docker containers are automatically removed. I also added two new methods to start/remove the docker registry container that was causing 3 tests to fail. Let me know what you think.