### PR TITLE
Add JSON output option to DockerInfo.

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerInfoFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerInfoFunctionalTest.groovy
@@ -18,25 +18,7 @@ class DockerInfoFunctionalTest extends AbstractFunctionalTest {
         result.output.contains('Retrieving Docker info.')
     }
 
-    def "Calls onNext when provided"() {
-        buildFile << """
-            import com.bmuschko.gradle.docker.tasks.DockerInfo
-
-            task dockerInfo(type: DockerInfo) {
-                onNext { logger.quiet "In onNext as expected" }
-            }
-        """
-
-        when:
-        BuildResult result = build('dockerInfo')
-
-        then:
-        (result.output.contains('Retrieving Docker info.')
-        && result.output.contains('In onNext as expected')
-        && !result.output.contains('Containers'))
-    }
-
-    def "Passes dockerinfo to onNext"() {
+    def "Passes dockerinfo to onNext if provided, w/o logger output"() {
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.DockerInfo
 
@@ -54,7 +36,8 @@ class DockerInfoFunctionalTest extends AbstractFunctionalTest {
 
         then:
         (result.output.contains('Retrieving Docker info.')
-        && result.output.contains('Architecture found'))
+        && result.output.contains('Architecture found')
+        && !result.output.contains('Containers'))
     }
 
 }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerInfoFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerInfoFunctionalTest.groovy
@@ -17,4 +17,44 @@ class DockerInfoFunctionalTest extends AbstractFunctionalTest {
         then:
         result.output.contains('Retrieving Docker info.')
     }
