### PR TITLE
Add support for specifying a user/group within DockerExecContainer

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
@@ -110,7 +110,7 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
             ex.message.contains('is not running')
     }
 
-    def "Execute command as a non-root user running container"() {
+    def "Execute command as a non-root user within a running container"() {
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
             import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
@@ -139,7 +139,7 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
                 dependsOn startContainer
                 targetContainerId { startContainer.getContainerId() }
                 cmd = ['sh', '-c', 'id -u && id -g']
-                user = "10000:10001"
+                user = '10000:10001'
             }
 
             task logContainer(type: DockerLogsContainer) {
@@ -163,6 +163,6 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
 
         expect:
         BuildResult result = build('workflow')
-        result.output.contains("10000\n10001")
+        result.output.contains('10000\n10001')
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
@@ -32,6 +32,12 @@ class DockerExecContainer extends DockerExistingContainer {
     @Optional
     Boolean attachStderr = true
 
+    /**
+     * Username or UID to execute the command as, with optional colon separated group or gid in format:
+     * &lt;name|uid&gt;[:&lt;group|gid&gt;]
+     *
+     * @since 3.2.8
+     */
     @Input
     @Optional
     String user


### PR DESCRIPTION
 * Allow a task to specify what user/group combination to execute
   the command as within the Docker container.
 * Added a simple integration test that validates expected user/group
   through the use of id commands to display the current user/group.

closes #573
