### PR TITLE
Added new task DockerLivenessProbeContainer.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -176,7 +176,7 @@ The plugin provides the following additional tasks:
 |=======
 |Type                                                                                                                                                                             |Description
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/extras/DockerWaitHealthyContainer.html[DockerWaitHealthyContainer] |Blocks until the container for a given id becomes link:https://docs.docker.com/engine/reference/builder/#healthcheck[healthy].
-|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.html[DockerLivenessProbeContainer] |Polls an arbitrary containers logs for a log message indicating liveness.
+|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.html[DockerLivenessProbeContainer] |Polls an arbitrary containers logs for a message indicating liveness.
 |=======
 
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -176,6 +176,7 @@ The plugin provides the following additional tasks:
 |=======
 |Type                                                                                                                                                                             |Description
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/extras/DockerWaitHealthyContainer.html[DockerWaitHealthyContainer] |Blocks until the container for a given id becomes link:https://docs.docker.com/engine/reference/builder/#healthcheck[healthy].
+|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.html[DockerLivenessProbeContainer] |Polls an arbitrary containers logs for a log message indicating liveness.
 |=======
 
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLivenessProbeFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLivenessProbeFunctionalTest.groovy
@@ -1,0 +1,57 @@
+package com.bmuschko.gradle.docker
+
+import org.gradle.testkit.runner.BuildResult
+
+class DockerLivenessProbeFunctionalTest extends AbstractFunctionalTest {
+
+    def "Can start a container and probe it for liveness"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
+            import com.bmuschko.gradle.docker.tasks.container.extras.DockerLivenessProbeContainer
+
+            task pullImage(type: DockerPullImage) {
+                repository = 'postgres'
+                tag = 'latest'
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn pullImage
+                targetImageId { pullImage.getImageId() }
+            }
+
+            task startContainer(type: DockerStartContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+            }
+            
+            task livenessProbe(type: DockerLivenessProbeContainer) {
+                dependsOn 'startContainer'
+                targetContainerId { startContainer.getContainerId() }
+                probe(300000, 30000, 'database system is ready to accept connections')
+                onComplete {
+                    println 'Container is now live...'
+                }
+            }
+            
+            task removeContainer(type: DockerRemoveContainer) {
+                removeVolumes = true
+                force = true
+                targetContainerId { startContainer.getContainerId() }
+            }
+
+            task workflow {
+                dependsOn livenessProbe
+                finalizedBy removeContainer
+            }
+        """
+
+        expect:
+        BuildResult result = build('workflow')
+        result.output.contains('Starting liveness probe on container')
+        result.output.contains('Container is now live')
+    }
+}

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLivenessProbeFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerLivenessProbeFunctionalTest.groovy
@@ -15,7 +15,7 @@ class DockerLivenessProbeFunctionalTest extends AbstractFunctionalTest {
 
             task pullImage(type: DockerPullImage) {
                 repository = 'postgres'
-                tag = 'latest'
+                tag = 'alpine'
             }
 
             task createContainer(type: DockerCreateContainer) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/domain/Probe.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/domain/Probe.groovy
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bmuschko.gradle.docker.domain
+
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+
+/**
+ *  Class holding metadata for an arbitrary probe.
+ */
+class Probe {
+
+    @Input
+    long pollTime // how long we poll until match is found
+
+    @Input
+    long pollInterval // how long we wait until next poll
+
+    @Input
+    String logContains // halt polling on logs containing this String
+
+    Probe(long pollTime, long pollInterval, String logContains) {
+        if (pollInterval > pollTime) {
+            throw new GradleException("pollInterval must be greater than pollTime: pollInterval=${pollInterval}, pollTime=${pollTime}")
+        }
+
+        String localLogContains = Objects.requireNonNull(logContains).trim()
+        if (localLogContains) {
+            this.pollTime = pollTime
+            this.pollInterval = pollInterval
+            this.logContains = localLogContains
+        } else {
+            throw new GradleException("logContains must be a valid non-empty String")
+        }
+    }
+
+    @Override
+    String toString() {
+        "pollTime=${pollTime}, pollInterval=${pollInterval}, logContains='${logContains}'"
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
@@ -94,6 +94,13 @@ class DockerLogsContainer extends DockerExistingContainer {
     @Override
     void runRemoteCommand(dockerClient) {
         logger.quiet "Logs for container with ID '${getContainerId()}'."
+        _runRemoteCommand(dockerClient)
+    }
+
+    // method used for sub-classes who wish to invoke this task
+    // multiple times but don't want the logging message to be
+    // printed for every iteration.
+    void _runRemoteCommand(dockerClient) {
         def logCommand = dockerClient.logContainerCmd(getContainerId())
         setContainerCommandConfig(logCommand)
         logCommand.exec(createCallback())?.awaitCompletion()

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
@@ -99,7 +99,8 @@ class DockerLivenessProbeContainer extends DockerLogsContainer {
     }
 
     /**
-     * Define the probe options for this liveness check.
+     * Define the probe options for this liveness check. We'll default to
+     * probing for 10 minutes with 30 second intervals between each probe.
      *
      * @param logContains content within container log we will search for
      * @return instance of Probe

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
@@ -40,9 +40,6 @@ class DockerLivenessProbeContainer extends DockerLogsContainer {
         if (!this.getSince()) {
             this.setSince(new Date())
         }
-        if(!this.getShowTimestamps()) {
-            this.setShowTimestamps(true)
-        }
         if(!this.getTailCount()) {
             this.setTailCount(10)
         }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
@@ -68,7 +68,7 @@ class DockerLivenessProbeContainer extends DockerLogsContainer {
             // 3.) execute our "special" version of `runRemoteCommand` to
             //     check if next log line has the message we're interested in
             //     which in turn will have its output written into the sink.
-            specialRunRemoteCommand(dockerClient)
+            _runRemoteCommand(dockerClient)
 
             // 4.) check if log contains expected message otherwise sleep
             String logLine = getSink().toString()
@@ -119,13 +119,5 @@ class DockerLivenessProbeContainer extends DockerLogsContainer {
      */
     def probe(final long pollTime, final long pollInterval, final String logContains) {
         this.probe = new Probe(pollTime, pollInterval, logContains)
-    }
-
-    // overridden version of `DockerLogsContainer` method `runRemoteCommand` to get the
-    // same functionality but without the `logger.quiet` call that gets run every time.
-    private specialRunRemoteCommand(dockerClient) {
-        def logCommand = dockerClient.logContainerCmd(getContainerId())
-        super.setContainerCommandConfig(logCommand)
-        logCommand.exec(super.createCallback())?.awaitCompletion()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bmuschko.gradle.docker.tasks.container.extras
+
+import static com.bmuschko.gradle.docker.utils.IOUtils.getProgressLogger
+
+import com.bmuschko.gradle.docker.domain.Probe
+import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
+
+import org.gradle.api.GradleException
+import org.gradle.api.tasks.Input
+
+/**
+ *  Poll a given running container for an arbitrary log message to confirm liveness.
+ */
+class DockerLivenessProbeContainer extends DockerLogsContainer {
+
+    @Input
+    Probe probe
+
+    @Override
+    void runRemoteCommand(dockerClient) {
+        logger.quiet "Starting liveness probe on container with ID '${getContainerId()}'."
+
+        // if not already set the following will be defaulted
+        if (!this.getSince()) {
+            this.setSince(new Date())
+        }
+        if(!this.getShowTimestamps()) {
+            this.setShowTimestamps(true)
+        }
+        if(!this.getTailCount()) {
+            this.setTailCount(10)
+        }
+
+        // create progressLogger for pretty printing of terminal log progression
+        final def progressLogger = getProgressLogger(project, DockerLivenessProbeContainer)
+        progressLogger.started()
+
+        boolean matchFound = false
+        long localPollTime = probe.pollTime
+        int pollTimes = 0
+
+        // 1.) Write the content of the logs into a StringWriter which we zero-out
+        //     below after each successive log grab.
+        setSink(new StringWriter())
+
+        while (localPollTime > 0) {
+            pollTimes = pollTimes + 1
+
+            // 2.) check if container is actually running
+            def container = dockerClient.inspectContainerCmd(getContainerId()).exec()
+            if (container.getState().getRunning() == false) {
+                throw new GradleException("Container with ID '${getContainerId()}' is not running and so can't perform liveness probe.");
+            }
+
+            // 3.) execute our "special" version of `runRemoteCommand` to
+            //     check if next log line has the message we're interested in
+            //     which in turn will have its output written into the sink.
+            specialRunRemoteCommand(dockerClient)
+
+            // 4.) check if log contains expected message otherwise sleep
+            String logLine = getSink().toString()
+            if (logLine && logLine.contains(probe.logContains)) {
+                matchFound = true
+                break
+            } else {
+                progressLogger.progress(sprintf('probing for %010dms', pollTimes *probe.pollInterval ))
+                try {
+
+                    // zero'ing out the below so as to save on memory for potentially
+                    // big logs returned from container.
+                    logLine = null
+                    getSink().getBuffer().setLength(0)
+
+                    localPollTime = localPollTime - probe.pollInterval
+                    sleep(probe.pollInterval)
+                } catch (Exception e) {
+                    throw e
+                }
+            }
+        }
+        progressLogger.completed()
+
+        if (!matchFound) {
+            throw new GradleException("Liveness probe failed to find a match: ${probe.toString()}")
+        }
+    }
+
+    /**
+     * Define the probe options for this liveness check.
+     *
+     * @param pollTime how long we will poll for
+     * @param pollInterval interval between poll requests
+     * @param logContains content within container log we will search for
+     * @return instance of Probe
+     */
+    def probe(final long pollTime, final long pollInterval, final String logContains) {
+        this.probe = new Probe(pollTime, pollInterval, logContains)
+    }
+
+    // overridden version of `DockerLogsContainer` method `runRemoteCommand` to get the
+    // same functionality but without the `logger.quiet` call that gets run every time.
+    private specialRunRemoteCommand(dockerClient) {
+        def logCommand = dockerClient.logContainerCmd(getContainerId())
+        super.setContainerCommandConfig(logCommand)
+        logCommand.exec(super.createCallback())?.awaitCompletion()
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessProbeContainer.groovy
@@ -101,6 +101,16 @@ class DockerLivenessProbeContainer extends DockerLogsContainer {
     /**
      * Define the probe options for this liveness check.
      *
+     * @param logContains content within container log we will search for
+     * @return instance of Probe
+     */
+    def probe(final String logContains) {
+        probe(600000, 30000, logContains)
+    }
+
+    /**
+     * Define the probe options for this liveness check.
+     *
      * @param pollTime how long we will poll for
      * @param pollInterval interval between poll requests
      * @param logContains content within container log we will search for

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/IOUtils.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/IOUtils.groovy
@@ -1,5 +1,10 @@
 package com.bmuschko.gradle.docker.utils
 
+import org.gradle.api.Project
+import org.gradle.internal.logging.progress.ProgressLoggerFactory
+import org.gradle.internal.logging.progress.ProgressLogger
+import org.gradle.internal.service.ServiceRegistry
+
 final class IOUtils {
 
     private static final int DEFAULT_BUFFER_SIZE = 1024 * 4
@@ -22,5 +27,21 @@ final class IOUtils {
         } catch (IOException ignored) {
             // ignore
         }
+    }
+
+    /**
+     * Create a progress logger for an arbitrary project and class.
+     *
+     * @param project the project to create a ProgressLogger for.
+     * @param clazz optional class to pair the ProgressLogger to. Defaults to _this_ class if null.
+     * @return instance of ProgressLogger.
+     */
+    static ProgressLogger getProgressLogger(final Project project,
+                                               final Class clazz = GradleDockerDatabasesPluginUtils) {
+        ServiceRegistry registry = project.gradle.getServices()
+        ProgressLoggerFactory factory = registry.get(ProgressLoggerFactory)
+        ProgressLogger progressLogger = factory.newOperation(Objects.requireNonNull(clazz))
+        progressLogger.setDescription("ProgressLogger for ${clazz.getSimpleName()}")
+        progressLogger.setLoggingHeader(null)
     }
 }


### PR DESCRIPTION
New task to check the "liveness" of a given container. This is modeled heavily after how kubernetes does things and checks for when a given container is up and ready to go.

The basic idea is that a user will stand up a container and then invoke this task immediately after doing so. The task itself is a subclass of `DockerLogsContainer` which will poll for some amount of time waiting for a given log to appear whilst also checking that the container itself is still running.

A container is considered **live** if it is both in a running state and the logs contain the requested message.