### PR TITLE
Add new task `DockerClient`

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -105,6 +105,7 @@ The plugin provides the following general-purpose custom task types:
 [options="header"]
 |=======
 |Type                                                                                                                                  |Description
+|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/DockerClient.html[DockerClient]   |Passes the raw docker-java client to the onNext closure if it's defined.
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/DockerInfo.html[DockerInfo]       |Displays system-wide information.
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/DockerVersion.html[DockerVersion] |Show the docker version information.
 |=======
@@ -138,7 +139,7 @@ The plugin provides the following custom task types for managing containers:
 [options="header"]
 |=======
 |Type                                                                                                                                                                        |Description
-|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.html[DockerCopyFileToContainer] |Copies a path from the host into the container.
+|link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.html[DockerCopyFileToContainer]     |Copies a path from the host into the container.
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.html[DockerCopyFileFromContainer] |Copies a path from the container as a tar file on to the host.
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.html[DockerCreateContainer]             |Creates a container.
 |link:http://bmuschko.github.io/gradle-docker-plugin/docs/groovydoc/com/bmuschko/gradle/docker/tasks/container/DockerInspectContainer.html[DockerInspectContainer]           |Returns low-level information on the container.

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerClientFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerClientFunctionalTest.groovy
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bmuschko.gradle.docker
+
+import org.gradle.testkit.runner.BuildResult
+
+class DockerClientFunctionalTest extends AbstractFunctionalTest {
+    def "Can get DockerClient with onNext defined"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.DockerClient
+
+            task dockerClient(type: DockerClient) {
+                onNext { client ->
+                    if (client != null) {
+                        logger.quiet "Found Version: " + client.versionCmd().exec().version
+                    } else {
+                        logger.quiet 'Client is NULL'
+                    }
+                }
+            }
+        """
+
+        when:
+        BuildResult result = build('dockerClient')
+
+        then:
+        result.output.contains('Found Version: ')
+        !result.output.contains('Client is NULL')
+    }
+
+    def "Print informational message when onNext is NOT defined"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.DockerClient
+
+            task dockerClient(type: DockerClient)
+        """
+
+        when:
+        BuildResult result = build('dockerClient')
+
+        then:
+        result.output.contains('Execution amounts to a no-op')
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClient.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClient.groovy
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bmuschko.gradle.docker.tasks
+
+/**
+ *  Passes the underlying `docker-java` client to the defined `onNext` closure if it exists.
+ */
+class DockerClient extends AbstractDockerRemoteApiTask {
+
+    @Override
+    void runRemoteCommand(dockerClient) {
+        if (onNext) {
+            onNext.call(dockerClient)
+        } else {
+            logger.quiet 'Execution amounts to a no-op if the onNext closure/reactive-stream is not defined.'
+        }
+    }
+}


### PR DESCRIPTION
Task whose sole purpose is to hand back the `docker-java` client to the defined `onNext` closure. If it's not defined we print out a ridiculous message.