### PR TITLE
Tests against private registry is only run if reachable

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -300,6 +300,7 @@ EXPOSE 8080
 """
     }
 
+    @Requires({ TestPrecondition.DOCKER_PRIVATE_REGISTRY_REACHABLE })
     def "Can create image for Java application and push to private registry"() {
         String projectName = temporaryFolder.root.name
         createJettyMainClass()

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerReactiveMethodsFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerReactiveMethodsFunctionalTest.groovy
@@ -17,6 +17,7 @@ package com.bmuschko.gradle.docker
 
 import org.gradle.api.GradleException
 import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
 
 class DockerReactiveMethodsFunctionalTest extends AbstractFunctionalTest {
 
@@ -420,6 +421,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractFunctionalTest {
         result.output.contains('Pull complete')
     }
 
+    @Requires({ TestPrecondition.DOCKER_PRIVATE_REGISTRY_REACHABLE })
     def "Can build an image and push to private registry"() {
         File dockerFileLocation = new File(getProjectDir(), 'build/private-reg-reactive/Dockerfile')
         if (!dockerFileLocation.parentFile.exists() && !dockerFileLocation.parentFile.mkdirs())

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -127,6 +127,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractFunctional
         plugin << REACTED_PLUGINS
     }
 
+    @Requires({ TestPrecondition.DOCKER_PRIVATE_REGISTRY_REACHABLE })
     @Unroll
     def "Can create image for a Spring Boot application and push it to private registry [#plugin.identifier plugin]"() {
         setupSpringBootBuild(plugin.identifier)

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -17,6 +17,7 @@ package com.bmuschko.gradle.docker
 
 import org.gradle.api.GradleException
 import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
 
 class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
     def "Can create Dockerfile and build an image from it"() {
@@ -232,6 +233,7 @@ class DockerWorkflowFunctionalTest extends AbstractFunctionalTest {
         result.output.contains("VolumesFrom : [${uniqueContainerName}-1:rw]")
     }
 
+    @Requires({ TestPrecondition.DOCKER_PRIVATE_REGISTRY_REACHABLE })
     def "Can build an image and push to private registry"() {
         File dockerFileLocation = new File(getProjectDir(), 'build/private-reg/Dockerfile')
         if (!dockerFileLocation.parentFile.exists() && !dockerFileLocation.parentFile.mkdirs())

--- a/src/testSetup/groovy/com/bmuschko/gradle/docker/TestPrecondition.groovy
+++ b/src/testSetup/groovy/com/bmuschko/gradle/docker/TestPrecondition.groovy
@@ -8,7 +8,7 @@ final class TestPrecondition {
     private TestPrecondition() {}
 
     private static boolean isPrivateDockerRegistryReachable() {
-        isUriReachable(new URI("${TestConfiguration.dockerPrivateRegistryUrl}".replaceFirst('tcp', 'http')), null)
+        isUriReachable(new URI("${TestConfiguration.dockerPrivateRegistryUrl}".replaceFirst('tcp', 'http')), 'v2')
     }
 
     private static boolean isUriReachable(URI dockerUri, String extraPath) {
@@ -26,8 +26,8 @@ final class TestPrecondition {
                 return false
             }
         } else {
-            
-            // TODO: should really use something like kohlschutter unix domain socket library 
+
+            // TODO: should really use something like kohlschutter unix domain socket library
             // or netty to test if the socket is live and can be pinged.
             return new File(dockerUri.path).exists()
         }


### PR DESCRIPTION
Developers new to the project will likely not have a private registry set up. Tests shouldn't fail just because of this reason. Instead the relevant tests are skipped. On CI all tests are executed as the private registry is set up as part of the Travis CI fixtures.