### PR TITLE
Add `DockerWaitHealthyContainer` task

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -163,6 +163,17 @@ The plugin provides the following custom task types for managing networks:
 |=======
 
 
+==== Extras
+
+The plugin provides the following additional tasks:
+
+[options="header"]
+|=======
+|Type                                                                                                                                                                             |Description
+|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/extras/DockerWaitHealthyContainer.html[DockerWaitHealthyContainer] |Blocks until the container for a given id becomes link:https://docs.docker.com/engine/reference/builder/#healthcheck[healthy].
+|=======
+
+
 === Extension properties
 
 The plugin defines the following extension properties in the `docker` closure:

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWaitHealthyContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWaitHealthyContainerFunctionalTest.groovy
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.docker
+
+import org.gradle.testkit.runner.BuildResult
+
+class DockerWaitHealthyContainerFunctionalTest extends AbstractFunctionalTest {
+
+    def "Wait for a container to be healthy"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.*
+            import com.bmuschko.gradle.docker.tasks.container.*
+            import com.bmuschko.gradle.docker.tasks.container.extras.*
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+                instruction { "HEALTHCHECK --interval=1s CMD test -e /tmp/HEALTHY || exit 1" }
+                defaultCommand '/bin/sh', '-c', 'sleep 5; touch /tmp/HEALTHY; sleep 60'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn buildImage
+                targetImageId { buildImage.getImageId() }
+            }
+
+            task startContainer(type: DockerStartContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+            }
+
+            task removeContainer(type: DockerRemoveContainer) {
+                targetContainerId { startContainer.getContainerId() }
+                force = true
+            }
+
+            task removeImage(type: DockerRemoveImage) {
+                dependsOn removeContainer
+                targetImageId { buildImage.getImageId() }
+                force = true
+            }
+
+            task waitContainer(type: DockerWaitHealthyContainer) {
+                dependsOn startContainer
+                targetContainerId { startContainer.getContainerId() }
+                timeout 10
+                finalizedBy removeImage
+            }
+        """
+
+        expect:
+        build('waitContainer')
+    }
+
+    def "Timeout when a container takes to long to be healthy"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.*
+            import com.bmuschko.gradle.docker.tasks.container.*
+            import com.bmuschko.gradle.docker.tasks.container.extras.*
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+                instruction { "HEALTHCHECK --interval=1s CMD test -e /tmp/HEALTHY || exit 1" }
+                defaultCommand '/bin/sh', '-c', 'sleep 10; touch /tmp/HEALTHY; sleep 60'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn buildImage
+                targetImageId { buildImage.getImageId() }
+            }
+
+            task startContainer(type: DockerStartContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+            }
+
+            task removeContainer(type: DockerRemoveContainer) {
+                targetContainerId { startContainer.getContainerId() }
+                force = true
+            }
+
+            task removeImage(type: DockerRemoveImage) {
+                dependsOn removeContainer
+                targetImageId { buildImage.getImageId() }
+                force = true
+            }
+
+            task waitContainer(type: DockerWaitHealthyContainer) {
+                dependsOn startContainer
+                targetContainerId { startContainer.getContainerId() }
+                timeout 5
+                finalizedBy removeImage
+            }
+        """
+
+        expect:
+        BuildResult result = buildAndFail('waitContainer')
+        result.output.contains("Health check timeout expired")
+    }
+
+    def "Fail if container stops before being healthy"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.*
+            import com.bmuschko.gradle.docker.tasks.container.*
+            import com.bmuschko.gradle.docker.tasks.container.extras.*
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+                instruction { "HEALTHCHECK --interval=1s CMD test -e /tmp/HEALTHY || exit 1" }
+                defaultCommand '/bin/sh', '-c', 'sleep 5'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn buildImage
+                targetImageId { buildImage.getImageId() }
+            }
+
+            task startContainer(type: DockerStartContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+            }
+
+            task removeContainer(type: DockerRemoveContainer) {
+                targetContainerId { startContainer.getContainerId() }
+                force = true
+            }
+
+            task removeImage(type: DockerRemoveImage) {
+                dependsOn removeContainer
+                targetImageId { buildImage.getImageId() }
+                force = true
+            }
+
+            task waitContainer(type: DockerWaitHealthyContainer) {
+                dependsOn startContainer
+                targetContainerId { startContainer.getContainerId() }
+                timeout 10
+                finalizedBy removeImage
+            }
+        """
+
+        expect:
+        BuildResult result = buildAndFail('waitContainer')
+        result.output ==~ /(?s).*Container with ID '.*' is not running.*/
+    }
+
+    def "Fail if waiting for a non-running container"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.*
+            import com.bmuschko.gradle.docker.tasks.container.*
+            import com.bmuschko.gradle.docker.tasks.container.extras.*
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+                instruction { "HEALTHCHECK --interval=1s CMD test -e /tmp/HEALTHY || exit 1" }
+                defaultCommand '/bin/sh', '-c', 'sleep 10'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn buildImage
+                targetImageId { buildImage.getImageId() }
+            }
+
+            task removeContainer(type: DockerRemoveContainer) {
+                targetContainerId { createContainer.getContainerId() }
+                force = true
+            }
+
+            task removeImage(type: DockerRemoveImage) {
+                dependsOn removeContainer
+                targetImageId { buildImage.getImageId() }
+                force = true
+            }
+
+            task waitContainer(type: DockerWaitHealthyContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+                timeout 10
+                finalizedBy removeImage
+            }
+        """
+
+        expect:
+        BuildResult result = buildAndFail('waitContainer')
+        result.output ==~ /(?s).*Container with ID '.*' is not running.*/
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerWaitHealthyContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerWaitHealthyContainer.groovy
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.bmuschko.gradle.docker.tasks.container.extras
+
+import com.bmuschko.gradle.docker.tasks.container.DockerExistingContainer
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Optional
+
+class DockerWaitHealthyContainer extends DockerExistingContainer {
+
+    @Input
+    @Optional
+    Integer timeout
+
+    @Override
+    void runRemoteCommand(dockerClient) {
+        logger.quiet "Waiting for container with ID '${getContainerId()}' to be healthy."
+
+        Long deadline = timeout ? System.currentTimeMillis() + timeout * 1000 : null
+        def timeout = { deadline ? System.currentTimeMillis() > deadline : false }
+        while(!timeout()) {
+            if (check(dockerClient)) return
+            sleep(100)
+        }
+        if (!check(dockerClient)) throw new GradleException("Health check timeout expired")
+    }
+
+    private boolean check(dockerClient) {
+        def command = dockerClient.inspectContainerCmd(getContainerId())
+        def response = command.exec()
+        def state = response.state
+        if (!state.running) {
+            throw new GradleException("Container with ID '${getContainerId()}' is not running")
+        }
+        return state.health.status == "healthy"
+    }
+}


