### PR TITLE
Support for zero exposed ports in java application

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -24,11 +24,11 @@ class DockerJavaApplication {
     String maintainer = System.getProperty('user.name')
     @Deprecated
     Integer port = 8080
-    Set<Integer> ports = []
+    Set<Integer> ports
     String tag
 
     Integer[] getPorts() {
-        return ports.size() > 0 ? ports : [port]
+        return ports != null ? ports : [port]
     }
 
     CompositeExecInstruction exec(@DelegatesTo(CompositeExecInstruction) Closure<Void> closure) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -77,7 +77,11 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
             addFile({ installTask.destinationDir.name }, { "/${installTask.destinationDir.name}" })
             addFile({ "app-lib/${jarTask.archiveName}" }, { "/${installTask.destinationDir.name}/lib/${jarTask.archiveName}" })
             instructions << dockerJavaApplication.exec
-            exposePort { dockerJavaApplication.getPorts() }
+            doFirst {
+                if (dockerJavaApplication.getPorts().length > 0) {
+                    exposePort { dockerJavaApplication.getPorts() }
+                }
+            }
         } as Dockerfile
     }
 


### PR DESCRIPTION
PR #254 introduced support for multiple exposed ports in java application. However, as far as I can tell, it was still not possible to have no ports exposed at all. This PR should fix this. The default of one exposed port 8080 is unchanged, but it is now possible to set ports = [] and override this default.