### PR TITLE
Bug fix to account for docker-java changing name of cpuset to cpusetcpus

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerCreateContainerFunctionalTest.groovy
@@ -36,7 +36,7 @@ class DockerCreateContainerFunctionalTest extends AbstractFunctionalTest {
                 targetImageId { pullImage.getImageId() }
                 cmd = ['ifconfig']
                 macAddress = '02:03:04:05:06:07'
-                cpuset = '2'
+                cpuset = '1'
             }
 
             task startContainer(type: DockerStartContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerCreateContainerFunctionalTest.groovy
@@ -36,6 +36,7 @@ class DockerCreateContainerFunctionalTest extends AbstractFunctionalTest {
                 targetImageId { pullImage.getImageId() }
                 cmd = ['ifconfig']
                 macAddress = '02:03:04:05:06:07'
+                cpuset = '2'
             }
 
             task startContainer(type: DockerStartContainer) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -262,7 +262,7 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
         }
 
         if(getCpuset()) {
-            containerCommand.withCpuset(getCpuset())
+            containerCommand.withCpusetCpus(getCpuset())
         }
 
         if(getAttachStdin()) {


### PR DESCRIPTION
Minor fix for param rename as well as add option to existing test to ensure this is at least tested in the future.