### PR TITLE
ISSUE-565: Add option to compress, using gzip, saved docker images.

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
@@ -83,7 +83,7 @@ class DockerSaveImageFunctionalTest extends AbstractFunctionalTest {
 
         then:
         noExceptionThrown()
-        assert file(controlSavedImage).size() > file(compressedImageFile).size()
+        file(controlSavedImage).size() > file(compressedImageFile).size()
     }
 
     File file(String relativePath) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
@@ -49,4 +49,24 @@ class DockerSaveImageFunctionalTest extends AbstractFunctionalTest {
         then:
         noExceptionThrown()
     }
+
+    def "Can docker image be saved with compression"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerSaveImage
+
+            task saveImage(type: DockerSaveImage) {
+                dependsOn dockerfile
+                useCompression = true
+                tag = "${ImageId}"
+                repository = "${ImageId}"
+                destFile = file("build/docker/${ImageId}-docker-image.tar.gz")
+            }
+        """
+
+        when:
+        build('saveImage')
+
+        then:
+        noExceptionThrown()
+    }
 }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
@@ -1,0 +1,52 @@
+package com.bmuschko.gradle.docker.tasks.image
+
+import com.bmuschko.gradle.docker.AbstractFunctionalTest
+import org.gradle.testkit.runner.BuildResult
+
+class DockerSaveImageFunctionalTest extends AbstractFunctionalTest {
+
+    final String ImageId = createUniqueImageId()
+
+    def setup() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+                tag = "${ImageId}"
+                labels = ["setup":"${ImageId}"]
+            }
+        """
+
+        when:
+        BuildResult result = build('buildImage')
+
+        then:
+        result.output.contains("Created image with ID")
+    }
+
+    def "Can docker image be saved without compression"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerSaveImage
+
+            task saveImage(type: DockerSaveImage) {
+                dependsOn dockerfile
+                tag = "${ImageId}"
+                repository = "${ImageId}"
+                destFile = file("build/docker/${ImageId}-docker-image.tar")
+            }
+        """
+
+        when:
+        build('saveImage')
+
+        then:
+        noExceptionThrown()
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
@@ -6,7 +6,6 @@ import org.gradle.api.GradleException
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 import org.gradle.api.tasks.OutputFile
-import org.gradle.internal.impldep.org.apache.commons.compress.compressors.gzip.GzipCompressorOutputStream
 
 import java.util.zip.GZIPOutputStream
 
@@ -27,7 +26,7 @@ class DockerSaveImage extends AbstractDockerRemoteApiTask {
 
     @Input
     @Optional
-    boolean compressImage
+    boolean useCompression
 
     /**
      * Where to save image. Can't be null.
@@ -57,7 +56,7 @@ class DockerSaveImage extends AbstractDockerRemoteApiTask {
         try {
             FileOutputStream fs = new FileOutputStream(destFile)
             os = fs;
-            if( compressImage ) {
+            if( useCompression ) {
                 os = new GZIPOutputStream(fs)
             }
             try {

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/IOUtils.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/IOUtils.groovy
@@ -23,4 +23,14 @@ final class IOUtils {
             // ignore
         }
     }
+
+    static void closeQuietly(OutputStream output) {
+        try {
+            if (output != null) {
+                output.close()
+            }
+        } catch (IOException ignored) {
+            // ignore
+        }
+    }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/IOUtils.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/IOUtils.groovy
@@ -14,20 +14,10 @@ final class IOUtils {
         }
     }
 
-    static void closeQuietly(InputStream input) {
+    static void closeQuietly(Closeable toClose) {
         try {
-            if (input != null) {
-                input.close()
-            }
-        } catch (IOException ignored) {
-            // ignore
-        }
-    }
-
-    static void closeQuietly(OutputStream output) {
-        try {
-            if (output != null) {
-                output.close()
+            if (toClose != null) {
+                toClose.close()
             }
         } catch (IOException ignored) {
             // ignore


### PR DESCRIPTION
This represents the changes required to compress the tar based image returned from docker-java via gzip (#565).

I did not see any existing tests for the DockerSaveImage task.  I would be happy to add one if someone could point out a good example to base a test off of.