### PR TITLE
When parsing deprecated envs property ensure we limit our response to…

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -290,7 +290,7 @@ class DockerCreateContainer extends AbstractDockerRemoteApiTask {
 
         // marshall deprecated old list onto new map
         getEnv()?.each { envVar ->
-            def keyValuePair = envVar.split('=')
+            def keyValuePair = envVar.split('=', 2)
             envVars.put(keyValuePair.first(), keyValuePair.last())
         }
 


### PR DESCRIPTION
… 2 to preserve backward compatibility and user expectations.

Fix for #612 