### PR DESCRIPTION
## Work Summary

- Add `DockerWaitHealthyContainer` task
  - Create functional tests
    - Create test class
    - Create successful execution test
    - Create timeout test
    - Create quick stop test
    - Create not running test
    - Add cleanup logic (revertable)
  - Create task
    - Create task class
    - Define I/O
    - Create utility
    - Implement task logic
    - Move to `extras` subpackage (revertable)
- Correction 1
  - Update interface: expose polling behavior as API
    - Add reactive tests
      - Create periodic emission test
      - Create last successful emission test 
    - Expose polling cycle as input
    - Invoke `onNext` at each cycle passing the health state string
  - Update implementation
    - Check based on command instead of client
    - Document IO
    - Rewrite polling `while` loop
- Correction 2
  - Update README file

## Notes

- I'm destroying the images and containers created by the tests so that the machine running them doesn't get flooded. I'm not sure if there is a reason why this is not being done on the other tests (maybe to isolate the features being tested or make the code more readable), but this behavior can be removed by reverting commit deb37eb.
- The new task was created under the `com.bmuschko.gradle.docker.tasks.container.extras` package as suggested by @cdancy. It can be moved to the container package by undoing commit c97f9ac.
- I changed the way timeout works (comparing to the snippet from the issue) so that it looks similar to the `DockerWaitContainer` task. The following changes were made:
  -  The `timeout` input can now be `null` (no timeout), which now is the default value
  -  The `checkInterval` input was removed in order to make the API more simple.

## Open Tasks

- [x] **Update README** - Since the task belongs to a new package, I'm not sure about how to update the README file.