### PR TITLE
declare entrypoint in shell form

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -19,6 +19,7 @@ import org.gradle.api.DefaultTask
 import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
+import org.gradle.internal.impldep.org.apache.commons.collections.Closure
 
 class Dockerfile extends DefaultTask {
     @Internal
@@ -293,7 +294,27 @@ class Dockerfile extends DefaultTask {
     }
 
     /**
-     * An <a href="https://docs.docker.com/reference/builder/#copy">ENTRYPOINT</a> allows you to configure a container
+     * An <a href="https://docs.docker.com/reference/builder/#entrypoint">ENTRYPOINT</a> allows you to configure a container
+     * that will run as an executable.
+     *
+     * @param entryPoint Entry point
+     */
+    void entryPointShellForm(String entryPoint) {
+        instructions << new EntryPointShellFormInstruction(entryPoint)
+    }
+
+    /**
+     * An <a href="https://docs.docker.com/reference/builder/#entrypoint">ENTRYPOINT</a> allows you to configure a container
+     * that will run as an executable.
+     *
+     * @param entryPoint Entry point
+     */
+    void entryPointShellForm(Closure entryPoint) {
+        instructions << new EntryPointShellFormInstruction(entryPoint)
+    }
+
+    /**
+     * An <a href="https://docs.docker.com/reference/builder/#entrypoint">ENTRYPOINT</a> allows you to configure a container
      * that will run as an executable.
      *
      * @param entryPoint Entry point
@@ -770,6 +791,22 @@ class Dockerfile extends DefaultTask {
         }
     }
 
+    static class EntryPointShellFormInstruction extends StringCommandInstruction {
+
+        EntryPointShellFormInstruction(String entrypoint) {
+            super(entrypoint)
+        }
+
+        EntryPointShellFormInstruction(Closure entrypoint) {
+            super(entrypoint)
+        }
+
+        @Override
+        String getKeyword() {
+            "ENTRYPOINT"
+        }
+    }
+
     static class EntryPointInstruction extends StringArrayInstruction {
         EntryPointInstruction(String... entryPoint) {
             super(entryPoint)
@@ -874,7 +911,7 @@ class Dockerfile extends DefaultTask {
         @Override
         String build() { instructions*.build().join('\n') }
 
-        CompositeExecInstruction apply(Closure<Void> closure) {
+        CompositeExecInstruction apply(Closure closure) {
             closure?.delegate = this
             closure?.call()
             this

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -75,6 +75,8 @@ with linebreaks in between\""
         new AddFileInstruction({ 'config.xml' }, { '/test' })                           | 'ADD'           | 'ADD config.xml /test'
         new CopyFileInstruction('config.xml', '/test')                                  | 'COPY'          | 'COPY config.xml /test'
         new CopyFileInstruction({ 'config.xml' }, { '/test' })                          | 'COPY'          | 'COPY config.xml /test'
+        new EntryPointShellFormInstruction('java -jar /opt/jenkins.war')                   | 'ENTRYPOINT'    | 'ENTRYPOINT java -jar /opt/jenkins.war'
+        new EntryPointShellFormInstruction({ 'java -jar /opt/jenkins.war' })             | 'ENTRYPOINT'    | 'ENTRYPOINT java -jar /opt/jenkins.war'
         new EntryPointInstruction('java', '-jar', '/opt/jenkins.war')                   | 'ENTRYPOINT'    | 'ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]'
         new EntryPointInstruction({ ['java', '-jar', '/opt/jenkins.war'] })             | 'ENTRYPOINT'    | 'ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]'
         new VolumeInstruction('/jenkins')                                               | 'VOLUME'        | 'VOLUME ["/jenkins"]'


### PR DESCRIPTION
Added `entryPointShellForm` to be able to specify and entrypoint of an image in shell form rather than using a generic `instruction`