### PR TITLE
Document using container names for management

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -447,6 +447,50 @@ task functionalTestMyApp(type: Test, dependsOn: startMyAppContainer) {
 }
 ----
 
+== Interacting with a container running in the background
+
+This plugin can be used to launch and manage a background container to facilitate
+locally running a Dockerized application. This can be done by creating the container
+with an explicit `containerName` which is then used as the `targetContainerId` for
+relevant tasks.
+
+[source,groovy]
+----
+apply plugin: 'com.bmuschko.docker-remote-api'
+
+import com.bmuschko.gradle.docker.tasks.container.*
+
+ext {
+  CONTAINER_NAME = 'myapp'
+} 
+
+task buildMyAppImage(type: DockerBuildImage) {
+    inputDir = file('docker/myapp')
+    tag = 'test/myapp:latest'
+}
+
+task dockerCreateContainer(type: DockerCreateContainer) {
+    dependsOn buildMyAppImage
+    targetImageId { buildMyAppImage.imageId }
+    containerName = CONTAINER_NAME
+}
+
+task dockerStartContainer(type: DockerStartContainer) {
+    dependsOn dockerCreateContainer
+    targetContainerId { dockerCreateContainer.getContainerName() }
+}
+
+task dockerStopContainer(type: DockerStopContainer) {
+    targetContainerId { dockerCreateContainer.getContainerName() }
+}
+
+task dockerRemoveContainer(type: DockerRemoveContainer) {
+    targetContainerId { dockerCreateContainer.getContainerName() }
+}
+// Remove the container to allow reuse of the name.
+dockerStopContainer.finalizedBy dockerRemoveContainer
+----
+
 == Java application plugin
 
 The plugin `com.bmuschko.docker-java-application` is a highly opinonated plugin for projects applying the link:http://www.gradle.org/docs/current/userguide/application_plugin.html[application plugin].

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExistingContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExistingContainer.groovy
@@ -24,7 +24,10 @@ import java.util.concurrent.Callable
 
 abstract class DockerExistingContainer extends AbstractDockerRemoteApiTask {
     /**
-     * Container ID used to perform operation. The container for the provided ID has to be created first.
+     * Container identifier upon which the operation will be performed.
+     *
+     * The ID or the name of a container are supported as identifiers.
+     * The container for the provided identifier has to be created first.
      */
     @Internal
     String containerId


### PR DESCRIPTION
The current GroovyDoc for `DockerExistingContainer` does not mention the Docker provided support for using a container name instead of ID and an example allowing for managing  of a Docker container across Gradle invocations has been added.

Provides solution for case outlined in #562 