### PR TITLE
Add support to specify the name of the install and jar tasks to use

### DIFF
--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -122,6 +122,21 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         task.tag == testTagName
     }
 
+    def "Can configure the jar and install tasks"() {
+        given:
+        applyDockerJavaApplicationPluginAndApplicationPlugin(project)
+        when:
+        project.docker.javaApplication {
+            jarTaskName = 'bootJar'
+            installTaskName = 'installBootDist'
+        }
+        then:
+        project.tasks.findByName(DockerJavaApplicationPlugin.DOCKERFILE_TASK_NAME)
+        project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
+        project.tasks.findByName(DockerJavaApplicationPlugin.PUSH_IMAGE_TASK_NAME)
+    }
+
+
     private void applyDockerJavaApplicationPluginWithoutApplicationPlugin(Project project) {
         project.apply(plugin: DockerJavaApplicationPlugin)
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -17,6 +17,8 @@ package com.bmuschko.gradle.docker
 
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile.CompositeExecInstruction
+import org.gradle.api.distribution.plugins.DistributionPlugin
+import org.gradle.api.plugins.JavaPlugin
 
 class DockerJavaApplication {
     String baseImage = 'java'
@@ -26,6 +28,8 @@ class DockerJavaApplication {
     Integer port = 8080
     Set<Integer> ports = []
     String tag
+    String jarTaskName = JavaPlugin.JAR_TASK_NAME
+    String installTaskName = DistributionPlugin.TASK_INSTALL_NAME
 
     Integer[] getPorts() {
         return ports.size() > 0 ? ports : [port]

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -44,8 +44,8 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
         DockerJavaApplication dockerJavaApplication = configureExtension(dockerExtension)
 
         project.plugins.withType(ApplicationPlugin) {
-            Sync installTask = project.tasks.getByName(DistributionPlugin.TASK_INSTALL_NAME)
-            Jar jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
+            Sync installTask = project.tasks.getByName(dockerJavaApplication.installTaskName)
+            Jar jarTask = project.tasks.getByName(dockerJavaApplication.jarTaskName)
             dockerJavaApplication.exec {
                 entryPoint { determineEntryPoint(project, installTask) }
             }


### PR DESCRIPTION
The Spring Boot project uses the following goals instead of `distTar`/`distZip`:

```
bootDistTar - Bundles the project as a distribution.
bootDistZip - Bundles the project as a distribution.
installBootDist - Installs the project as a distribution as-is.
```

This is because of [Spring Boot's executable JAR](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment-install.html) format, similar to "fat JARs".

However, the `DockerJavaApplicationPlugin` class is hardcoded to use the "default" tasks:

```
            Sync installTask = project.tasks.getByName(DistributionPlugin.TASK_INSTALL_NAME)
            Jar jarTask = project.tasks.getByName(JavaPlugin.JAR_TASK_NAME)
```

This PR extends the `DockerJavaApplication` class to allow setting the `jar` and `install` tasks by name, defaulting to the original behavior.