### PR TITLE
Expose network mode in the DockerBuildImage task

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -110,6 +110,16 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         result.output.contains("Using cache")
     }
 
+    def "can build image using --network host"() {
+        buildFile << buildImageWithHostNetwork()
+
+        when:
+        build('buildWithHostNetwork')
+
+        then:
+        noExceptionThrown()
+    }
+
     private String buildImageWithShmSize() {
         """
             import com.bmuschko.gradle.docker.tasks.image.Dockerfile
@@ -288,6 +298,23 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 dependsOn pullImage
                 inputDir = dockerfile.destFile.parentFile
                 ${useCacheFrom ? "cacheFrom.add('$uniqueTag:latest')" : ""}
+            }
+        """
+    }
+
+    private String buildImageWithHostNetwork() {
+        """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+            task dockerfile(type: Dockerfile) {
+                from 'alpine'
+            }
+
+            task buildWithHostNetwork(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+                network = 'host'
             }
         """
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -70,6 +70,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
     @Input
     @Optional
+    String network
+
+    @Input
+    @Optional
     Map<String, String> labels = [:]
 
     @Input
@@ -140,6 +144,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
         if (getPull()) {
             buildImageCmd.withPull(getPull())
+        }
+
+        if (getNetwork()) {
+            buildImageCmd.withNetworkMode(getNetwork())
         }
 
         if (getLabels()) {


### PR DESCRIPTION
This simply exposes the docker-java property so it can be used in the Gradle task.

This cannot be merged in until the corresponding pull request in docker-java has been merged and a new release has been made.

See: https://github.com/docker-java/docker-java/pull/1061

closes #555