### PR TITLE
Support usage of Gradle build cache for task

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
@@ -145,8 +145,8 @@ LABEL version=1.0
             import com.bmuschko.gradle.docker.tasks.image.Dockerfile
             
             task ${DOCKERFILE_TASK_NAME}(type: Dockerfile) {
-                instructions = [new Dockerfile.FromInstruction('$TEST_IMAGE_WITH_TAG'),
-                                new Dockerfile.LabelInstruction(['maintainer': 'benjamin.muschko@gmail.com'])]
+                instructions << new Dockerfile.FromInstruction('$TEST_IMAGE_WITH_TAG')
+                instructions << new Dockerfile.LabelInstruction(['maintainer': 'benjamin.muschko@gmail.com'])
             }
         """
 


### PR DESCRIPTION
- Uses input/output annotations instead of runtime API (preferred practice).
- Annotations require a getter method to work properly. Therefore introduce new method used for input annotation and deprecate existing one.
- Moves instruction-implementation specific to application plugin to relevant code.