### PR TITLE
Various minor refactorings to allow for DockerExecStopContainer to be more flexible

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
@@ -74,7 +74,7 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
         result.output.contains("Hello World")
     }
 
-    def "Execute command within running container using cmd closure"() {
+    def "Execute command within running container and not specify cmd arg"() {
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
             import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
@@ -102,7 +102,7 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
             task execContainer(type: DockerExecContainer) {
                 dependsOn startContainer
                 targetContainerId { startContainer.getContainerId() }
-                cmd { ['echo', 'Hello World'] }
+                cmd = ['echo', 'Hello World']
             }
             
             task logContainer(type: DockerLogsContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecContainerFunctionalTest.groovy
@@ -74,6 +74,61 @@ class DockerExecContainerFunctionalTest extends AbstractFunctionalTest {
         result.output.contains("Hello World")
     }
 
+    def "Execute command within running container using cmd closure"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerExecContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+
+            task pullImage(type: DockerPullImage) {
+                repository = '$TEST_IMAGE'
+                tag = '$TEST_IMAGE_TAG'
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn pullImage
+                targetImageId { pullImage.getImageId() }
+                cmd = ['sleep','10']
+            }
+
+            task startContainer(type: DockerStartContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+            }
+
+            task execContainer(type: DockerExecContainer) {
+                dependsOn startContainer
+                targetContainerId { startContainer.getContainerId() }
+                cmd { ['echo', 'Hello World'] }
+            }
+            
+            task logContainer(type: DockerLogsContainer) {
+                dependsOn execContainer
+                targetContainerId { startContainer.getContainerId() }
+                follow = true
+                tailAll = true
+            }
+            
+            task removeContainer(type: DockerRemoveContainer) {
+                dependsOn logContainer
+                removeVolumes = true
+                force = true
+                targetContainerId { startContainer.getContainerId() }
+            }
+
+            task workflow {
+                dependsOn removeContainer
+            }
+        """
+
+        expect:
+        BuildResult result = build('workflow')
+        result.output.contains("Hello World")
+    }
+
     def "Execute command within stopped container"() {
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecStopFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerExecStopFunctionalTest.groovy
@@ -1,0 +1,172 @@
+package com.bmuschko.gradle.docker
+
+import org.gradle.testkit.runner.BuildResult
+
+class DockerExecStopFunctionalTest extends AbstractFunctionalTest {
+
+    def "Can start a container and then successfully exec-stop it"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+            import com.bmuschko.gradle.docker.tasks.container.extras.DockerLivenessProbeContainer
+            import com.bmuschko.gradle.docker.tasks.container.extras.DockerExecStopContainer
+
+            task pullImage(type: DockerPullImage) {
+                repository = 'postgres'
+                tag = 'alpine'
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn pullImage
+                targetImageId { pullImage.getImageId() }
+            }
+
+            task startContainer(type: DockerStartContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+            }
+            
+            task livenessProbe(type: DockerLivenessProbeContainer) {
+                dependsOn 'startContainer'
+                targetContainerId { startContainer.getContainerId() }
+                probe(60000, 5000, 'database system is ready to accept connections')
+                onComplete {
+                    println 'Container is now live'
+                }
+            }
+            
+            task execStopContainer(type: DockerExecStopContainer) {
+                dependsOn 'livenessProbe'
+                targetContainerId { startContainer.getContainerId() }
+                cmd = ['su', 'postgres', "-c", "/usr/local/bin/pg_ctl stop -m fast"]
+                successOnExitCodes = [0, 137]
+                timeout = 60000
+                probe(60000, 5000)
+                onComplete {
+                    println 'Container has been exec-stopped'
+                }
+            }
+
+            task removeContainer(type: DockerRemoveContainer) {
+                removeVolumes = true
+                force = true
+                targetContainerId { startContainer.getContainerId() }
+            }
+
+            task workflow {
+                dependsOn execStopContainer
+                finalizedBy removeContainer
+            }
+        """
+
+        expect:
+        BuildResult result = build('workflow')
+        result.output.contains('Starting liveness probe on container')
+        result.output.contains('Container is now live')
+        result.output.contains('Container has been exec-stopped')
+    }
+
+    def "Can start a container and exec-stop it with no cmd args"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+            import com.bmuschko.gradle.docker.tasks.container.extras.DockerLivenessProbeContainer
+            import com.bmuschko.gradle.docker.tasks.container.extras.DockerExecStopContainer
+
+            task pullImage(type: DockerPullImage) {
+                repository = 'postgres'
+                tag = 'alpine'
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn pullImage
+                targetImageId { pullImage.getImageId() }
+            }
+
+            task startContainer(type: DockerStartContainer) {
+                dependsOn createContainer
+                targetContainerId { createContainer.getContainerId() }
+            }
+            
+            task livenessProbe(type: DockerLivenessProbeContainer) {
+                dependsOn 'startContainer'
+                targetContainerId { startContainer.getContainerId() }
+                probe(60000, 5000, 'database system is ready to accept connections')
+                onComplete {
+                    println 'Container is now live'
+                }
+            }
+            
+            task execStopContainer(type: DockerExecStopContainer) {
+                dependsOn 'livenessProbe'
+                targetContainerId { startContainer.getContainerId() }
+                onComplete {
+                    println 'Container has been exec-stopped'
+                }
+            }
+
+            task removeContainer(type: DockerRemoveContainer) {
+                removeVolumes = true
+                force = true
+                targetContainerId { startContainer.getContainerId() }
+            }
+
+            task workflow {
+                dependsOn execStopContainer
+                finalizedBy removeContainer
+            }
+        """
+
+        expect:
+        BuildResult result = build('workflow')
+        result.output.contains('Starting liveness probe on container')
+        result.output.contains('Container is now live')
+        result.output.contains('Container has been exec-stopped')
+    }
+
+    def "Can  exec-stop a created container with no cmd args and catch normal DockerStopContainer exception"() {
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+            import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
+            import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
+            import com.bmuschko.gradle.docker.tasks.container.extras.DockerExecStopContainer
+
+            task pullImage(type: DockerPullImage) {
+                repository = 'postgres'
+                tag = 'alpine'
+            }
+
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn pullImage
+                targetImageId { pullImage.getImageId() }
+            }
+            
+            task execStopContainer(type: DockerExecStopContainer) {
+                dependsOn 'createContainer'
+                targetContainerId { createContainer.getContainerId() }
+                onError { exc ->
+                    logger.quiet "Found exception: " + exc.class.simpleName
+                }
+            }
+
+            task removeContainer(type: DockerRemoveContainer) {
+                removeVolumes = true
+                force = true
+                targetContainerId { createContainer.getContainerId() }
+            }
+
+            task workflow {
+                dependsOn execStopContainer
+                finalizedBy removeContainer
+            }
+        """
+
+        expect:
+        BuildResult result = build('workflow')
+        result.output.contains('Found exception: NotModifiedException')
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
@@ -22,6 +22,8 @@ import org.gradle.api.tasks.Optional
 
 class DockerExecContainer extends DockerExistingContainer {
 
+    // set as optional for downstream sub-classes who configure
+    // things a bit later.
     @Input
     @Optional
     String[] cmd

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.Optional
 class DockerExecContainer extends DockerExistingContainer {
 
     @Input
+    @Optional
     String[] cmd
 
     @Input

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStopContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStopContainer.groovy
@@ -33,6 +33,7 @@ class DockerStopContainer extends DockerExistingContainer {
         _runRemoteCommand(dockerClient, getContainerId(), getTimeout())
     }
 
+    // overloaded method used by sub-classes and ad-hoc processes
     static void _runRemoteCommand(dockerClient, String containerId, Integer optionalTimeout) {
         def stopContainerCmd = dockerClient.stopContainerCmd(containerId)
 


### PR DESCRIPTION
Handful of updates so that `DockerExecStopContainer` is more forgiving/flexible when being used at runtime.