### PR TITLE
Clarify docs

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -53,10 +53,34 @@ code snippet in your build script:
 ----
 apply plugin: 'com.bmuschko.docker-remote-api'
 ----
-If you're using this plugin from a build file which is not the *main* build file you must apply plugin like so:
+
+If you would like to use this plugin from a build file which is not the *main* build file you must apply/use it like this:
+
+.build.gradle
 [source,groovy]
 ----
+apply from: 'gradle/docker.gradle'
+----
+
+.gradle/docker.gradle
+[source,groovy]
+----
+buildscript {
+    repositories {
+        jcenter()
+    }
+    dependencies {
+        classpath 'com.bmuschko:gradle-docker-plugin:X.Y.Z'
+    }
+}
+
+// use fully qualified class name
 apply plugin: com.bmuschko.gradle.docker.DockerRemoteApiPlugin
+
+// import task classes
+import com.bmuschko.gradle.docker.tasks.image.*
+
+// use task classes
 ----
 
 The plugin automatically resolves the Docker Java library with the pre-configured version under the covers. The only


### PR DESCRIPTION
This addresses #456.
Not sure about the sentence directly below, where it mentions `mavenCentral()`, when in the example above it says `jcenter()`. Maybe just remove that sentence?