### PR TITLE
:dockerBuildImage is suspiciously building too often

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -15,11 +15,15 @@
  */
 package com.bmuschko.gradle.docker
 
+import org.gradle.api.GradleException
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.Rule
 import org.junit.rules.TemporaryFolder
 import spock.lang.Specification
+
+import java.nio.file.Files
+import java.nio.file.Paths
 
 abstract class AbstractFunctionalTest extends Specification {
     @Rule
@@ -51,6 +55,7 @@ abstract class AbstractFunctionalTest extends Specification {
         setupDockerServerUrl()
         setupDockerCertPath()
         setupDockerPrivateRegistryUrl()
+        setupDockerTemplateFile()
 
         buildFile << """
             task dockerVersion(type: com.bmuschko.gradle.docker.tasks.DockerVersion)
@@ -92,6 +97,20 @@ abstract class AbstractFunctionalTest extends Specification {
                     url = '$dockerPrivateRegistryUrl'
                 }
             """
+        }
+    }
+
+    private void setupDockerTemplateFile() {
+        File source = new File(TestConfiguration.class.getClassLoader().getResource("Dockerfile.template").toURI())
+        if (source.exists()) {
+            File resourcesDir = new File(projectDir, 'src/main/docker/')
+            if (resourcesDir.mkdirs()) {
+                if (Files.copy(source.toPath(),Paths.get(projectDir.path, 'src/main/docker/Dockerfile.template')).toFile().length() != source.length()) {
+                    throw new GradleException("File could not be successfully copied")
+                }
+            } else {
+                throw new IOException("can not create the directory ${resourcesDir.absolutePath}")
+            }
         }
     }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -1,6 +1,7 @@
 package com.bmuschko.gradle.docker
 
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
 import spock.lang.Requires
 
 class DockerJavaApplicationPluginFunctionalTest extends AbstractFunctionalTest {
@@ -26,6 +27,71 @@ ENTRYPOINT ["/${projectName}-1.0/bin/${projectName}"]
 EXPOSE 8080
 """
         result.output.contains('Author           : ')
+    }
+
+    def "Can build image for Java application with default configuration and changes on changed application package"() {
+        String projectName = temporaryFolder.root.name
+        createJettyMainClass()
+        writeBasicSetupToBuildFile()
+        writeCustomTasksToBuildFile()
+
+        when: // … building an image …
+        BuildResult result = build('dockerBuildImage')
+
+        then: // … the Dockerfile is generated as expected along with the image …
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerBuildImage"}.outcome
+        File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
+        File distTarFile = new File(projectDir, "build/distributions/${projectName}-1.0.tar")
+        distTarFile.exists()
+        def distTarFileLastLength = distTarFile.length()
+        dockerfile.exists()
+        dockerfile.text ==
+"""FROM java
+MAINTAINER ${System.getProperty('user.name')}
+ADD ${projectName}-1.0.tar /
+ENTRYPOINT ["/${projectName}-1.0/bin/${projectName}"]
+EXPOSE 8080
+"""
+
+        when: // … just rebuilding …
+        result = build('dockerBuildImage')
+
+        then: // … the image is built again, since that way works docker build too  …
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerBuildImage"}.outcome
+
+        when: // … any files are added to the distTar, i.e. input of the …
+        temporaryFolder.newFile('file1.txt')
+        buildFile << """
+        distTar {
+            from '${temporaryFolder}'
+            into '${temporaryFolder}'
+        }
+        """
+        result = build('dockerBuildImage')
+
+        then: // … the distTar is copied and anything is rebuild, except the Dockerfile …
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":distTar"}.outcome
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerCopyDistResources"}.outcome
+        TaskOutcome.UP_TO_DATE == result.tasks.find{it.path == ":dockerDistTar"}.outcome
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerBuildImage"}.outcome
+
+        when: // … only the name changes …
+        buildFile << "version = 1.1"
+        result = build('dockerBuildImage')
+
+        then: // … both, image and Dockerfile changes
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":distTar"}.outcome
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerCopyDistResources"}.outcome
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerDistTar"}.outcome
+        TaskOutcome.SUCCESS == result.tasks.find{it.path == ":dockerBuildImage"}.outcome
+        dockerfile.exists()
+        dockerfile.text ==
+"""FROM java
+MAINTAINER ${System.getProperty('user.name')}
+ADD ${projectName}-1.1.tar /
+ENTRYPOINT ["/${projectName}-1.1/bin/${projectName}"]
+EXPOSE 8080
+"""
     }
 
     def "Can create image for Java application with user-driven configuration"() {


### PR DESCRIPTION
By testing some cases regarding the UP-TO-DATE behaviour (#357 -> #433, #434), I stumbled over a case that is possibly a bug to be discussed.

To prove that, I began to write some test 8fab023 .. in the meanwhile there is a second commit with a suggested improvment patch for the `DockerJavaApplicationPlugin`

Details:
- [ ] it is expected, that a `DockerBuildImage` only runs twice if any input has changed. i.e. either the Dockerfile itself or any file affected.
  - (?) this has to be discussed, if this is either resolvable - since we allow to pass an existing Dockerfile - or it is "correct" because `docker build` not even respects that too. So it might be ok that DockerBuildImage rebuilds anytime?! The UP-TO-DATE assumption only comes from the traditional gradle build behaviour not doing things twice. 
- regarding the `DockerJavaApplicationPlugin`
  - [x] it is expected, that any incoming change from the `:distTar` (type `Tar` from gradle application plugin) affects `:dockerCopyDistResources` (type `Copy`) and therefor `:dockerDistTar` (type `Dockerfile`)
    - while the UP-TO-DATE logic of `:dockerDistTar` seems to be correct with the changes from #433 it now (again) respects if the filename of the distTar changes.
`:dockerCopyDistResources` works out of the box due to gradle `Copy` from instructions implies any changes to `:distTar` affects this task too.
  - it is expected, that no changes made to the Dockerfile (or input in general) doesn't trigger `:dockerBuildImage` -> see first point in general.

The possible improvement I see:
- [ ] The `DockerBuildImage` by DockerJavaApplicationPlugin `:dockerBuildImage` might get an [`onlyIf {}`](https://docs.gradle.org/current/dsl/org.gradle.api.Task.html?#org.gradle.api.Task:onlyIf(groovy.lang.Closure)) spec / directive to regard the status of the `DockerFile` task `:dockerDistTar`

=> see patch 570b3ef