### PR TITLE
Correctly handle the case where `inputDir` is not where `dockerFile` is located

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -43,6 +43,22 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         result.output.contains("Created image with ID")
     }
 
+    def "can build image in a parent context"() {
+        buildFile << imageCreation()
+        buildFile << """
+            buildImage {
+                inputDir = projectDir
+                dockerFile = dockerfile.destFile
+            }
+        """
+
+        when:
+        BuildResult result = build('buildImage')
+
+        then:
+        result.output.contains("Created image with ID")
+    }
+
     @Unroll
     def "can build image with labels"(String gradleTaskDefinition) {
         buildFile << gradleTaskDefinition

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -138,7 +138,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             logger.quiet "Using Dockerfile '${dockerFile.get()}'"
             buildImageCmd = dockerClient.buildImageCmd()
                     .withBaseDirectory(inputDir.get().asFile)
-                    .withDockerfile(dockerFile.get())
+                    .withDockerfile(dockerFile.get().asFile)
         } else {
             buildImageCmd = dockerClient.buildImageCmd(inputDir.get().asFile)
         }


### PR DESCRIPTION
Fixes #692 
