### PR TITLE
Support for --cache-from

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -1,7 +1,10 @@
 package com.bmuschko.gradle.docker.tasks.image
 
 import com.bmuschko.gradle.docker.AbstractGroovyDslFunctionalTest
+import com.bmuschko.gradle.docker.TestConfiguration
+import com.bmuschko.gradle.docker.TestPrecondition
 import org.gradle.testkit.runner.BuildResult
+import spock.lang.Requires
 import spock.lang.Unroll
 
 class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
@@ -73,6 +76,38 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
         then:
         noExceptionThrown()
+    }
+
+    def "can build image using --cache-from with nothing in the cache"() {
+        buildFile << buildImageUsingCacheFromWithNothingInCache()
+
+        when:
+        BuildResult result = build('buildImageWithCacheFrom')
+
+        then:
+        result.output.contains("Successfully built")
+    }
+
+    @Requires({ TestPrecondition.DOCKER_PRIVATE_REGISTRY_REACHABLE })
+    def "cache is not used for build without --cached-from"() {
+        buildFile << buildPushRemovePullBuildImage(false)
+
+        when:
+        BuildResult result = build('buildImageWithCacheFrom')
+
+        then:
+        !result.output.contains("Using cache")
+    }
+
+    @Requires({ TestPrecondition.DOCKER_PRIVATE_REGISTRY_REACHABLE })
+    def "cache is used for build using --cached-from"() {
+        buildFile << buildPushRemovePullBuildImage(true)
+
+        when:
+        BuildResult result = build('buildImageWithCacheFrom')
+
+        then:
+        result.output.contains("Using cache")
     }
 
     private String buildImageWithShmSize() {
@@ -180,6 +215,79 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 dependsOn dockerfile
                 inputDir = file("build/docker")
                 tag = 'test/image:123'
+            }
+        """
+    }
+
+    private String buildImageUsingCacheFromWithNothingInCache() {
+        def uniqueImageId = createUniqueImageId()
+        def uniqueTag = "${TestConfiguration.dockerPrivateRegistryDomain}/$uniqueImageId"
+        """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+
+            project.version = "123"
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+                maintainer '${UUID.randomUUID().toString()}'
+            }
+
+            task buildImageWithCacheFrom(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+                cacheFrom.add('$uniqueTag:latest')
+                tag = '$uniqueTag:latest'
+            }
+        """
+    }
+
+    private String buildPushRemovePullBuildImage(boolean useCacheFrom) {
+        def uniqueImageId = createUniqueImageId()
+        def uniqueTag = "${TestConfiguration.dockerPrivateRegistryDomain}/$uniqueImageId"
+        """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
+
+            project.version = "123"
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+                maintainer '${UUID.randomUUID().toString()}'
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = dockerfile.destFile.parentFile
+                cacheFrom.add('$TEST_IMAGE_WITH_TAG') // no effect
+                tag = '$uniqueTag'
+            }
+
+            task pushImage(type: DockerPushImage) {
+                dependsOn buildImage
+                conventionMapping.imageName = { buildImage.getTag() }
+                tag = 'latest'
+            }
+
+            task removeImage(type: DockerRemoveImage) {
+                dependsOn pushImage
+                force = true
+                targetImageId { buildImage.getImageId() }
+            }
+
+            task pullImage(type: DockerPullImage) {
+                dependsOn removeImage
+                repository = '$uniqueTag'
+                tag = 'latest'
+            }
+
+            task buildImageWithCacheFrom(type: DockerBuildImage) {
+                dependsOn pullImage
+                inputDir = dockerfile.destFile.parentFile
+                ${useCacheFrom ? "cacheFrom.add('$uniqueTag:latest')" : ""}
             }
         """
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -160,8 +160,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             buildImageCmd = buildImageCmd.withBuildArg(arg, value)
         }
 
-        if (!cacheFrom.isEmpty()) {
-            buildImageCmd = buildImageCmd.withCacheFrom(cacheFrom)
+        if (getCacheFrom()) {
+            // Workaround a bug in dockerjava that double-unmarshalls this argument
+            def doubleMarshalledCacheFrom = ["[\"${getCacheFrom().join('","')}\"]".toString()].toSet()
+            buildImageCmd = buildImageCmd.withCacheFrom(doubleMarshalledCacheFrom)
         }
 
         def callback = onNext ? threadContextClassLoader.createBuildImageResultCallback(this.onNext)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -76,6 +76,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     @Optional
     Map<String, String> buildArgs = [:]
 
+    @Input
+    @Optional
+    Set<String> cacheFrom = []
+
     /**
      * Size of <code>/dev/shm</code> in bytes.
      * The size must be greater than 0.
@@ -154,6 +158,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
         buildArgs.each { arg, value ->
             buildImageCmd = buildImageCmd.withBuildArg(arg, value)
+        }
+
+        if (!cacheFrom.isEmpty()) {
+            buildImageCmd = buildImageCmd.withCacheFrom(cacheFrom)
         }
 
         def callback = onNext ? threadContextClassLoader.createBuildImageResultCallback(this.onNext)


### PR DESCRIPTION
Reopen of https://github.com/bmuschko/gradle-docker-plugin/pull/629, issue https://github.com/bmuschko/gradle-docker-plugin/pull/628

dockerjava seems to doubly-parse this argument, the workaround is to doubly-serialize.

Added three tests, testing the following:

| --cache-from flag present? | layer to be built in cache? | result                          |
|----------------------------|-----------------------------|---------------------------------|
| true                       | false                       | build success, cache isn't used |
| false                      | true                        | build success, cache isn't used |
| true                       | true                        | build success, cache is used    |

It's a bit tricky to populate the cache without "linking" it to local builds, the way the tests do it is they build a layer, push it to the registry, then delete the layer locally, and finally pull the layer. This populates the cache but removes the build "link".