### PR TITLE
Use docker-java-shaded in place of docker-java

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,8 @@ apply from: "$rootDir/gradle/publishing.gradle"
 apply from: "$rootDir/gradle/documentation.gradle"
 
 repositories {
-    mavenCentral()
+    mavenLocal()
+    jcenter()
 }
 
 dependencies {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -57,7 +57,8 @@ abstract class AbstractFunctionalTest extends Specification {
             }
 
             repositories {
-                mavenCentral()
+                mavenLocal()
+                jcenter()
             }
         """
 

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoaderIntegrationTest.groovy
@@ -30,7 +30,8 @@ class DockerThreadContextClassLoaderIntegrationTest extends AbstractIntegrationT
         project = ProjectBuilder.builder().build()
 
         project.repositories {
-            mavenCentral()
+            mavenLocal()
+            jcenter()
         }
 
         dockerExtension = new DockerExtension(project)

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.file.FileCollection
  */
 class DockerRemoteApiPlugin implements Plugin<Project> {
     public static final String DOCKER_JAVA_CONFIGURATION_NAME = 'dockerJava'
-    public static final String DOCKER_JAVA_DEFAULT_VERSION = '0.0.1'
+    public static final String DOCKER_JAVA_DEFAULT_VERSION = '3.0.14'
     public static final String EXTENSION_NAME = 'docker'
     public static final String DEFAULT_TASK_GROUP = 'Docker'
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.file.FileCollection
  */
 class DockerRemoteApiPlugin implements Plugin<Project> {
     public static final String DOCKER_JAVA_CONFIGURATION_NAME = 'dockerJava'
-    public static final String DOCKER_JAVA_DEFAULT_VERSION = '3.0.14'
+    public static final String DOCKER_JAVA_DEFAULT_VERSION = '0.0.1-SNAPSHOT'
     public static final String EXTENSION_NAME = 'docker'
     public static final String DEFAULT_TASK_GROUP = 'Docker'
 
@@ -50,7 +50,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
 
         Configuration config = project.configurations[DOCKER_JAVA_CONFIGURATION_NAME]
         config.defaultDependencies { dependencies ->
-            dependencies.add(project.dependencies.create("com.github.docker-java:docker-java:$DockerRemoteApiPlugin.DOCKER_JAVA_DEFAULT_VERSION"))
+            dependencies.add(project.dependencies.create("com.aries:docker-java-shaded:$DockerRemoteApiPlugin.DOCKER_JAVA_DEFAULT_VERSION"))
             dependencies.add(project.dependencies.create('org.slf4j:slf4j-simple:1.7.5'))
             dependencies.add(project.dependencies.create('cglib:cglib:3.2.0'))
         }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.file.FileCollection
  */
 class DockerRemoteApiPlugin implements Plugin<Project> {
     public static final String DOCKER_JAVA_CONFIGURATION_NAME = 'dockerJava'
-    public static final String DOCKER_JAVA_DEFAULT_VERSION = '0.0.1-SNAPSHOT'
+    public static final String DOCKER_JAVA_DEFAULT_VERSION = '0.0.1'
     public static final String EXTENSION_NAME = 'docker'
     public static final String DEFAULT_TASK_GROUP = 'Docker'
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -27,8 +27,11 @@ import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
 class DockerThreadContextClassLoader implements ThreadContextClassLoader {
-    public static final String MODEL_PACKAGE = 'com.github.dockerjava.api.model'
-    public static final String COMMAND_PACKAGE = 'com.github.dockerjava.core.command'
+    public static final String CORE_PACKAGE = "com.github.dockerjava.core"
+    public static final String MODEL_PACKAGE = "com.github.dockerjava.api.model"
+    public static final String COMMAND_PACKAGE = "com.github.dockerjava.core.command"
+    public static final String ENHANCER_CLASS = "net.sf.cglib.proxy.Enhancer"
+    public static final String INVOCATION_CLASS = "net.sf.cglib.proxy.InvocationHandler"
     private static final TRAILING_WHIESPACE = /\s+$/
 
     private DockerExtension dockerExtension
@@ -100,8 +103,8 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     private getDockerClient(String dockerUrl, File dockerCertPath, String apiVersion) {
 
         // Create configuration
-        Class dockerClientConfigClass = loadClass('com.github.dockerjava.core.DockerClientConfig')
-        Class dockerClientConfigClassImpl = loadClass('com.github.dockerjava.core.DefaultDockerClientConfig')
+        Class dockerClientConfigClass = loadClass("${CORE_PACKAGE}.DockerClientConfig")
+        Class dockerClientConfigClassImpl = loadClass("${CORE_PACKAGE}.DefaultDockerClientConfig")
         Method dockerClientConfigMethod = dockerClientConfigClassImpl.getMethod('createDefaultConfigBuilder')
         def dockerClientConfigBuilder = dockerClientConfigMethod.invoke(null)
         dockerClientConfigBuilder.withDockerHost(dockerUrl)
@@ -120,7 +123,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         def dockerClientConfig = dockerClientConfigBuilder.build()
 
         // Create client
-        Class dockerClientBuilderClass = loadClass('com.github.dockerjava.core.DockerClientBuilder')
+        Class dockerClientBuilderClass = loadClass("${CORE_PACKAGE}.DockerClientBuilder")
         Method method = dockerClientBuilderClass.getMethod('getInstance', dockerClientConfigClass)
         def dockerClientBuilder = method.invoke(null, dockerClientConfig)
         dockerClientBuilder.build()
@@ -420,7 +423,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         Class callbackClass = loadClass("${COMMAND_PACKAGE}.LogContainerResultCallback")
         def delegate = callbackClass.getConstructor().newInstance()
 
-        Class enhancerClass = loadClass('net.sf.cglib.proxy.Enhancer')
+        Class enhancerClass = loadClass(ENHANCER_CLASS)
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(callbackClass)
         enhancer.setCallback([
@@ -445,7 +448,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                 }
             }
 
-        ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
+        ].asType(loadClass(INVOCATION_CLASS)))
 
         enhancer.create()
     }
@@ -462,7 +465,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
         Class callbackClass = loadClass("${COMMAND_PACKAGE}.LogContainerResultCallback")
         def delegate = callbackClass.getConstructor().newInstance()
 
-        Class enhancerClass = loadClass('net.sf.cglib.proxy.Enhancer')
+        Class enhancerClass = loadClass(ENHANCER_CLASS)
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(callbackClass)
         enhancer.setCallback([
@@ -486,7 +489,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                 }
             }
 
-        ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
+        ].asType(loadClass(INVOCATION_CLASS)))
 
         enhancer.create()
     }
@@ -496,7 +499,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
      */
     @Override
     def createExecCallback(OutputStream out, OutputStream err) {
-        Class callbackClass = loadClass('com.github.dockerjava.core.command.ExecStartResultCallback')
+        Class callbackClass = loadClass("${COMMAND_PACKAGE}.ExecStartResultCallback")
         Constructor constructor = callbackClass.getConstructor(OutputStream, OutputStream)
         constructor.newInstance(out, err)
     }
@@ -504,7 +507,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     @Override
     def createExecCallback(Closure onNext) {
         def defaultHandler = createExecCallback(null, null)
-        Class enhancerClass = loadClass('net.sf.cglib.proxy.Enhancer')
+        Class enhancerClass = loadClass(ENHANCER_CLASS)
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(defaultHandler.getClass())
         enhancer.setCallback([
@@ -519,7 +522,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                 }
             }
 
-        ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
+        ].asType(loadClass(INVOCATION_CLASS)))
 
         enhancer.create()
     }
@@ -538,7 +541,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     }
 
     private createOnNextProxyCallback(Closure onNext, defaultHandler) {
-        Class enhancerClass = loadClass('net.sf.cglib.proxy.Enhancer')
+        Class enhancerClass = loadClass(ENHANCER_CLASS)
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(defaultHandler.getClass())
         enhancer.setCallback([
@@ -553,13 +556,13 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                 }
             }
 
-        ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
+        ].asType(loadClass(INVOCATION_CLASS)))
 
         enhancer.create()
     }
 
     private createPrintStreamProxyCallback(Logger logger, delegate) {
-        Class enhancerClass = loadClass('net.sf.cglib.proxy.Enhancer')
+        Class enhancerClass = loadClass(ENHANCER_CLASS)
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(delegate.getClass())
         enhancer.setCallback([
@@ -577,7 +580,7 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
                 }
             }
 
-        ].asType(loadClass('net.sf.cglib.proxy.InvocationHandler')))
+        ].asType(loadClass(INVOCATION_CLASS)))
 
         enhancer.create()
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/DockerThreadContextClassLoader.groovy
@@ -27,12 +27,11 @@ import java.lang.reflect.InvocationTargetException
 import java.lang.reflect.Method
 
 class DockerThreadContextClassLoader implements ThreadContextClassLoader {
-    public static final String CORE_PACKAGE = "com.github.dockerjava.core"
-    public static final String MODEL_PACKAGE = "com.github.dockerjava.api.model"
-    public static final String COMMAND_PACKAGE = "com.github.dockerjava.core.command"
-    public static final String ENHANCER_CLASS = "net.sf.cglib.proxy.Enhancer"
-    public static final String INVOCATION_CLASS = "net.sf.cglib.proxy.InvocationHandler"
-    private static final TRAILING_WHIESPACE = /\s+$/
+    public static final String CORE_PACKAGE = 'com.github.dockerjava.core'
+    public static final String MODEL_PACKAGE = 'com.github.dockerjava.api.model'
+    public static final String COMMAND_PACKAGE = 'com.github.dockerjava.core.command'
+    public static final String ENHANCER_CLASS = 'net.sf.cglib.proxy.Enhancer'
+    public static final String INVOCATION_CLASS = 'net.sf.cglib.proxy.InvocationHandler'
 
     private static final String TRAILING_WHIESPACE = /\s+$/
     private static final String COLON_CHAR = ':'
@@ -544,7 +543,6 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     }
 
     private createOnNextProxyCallback(Closure onNext, defaultHandler) {
-
         Class enhancerClass = loadClass(ENHANCER_CLASS)
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(defaultHandler.getClass())
@@ -565,7 +563,6 @@ class DockerThreadContextClassLoader implements ThreadContextClassLoader {
     }
 
     private createPrintStreamProxyCallback(Logger logger, delegate) {
-
         Class enhancerClass = loadClass(ENHANCER_CLASS)
         def enhancer = enhancerClass.getConstructor().newInstance()
         enhancer.setSuperclass(delegate.getClass())


### PR DESCRIPTION
As our users keep getting bit by transitive deps with docker-java this is an attempt at creating an uber/fat/shadow jar to use in its place. As `docker-java` doesn't provide an artifact like this I went ahead and created one for us or really for anyone that may need it.

Still a work in progress just wanted to get the general PR out there to work on. Changed a couple repo definitions as I was working on things locally and wanted to access mavenLocal. Also changed things to point at jcenter, instead of mavencentral, as the former is a proxy to the latter plus more packages.