### PR TITLE
Allow for multiple files to be copied into a given container.

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/domain/CopyFileToContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/domain/CopyFileToContainer.groovy
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.bmuschko.gradle.docker.domain
+
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.Internal
+
+/**
+ *  Class holding metadata for an arbitrary copy-file-to-container invocation
+ */
+class CopyFileToContainer {
+
+    @Input
+    def hostPath // the host path of the file
+
+    @Input
+    def remotePath // how remote path of the file
+
+    @Internal
+    boolean isTar = false
+}


### PR DESCRIPTION
`DockerCopyFileToContainer` can now take N number of files to be copied in.