### PR TITLE
Add skipMaintainer to DockerJavaApplication

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -463,7 +463,7 @@ The plugin defines the following extension properties in the `javaApplication` c
 |Property name   |Type      |Default value                                          |Description
 |`baseImage`     |String    |openjdk                                                |The Docker base image used for Java application.
 |`exec`          |Closure   |Create ENTRYPOINT using script from Application plugin |The ENTRYPOINT and/or CMD Dockerfile instructions
-|`maintainer`    |String    |Value of `user.home` system property                   |The name and email address of the image maintainer.
+|`maintainer`    |String    |Value of `user.home` system property                   |The name and email address of the image maintainer (Deprecated).
 |`port`          |Integer   |8080                                                   |The Docker image entry point port used for the Java application (Deprecated)
 |`ports`         |Integer[] |[]                                                     |The Docker image exposed ports (if provided, this values will override `port` configuration property)
 |`tag`           |String    |<project.group>/<applicationName>:<project.version>    |The tag used for the Docker image.

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -20,7 +20,21 @@ import com.bmuschko.gradle.docker.tasks.image.Dockerfile.CompositeExecInstructio
 class DockerJavaApplication {
     String baseImage = 'openjdk'
     final CompositeExecInstruction exec = new CompositeExecInstruction()
+
+    /**
+     * Deprecated as per https://docs.docker.com/engine/deprecated/#maintainer-in-dockerfile
+     * Will be removed in 4.x release.
+     */
+    @Deprecated
     String maintainer = System.getProperty('user.name')
+
+    /**
+     * Temporary solution to be able to create image without
+     * <code>MAINTAINER</code> and preserve backward compatibility.
+     * Will be removed in 4.x release.
+     */
+    boolean skipMaintainer
+
     @Deprecated
     Integer port = 8080
     Set<Integer> ports

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -81,6 +81,9 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
                 if (dockerJavaApplication.getPorts().length > 0) {
                     exposePort { dockerJavaApplication.getPorts() }
                 }
+                if(dockerJavaApplication.skipMaintainer) {
+                    instructions.removeAll { it instanceof Dockerfile.MaintainerInstruction }
+                }
             }
         } as Dockerfile
     }


### PR DESCRIPTION
This change will fix #445.

The new property `skipMaintainer` allows to create `Dockerfile` without `MAINTAINER` instruction in it. This preserves backward compatibility. In 4.x release it should be removed and default behavior must be changed to use `LABEL`.