### PR TITLE
Allow to specify additional groups in DockerCreateContainer

### DIFF
--- a/src/docs/asciidoc/50-changes.adoc
+++ b/src/docs/asciidoc/50-changes.adoc
@@ -3,6 +3,7 @@
 [discrete]
 === v4.4.0 (TBA)
 * Bump **docker-java-shaded** to latest and greatest and decrease wait time for **DockerLiveness** test. - {uri-github}/pull/729[PR 729]
+* Task `DockerCreateContainer` gained option `groups` - {uri-github}/pull/731[Pull Request 731]
 
 [discrete]
 === v4.3.0 (January 12, 2019)

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -48,11 +48,8 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
             }
         """
 
-        when:
+        expect:
         build('inspectContainer')
-
-        then:
-        noExceptionThrown()
     }
 
     def "can override default MAC address"() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -21,6 +21,27 @@ import org.gradle.testkit.runner.TaskOutcome
 
 class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
+    def "can setup additional user groups"() {
+        given:
+        String containerCreationTask = """
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn pullImage
+                targetImageId pullImage.getImageId()
+                cmd = ['groups']
+                groups = ['postgres']
+            }
+        """
+        buildFile <<
+            containerStart(containerCreationTask) <<
+            containerLogAndRemove()
+
+        when:
+        BuildResult result = build('logContainer')
+
+        then:
+        result.output.contains("postgres")
+    }
+
     def "can override default MAC address"() {
         given:
         String containerCreationTask = """

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -50,6 +50,8 @@ class DockerCreateContainer extends DockerExistingImage {
 
     /**
      * A list of additional groups that the container process will run as.
+     *
+     * @since 4.4.0
      */
     @Input
     @Optional

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -48,6 +48,13 @@ class DockerCreateContainer extends DockerExistingImage {
     @Optional
     final Property<String> user = project.objects.property(String)
 
+    /**
+     * A list of additional groups that the container process will run as.
+     */
+    @Input
+    @Optional
+    final ListProperty<String> groups = project.objects.listProperty(String)
+
     @Input
     @Optional
     final Property<Boolean> stdinOpen = project.objects.property(Boolean)
@@ -215,6 +222,7 @@ class DockerCreateContainer extends DockerExistingImage {
         tty.set(false)
         devices.set([])
         autoRemove.set(false)
+        groups.set([])
     }
 
     @Override
@@ -269,6 +277,10 @@ class DockerCreateContainer extends DockerExistingImage {
 
         if(user.getOrNull()) {
             containerCommand.withUser(user.get())
+        }
+
+        if(groups.getOrNull()) {
+            containerCommand.hostConfig.withGroupAdd(groups.get())
         }
 
         if(stdinOpen.getOrNull()) {


### PR DESCRIPTION
Adds `groups` property to `DockerCreateContainer`.

Closes #551 
