### PR TITLE
#674 Configuration avoidance api migration for DockerRemoteApiPlugin

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -67,7 +67,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
 
     private void configureAbstractDockerTask(Project project, DockerExtension extension) {
         ThreadContextClassLoader dockerClassLoader = new DockerThreadContextClassLoader(extension)
-        project.tasks.withType(AbstractDockerRemoteApiTask, new Action<AbstractDockerRemoteApiTask>() {
+        project.tasks.withType(AbstractDockerRemoteApiTask).configureEach(new Action<AbstractDockerRemoteApiTask>() {
             @Override
             void execute(AbstractDockerRemoteApiTask apiTask) {
                 apiTask.with {
@@ -79,7 +79,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
     }
 
     private void configureRegistryAwareTasks(Project project, DockerRegistryCredentials dockerRegistryCredentials) {
-        project.tasks.withType(RegistryCredentialsAware, new Action<RegistryCredentialsAware>() {
+        project.tasks.withType(RegistryCredentialsAware).configureEach(new Action<RegistryCredentialsAware>() {
             @Override
             void execute(RegistryCredentialsAware registryCredentialsAware) {
                 registryCredentialsAware.setRegistryCredentials(dockerRegistryCredentials)


### PR DESCRIPTION
Relates to issue #674.

Really simple two-line PR  that starts the migration to the configuration avoidance api, following the [migration guide for configuration avoidance](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview).

<img width="493" alt="screen shot 2018-12-17 at 5 11 43 pm" src="https://user-images.githubusercontent.com/12202344/50118800-dce85980-021e-11e9-89cd-9230eae19d51.png">

Motivation was due to any tasks of type `AbstractDockerRemoteApiTask` being secretly "realized" early due to explicit task configuration occurring through the old method, which was difficult to track down when converting our tasks to use the newest gradle hotness. This will allow plugins that wrap the `DockerRemoteApiPlugin` to make use of the configuration avoidance API for tasks brought in by this plugin.
