### PR TITLE
Make taskPath safe for windows before using it

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -132,7 +132,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 }
             }
         """
-        File imageIdFile = new File(projectDir, 'build/.docker/:buildImage-imageId.txt')
+        File imageIdFile = new File(projectDir, 'build/.docker/buildImage-imageId.txt')
 
         when:
         BuildResult result = build('verifyImageId')

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -108,7 +108,8 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     DockerRegistryCredentials registryCredentials
 
     /**
-     * Output file containing the image ID of the built image. Defaults to "$buildDir/.docker/$taskpath-imageId.txt".
+     * Output file containing the image ID of the built image. Defaults to "$buildDir/.docker/$taskpath-imageId.txt"
+     * with the leading colon of taskpath stripped and remaining colons replaced with underscores.
      *
      * @since 4.0.0
      */
@@ -121,7 +122,9 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
     DockerBuildImage() {
         inputDir.set(project.file('docker'))
-        File imageIdTextFile = new File(project.buildDir, ".docker/${path}-imageId.txt")
+
+        String safeTaskPath = path.replaceFirst("^:", "").replaceAll(":", "_")
+        File imageIdTextFile = new File(project.buildDir, ".docker/${safeTaskPath}-imageId.txt")
         imageIdFile.set(imageIdTextFile)
 
         if (imageIdTextFile.isFile()) {


### PR DESCRIPTION
The BuildDockerImage task writes a file to `$buildDir/.docker/$taskpath-imageId.txt` but didn't properly sanitize the path for windows (which doesn't allow colons in file paths).

This PR adds logic to strip the first colon and replace any others with underscores.
Closes #689. 


(Just an FYI - I wasn't able to run the full suite of tests before committing as it seems they don't run on windows - lots of errors to do with paths not being supported and unix sockets. So hopefully I didn't break a bunch of tests =D )