+
+    def "Calls onNext when provided"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.DockerInfo
+
+            task dockerInfo(type: DockerInfo) {
+                onNext { logger.quiet "In onNext as expected" }
+            }
+        """
+
+        when:
+        BuildResult result = build('dockerInfo')
+
+        then:
+        (result.output.contains('Retrieving Docker info.')
+        && result.output.contains('In onNext as expected')
+        && !result.output.contains('Containers'))
+    }
+
+    def "Passes dockerinfo to onNext"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.DockerInfo
+
+            task dockerInfo(type: DockerInfo) {
+                onNext { m ->
+                    if (m.architecture) {  // Because I implemented and I care
+                        logger.quiet "Architecture found"
+                    }
+                }
+            }
+        """
+
+        when:
+        BuildResult result = build('dockerInfo')
+
+        then:
+        (result.output.contains('Retrieving Docker info.')
+        && result.output.contains('Architecture found'))
+    }
+
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerInfo.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerInfo.groovy
@@ -22,26 +22,26 @@ class DockerInfo extends AbstractDockerRemoteApiTask {
         logger.quiet "Retrieving Docker info."
         def info = dockerClient.infoCmd().exec()
 
-        logger.quiet "Debug                : $info.debug"
-        logger.quiet "Containers           : $info.containers"
-        logger.quiet "Driver               : $info.driver"
-        logger.quiet "Driver Statuses      : $info.driverStatuses"
-        logger.quiet "Images               : $info.images"
-        logger.quiet "IPv4 Forwarding      : $info.ipv4Forwarding"
-        logger.quiet "Index Server Address : $info.indexServerAddress"
-        logger.quiet "Init Path            : $info.initPath"
-        logger.quiet "Init SHA1            : $info.initSha1"
-        logger.quiet "Kernel Version       : $info.kernelVersion"
-        logger.quiet "Sockets              : $info.sockets"
-        logger.quiet "Memory Limit         : $info.memoryLimit"
-        logger.quiet "nEvent Listener      : $info.nEventsListener"
-        logger.quiet "NFd                  : $info.nfd"
-        logger.quiet "NGoroutines          : $info.nGoroutines"
-        logger.quiet "Swap Limit           : $info.swapLimit"
-        logger.quiet "Execution Driver     : $info.executionDriver"
-
         if (onNext) {
             onNext.call(info)
+        } else {
+            logger.quiet "Debug                : $info.debug"
+            logger.quiet "Containers           : $info.containers"
+            logger.quiet "Driver               : $info.driver"
+            logger.quiet "Driver Statuses      : $info.driverStatuses"
+            logger.quiet "Images               : $info.images"
+            logger.quiet "IPv4 Forwarding      : $info.ipv4Forwarding"
+            logger.quiet "Index Server Address : $info.indexServerAddress"
+            logger.quiet "Init Path            : $info.initPath"
+            logger.quiet "Init SHA1            : $info.initSha1"
+            logger.quiet "Kernel Version       : $info.kernelVersion"
+            logger.quiet "Sockets              : $info.sockets"
+            logger.quiet "Memory Limit         : $info.memoryLimit"
+            logger.quiet "nEvent Listener      : $info.nEventsListener"
+            logger.quiet "NFd                  : $info.nfd"
+            logger.quiet "NGoroutines          : $info.nGoroutines"
+            logger.quiet "Swap Limit           : $info.swapLimit"
+            logger.quiet "Execution Driver     : $info.executionDriver"
         }
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerInfo.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerInfo.groovy
@@ -15,18 +15,7 @@
  */
 package com.bmuschko.gradle.docker.tasks
 
-import org.gradle.api.tasks.*
-import groovy.json.JsonBuilder
-
 class DockerInfo extends AbstractDockerRemoteApiTask {
-
-    /**
-     *  If a dump of the JSON docker info structure is desired, set this to
-     *  the file to which the dump should be written.
-     */
-    @Optional
-    @OutputFile
-    def dockerInfoFile = null
 
     @Override
     void runRemoteCommand(dockerClient) {
@@ -51,11 +40,8 @@ class DockerInfo extends AbstractDockerRemoteApiTask {
         logger.quiet "Swap Limit           : $info.swapLimit"
         logger.quiet "Execution Driver     : $info.executionDriver"
 
-        if (dockerInfoFile) {
-            logger.quiet "Writing results to ${dockerInfoFile.path}"
-            dockerInfoFile.write(new JsonBuilder(info).toPrettyString())
-        } else {
-            logger.debug "No write file specified for DockerInfo"
+        if (onNext) {
+            onNext.call(info)
         }
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerInfo.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerInfo.groovy
@@ -15,11 +15,24 @@
  */
 package com.bmuschko.gradle.docker.tasks
 
+import org.gradle.api.tasks.*
+import groovy.json.JsonBuilder
+
 class DockerInfo extends AbstractDockerRemoteApiTask {
+
+    /**
+     *  If a dump of the JSON docker info structure is desired, set this to
+     *  the file to which the dump should be written.
+     */
+    @Optional
+    @OutputFile
+    def dockerInfoFile = null
+
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Retrieving Docker info."
         def info = dockerClient.infoCmd().exec()
+
         logger.quiet "Debug                : $info.debug"
         logger.quiet "Containers           : $info.containers"
         logger.quiet "Driver               : $info.driver"
@@ -37,5 +50,12 @@ class DockerInfo extends AbstractDockerRemoteApiTask {
         logger.quiet "NGoroutines          : $info.nGoroutines"
         logger.quiet "Swap Limit           : $info.swapLimit"
         logger.quiet "Execution Driver     : $info.executionDriver"
+
+        if (dockerInfoFile) {
+            logger.quiet "Writing results to ${dockerInfoFile.path}"
+            dockerInfoFile.write(new JsonBuilder(info).toPrettyString())
+        } else {
+            logger.debug "No write file specified for DockerInfo"
+        }
     }
 }


### PR DESCRIPTION
As part of a multi-architecture build, I need to be able access variables from the DockerInfo of the Docker with which I am interacting.  This adds a parameter (dockerInfoFile) to the DockerInfo task which, if set, will trigger a write of JSON representing the DockerInfo received from the Docker instance.