### PR TITLE
Use smaller base images for convention plugins

### DIFF
--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -5,7 +5,7 @@ The plugin defines an extension with the namespace `javaApplication` as a child 
 [options="header"]
 |=======
 |Property name   |Type        |Default value                                            |Description
-|`baseImage`     |`String`    |`openjdk`                                                |The Docker base image used for Java application.
+|`baseImage`     |`String`    |`openjdk:jre-alpine`                                     |The Docker base image used for Java application.
 |`exec`          |`Closure`   |Create ENTRYPOINT using script from Application plugin   |The ENTRYPOINT and/or CMD Dockerfile instructions
 |`maintainer`    |`String`    |Value of `user.home` system property                     |The name and email address of the image maintainer (Deprecated).
 |`port`          |`Integer`   |`8080`                                                   |The Docker image entry point port used for the Java application (Deprecated)

--- a/src/docs/asciidoc/32-extension.adoc
+++ b/src/docs/asciidoc/32-extension.adoc
@@ -6,7 +6,7 @@ The following properties can be configured:
 [options="header"]
 |=======
 |Property name   |Type        |Default value                                            |Description
-|`baseImage`     |`String`    |`openjdk`                                                |The Docker base image used for the Spring Boot application.
+|`baseImage`     |`String`    |`openjdk:jre-alpine`                                     |The Docker base image used for the Spring Boot application.
 |`ports`         |`Integer[]` |`[8080]`                                                 |The Docker image exposed ports.
 |`tag`           |`String`    |`<project.group>/<project.name>:<project.version>`       |The tag used for the Docker image.
 |=======

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -4,7 +4,8 @@ import org.gradle.testkit.runner.BuildResult
 import spock.lang.Requires
 
 class DockerJavaApplicationPluginFunctionalTest extends AbstractFunctionalTest {
-    public static final CUSTOM_BASE_IMAGE = 'openjdk:8-alpine'
+    public static final DEFAULT_BASE_IMAGE = 'openjdk:jre-alpine'
+    public static final CUSTOM_BASE_IMAGE = 'openjdk:8u171-jre-alpine'
 
     def "Can create image for Java application with default configuration"() {
         String projectName = temporaryFolder.root.name
@@ -19,7 +20,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractFunctionalTest {
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-"""FROM openjdk
+"""FROM $DEFAULT_BASE_IMAGE
 MAINTAINER ${System.getProperty('user.name')}
 ADD ${projectName} /${projectName}
 ADD app-lib/${projectName}-1.0.jar /$projectName/lib/$projectName-1.0.jar
@@ -348,7 +349,7 @@ EXPOSE 8080
         File dockerfile = new File(projectDir, 'build/docker/Dockerfile')
         dockerfile.exists()
         dockerfile.text ==
-            """FROM openjdk
+            """FROM $DEFAULT_BASE_IMAGE
 ADD ${projectName} /${projectName}
 ADD app-lib/${projectName}-1.0.jar /$projectName/lib/$projectName-1.0.jar
 ENTRYPOINT ["/${projectName}/bin/${projectName}"]

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -5,7 +5,8 @@ import spock.lang.Unroll
 
 class DockerSpringBootApplicationPluginFunctionalTest extends AbstractFunctionalTest {
     private static final String PROJECT_NAME = 'spring-boot'
-    private static final String CUSTOM_BASE_IMAGE = 'openjdk:8-alpine'
+    public static final DEFAULT_BASE_IMAGE = 'openjdk:jre-alpine'
+    private static final String CUSTOM_BASE_IMAGE = 'openjdk:8u171-jre-alpine'
     private static final List<ReactedPlugin> REACTED_PLUGINS = [ReactedPlugin.WAR, ReactedPlugin.JAVA]
 
     def setup() {
@@ -32,7 +33,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractFunctional
         then:
         File dockerfile = dockerFile()
         dockerfile.exists()
-        dockerfile.text == expectedDockerFileContent('openjdk', plugin.archiveExtension, [8080])
+        dockerfile.text == expectedDockerFileContent(DEFAULT_BASE_IMAGE, plugin.archiveExtension, [8080])
 
         where:
         plugin << REACTED_PLUGINS

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -18,7 +18,7 @@ package com.bmuschko.gradle.docker
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile.CompositeExecInstruction
 
 class DockerJavaApplication {
-    String baseImage = 'openjdk'
+    String baseImage = 'openjdk:jre-alpine'
     final CompositeExecInstruction exec = new CompositeExecInstruction()
 
     /**

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
@@ -10,7 +10,7 @@ import groovy.transform.CompileStatic
 @CompileStatic
 class DockerSpringBootApplication {
     final CompositeExecInstruction exec = new CompositeExecInstruction()
-    String baseImage = 'openjdk'
+    String baseImage = 'openjdk:jre-alpine'
     Set<Integer> ports
     String tag
 


### PR DESCRIPTION
Reduces the built image size by ~500MB. There's no need to pull a JDK image. The JRE image will do as we are just executing the java command.

This change will also lead to faster, initial builds that don't have the base images yet.