### PR TITLE
Define image with more fine-grained image layers

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 }
 
 dependencies {
+    implementation("org.springframework.boot:spring-boot-loader-tools:2.1.2.RELEASE")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {
         exclude(group = "org.codehaus.groovy")
     }

--- a/src/docs/asciidoc/23-tasks.adoc
+++ b/src/docs/asciidoc/23-tasks.adoc
@@ -5,8 +5,8 @@ The plugin provides a set of tasks for your project and preconfigures them with 
 [options="header"]
 |=======
 |Task name                 |Depends On                |Type                                                                                 |Description
-|`dockerSyncArchive`       |`distTar`                 |{uri-gradle-docs}/javadoc/org/gradle/api/tasks/Sync.html[Sync]                       |Copies the resource files (like the Java application's TAR file) to a temporary directory for image creation.
-|`dockerCreateDockerfile`  |`dockerSyncArchive`       |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/Dockerfile.html[Dockerfile] |Creates the Docker image for the Java application.
+|`dockerSyncBuildContext`  |`classes`                 |{uri-gradle-docs}/javadoc/org/gradle/api/tasks/Sync.html[Sync]                       |Copies the application files to a temporary directory for image creation.
+|`dockerCreateDockerfile`  |`dockerSyncBuildContext`       |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/Dockerfile.html[Dockerfile] |Creates the Docker image for the Java application.
 |`dockerBuildImage`        |`dockerCreateDockerfile`  |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.html[DockerBuildImage] |Builds the Docker image for the Java application.
 |`dockerPushImage`         |`dockerBuildImage`        |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.html[DockerPushImage] |Pushes created Docker image to the repository.
 |=======

--- a/src/docs/asciidoc/24-examples.adoc
+++ b/src/docs/asciidoc/24-examples.adoc
@@ -33,17 +33,6 @@ include::{samplesCodeDir}/application-plugin/basic/groovy/build.gradle[tags=dock
 include::{samplesCodeDir}/application-plugin/basic/kotlin/build.gradle.kts[tags=dockerfile-addition-instructions]
 ----
 
-will result in
-
-----
-FROM openjdk:jre-alpine
-LABEL maintainer=user
-ADD javaapp-1.0.0-SNAPSHOT.tar /
-ENTRYPOINT ["/javaapp-1.0.0-SNAPSHOT/bin/javaapp"]
-EXPOSE 8080
-RUN ls -la
-----
-
 Or you can use form
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/docs/asciidoc/33-tasks.adoc
+++ b/src/docs/asciidoc/33-tasks.adoc
@@ -5,8 +5,8 @@ The plugin provides a set of tasks for your project and preconfigures them with 
 [options="header"]
 |=======
 |Task name                 |Depends On                |Type                                                                                 |Description
-|`dockerSyncArchive`       |`assemble`                |{uri-gradle-docs}/javadoc/org/gradle/api/tasks/Sync.html[Sync]                       |Copies the Spring Boot archive to a temporary directory for image creation.
-|`dockerCreateDockerfile`  |`bootJar` or `bootWar`    |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/Dockerfile.html[Dockerfile] |Creates the Docker image for the Spring Boot application.
+|`dockerSyncBuildContext`  |`classes`                |{uri-gradle-docs}/javadoc/org/gradle/api/tasks/Sync.html[Sync]                       |Copies the application files to a temporary directory for image creation.
+|`dockerCreateDockerfile`  |`dockerSyncBuildContext`    |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/Dockerfile.html[Dockerfile] |Creates the Docker image for the Spring Boot application.
 |`dockerBuildImage`        |`dockerCreateDockerfile`  |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.html[DockerBuildImage] |Builds the Docker image for the Spring Boot application.
 |`dockerPushImage`         |`dockerBuildImage`        |{uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.html[DockerPushImage] |Pushes created Docker image to the repository.
 |=======

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -4,6 +4,7 @@ import spock.lang.Requires
 
 import static com.bmuschko.gradle.docker.fixtures.DockerConventionPluginFixture.*
 import static com.bmuschko.gradle.docker.fixtures.DockerJavaApplicationPluginFixture.writeJettyMainClass
+import static com.bmuschko.gradle.docker.fixtures.DockerJavaApplicationPluginFixture.writePropertiesFile
 
 class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
@@ -16,15 +17,23 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
         build('buildAndCleanResources')
 
         then:
-        File dockerfile = dockerFile()
-        dockerfile.exists()
-        dockerfile.text == """FROM $DEFAULT_BASE_IMAGE
-LABEL maintainer=${System.getProperty('user.name')}
-ADD ${PROJECT_NAME} /${PROJECT_NAME}
-ADD app-lib/${PROJECT_NAME}-1.0.jar /$PROJECT_NAME/lib/$PROJECT_NAME-1.0.jar
-ENTRYPOINT ["/${PROJECT_NAME}/bin/${PROJECT_NAME}"]
-EXPOSE 8080
-"""
+        assertGeneratedDockerfile()
+        assertBuildContextLibs()
+        assertBuildContextClasses()
+    }
+
+    def "Can create image and start container for Java application with resource file"() {
+        given:
+        writePropertiesFile(projectDir)
+
+        when:
+        build('buildAndCleanResources')
+
+        then:
+        assertGeneratedDockerfile(new ExpectedDockerfile(copyResources: true))
+        assertBuildContextLibs()
+        assertBuildContextResources()
+        assertBuildContextClasses()
     }
 
     def "Can create image and start container for Java application with user-driven configuration"() {
@@ -44,15 +53,9 @@ EXPOSE 8080
         build('buildAndCleanResources')
 
         then:
-        File dockerfile = dockerFile()
-        dockerfile.exists()
-        dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
-LABEL maintainer=benjamin.muschko@gmail.com
-ADD ${PROJECT_NAME} /${PROJECT_NAME}
-ADD app-lib/${PROJECT_NAME}-1.0.jar /$PROJECT_NAME/lib/$PROJECT_NAME-1.0.jar
-ENTRYPOINT ["/${PROJECT_NAME}/bin/${PROJECT_NAME}"]
-EXPOSE 9090
-"""
+        assertGeneratedDockerfile(new ExpectedDockerfile(baseImage: CUSTOM_BASE_IMAGE, maintainer: 'benjamin.muschko@gmail.com', exposedPorts: [9090]))
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     def "Can create image for Java application with user-driven configuration with several ports"() {
@@ -72,15 +75,9 @@ EXPOSE 9090
         build('buildAndRemoveImage')
 
         then:
-        File dockerfile = dockerFile()
-        dockerfile.exists()
-        dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
-LABEL maintainer=benjamin.muschko@gmail.com
-ADD ${PROJECT_NAME} /${PROJECT_NAME}
-ADD app-lib/${PROJECT_NAME}-1.0.jar /$PROJECT_NAME/lib/$PROJECT_NAME-1.0.jar
-ENTRYPOINT ["/${PROJECT_NAME}/bin/${PROJECT_NAME}"]
-EXPOSE 9090 8080
-"""
+        assertGeneratedDockerfile(new ExpectedDockerfile(baseImage: CUSTOM_BASE_IMAGE, maintainer: 'benjamin.muschko@gmail.com', exposedPorts: [9090, 8080]))
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     def "Can create image for Java application with user-driven configuration without exposed ports"() {
@@ -100,14 +97,9 @@ EXPOSE 9090 8080
         build('buildAndRemoveImage')
 
         then:
-        File dockerfile = dockerFile()
-        dockerfile.exists()
-        dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
-LABEL maintainer=benjamin.muschko@gmail.com
-ADD ${PROJECT_NAME} /${PROJECT_NAME}
-ADD app-lib/${PROJECT_NAME}-1.0.jar /$PROJECT_NAME/lib/$PROJECT_NAME-1.0.jar
-ENTRYPOINT ["/${PROJECT_NAME}/bin/${PROJECT_NAME}"]
-"""
+        assertGeneratedDockerfile(new ExpectedDockerfile(baseImage: CUSTOM_BASE_IMAGE, maintainer: 'benjamin.muschko@gmail.com', exposedPorts: []))
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     def "Can create image for Java application with user-driven configuration with custom cmd/entrypoint"() {
@@ -135,12 +127,15 @@ ENTRYPOINT ["/${PROJECT_NAME}/bin/${PROJECT_NAME}"]
         dockerfile.exists()
         dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
 LABEL maintainer=benjamin.muschko@gmail.com
-ADD ${PROJECT_NAME} /${PROJECT_NAME}
-ADD app-lib/${PROJECT_NAME}-1.0.jar /$PROJECT_NAME/lib/$PROJECT_NAME-1.0.jar
+WORKDIR /app
+COPY libs libs/
+COPY classes classes/
 CMD ["arg1"]
 ENTRYPOINT ["bin/run.sh"]
 EXPOSE 9090
 """
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     def "Can create image for Java application with user-driven configuration with empty cmd/entrypoint"() {
@@ -165,10 +160,13 @@ EXPOSE 9090
         dockerfile.exists()
         dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
 LABEL maintainer=benjamin.muschko@gmail.com
-ADD ${PROJECT_NAME} /${PROJECT_NAME}
-ADD app-lib/${PROJECT_NAME}-1.0.jar /$PROJECT_NAME/lib/$PROJECT_NAME-1.0.jar
+WORKDIR /app
+COPY libs libs/
+COPY classes classes/
 EXPOSE 9090
 """
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     def "Can create image for Java application with additional files"() {
@@ -177,7 +175,7 @@ EXPOSE 9090
         temporaryFolder.newFile('file2.txt')
 
         buildFile << """
-            dockerSyncArchive {
+            dockerSyncBuildContext {
                 from file('file1.txt')
                 from file('file2.txt')
             }
@@ -205,15 +203,18 @@ EXPOSE 9090
         dockerfile.exists()
         dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
 LABEL maintainer=benjamin.muschko@gmail.com
-ADD ${PROJECT_NAME} /${PROJECT_NAME}
-ADD app-lib/${PROJECT_NAME}-1.0.jar /$PROJECT_NAME/lib/$PROJECT_NAME-1.0.jar
-ENTRYPOINT ["/${PROJECT_NAME}/bin/${PROJECT_NAME}"]
+WORKDIR /app
+COPY libs libs/
+COPY classes classes/
+ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmuschko.gradle.docker.application.JettyMain"]
 EXPOSE 9090
 ADD file1.txt /some/dir/file1.txt
 ADD file2.txt /other/dir/file2.txt
 """
-        new File(projectDir, 'build/docker/file1.txt').exists()
-        new File(projectDir, 'build/docker/file2.txt').exists()
+        new File(buildContextDir(), 'file1.txt').exists()
+        new File(buildContextDir(), 'file2.txt').exists()
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     @Requires({ TestPrecondition.DOCKER_HUB_CREDENTIALS_AVAILABLE })
@@ -241,15 +242,9 @@ ADD file2.txt /other/dir/file2.txt
         build('pushAndRemoveImage')
 
         then:
-        File dockerfile = dockerFile()
-        dockerfile.exists()
-        dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
-LABEL maintainer=${System.getProperty('user.name')}
-ADD javaapp /javaapp
-ADD app-lib/${PROJECT_NAME}-1.0.jar /javaapp/lib/$PROJECT_NAME-1.0.jar
-ENTRYPOINT ["/javaapp/bin/javaapp"]
-EXPOSE 8080
-"""
+        assertGeneratedDockerfile(new ExpectedDockerfile(baseImage: CUSTOM_BASE_IMAGE))
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     @Requires({ TestPrecondition.DOCKER_PRIVATE_REGISTRY_REACHABLE })
@@ -270,15 +265,9 @@ EXPOSE 8080
         build('pushAndRemoveImage')
 
         then:
-        File dockerfile = dockerFile()
-        dockerfile.exists()
-        dockerfile.text == """FROM $CUSTOM_BASE_IMAGE
-LABEL maintainer=${System.getProperty('user.name')}
-ADD javaapp /javaapp
-ADD app-lib/${PROJECT_NAME}-1.0.jar /javaapp/lib/$PROJECT_NAME-1.0.jar
-ENTRYPOINT ["/javaapp/bin/javaapp"]
-EXPOSE 8080
-"""
+        assertGeneratedDockerfile(new ExpectedDockerfile(baseImage: CUSTOM_BASE_IMAGE))
+        assertBuildContextLibs()
+        assertBuildContextClasses()
     }
 
     private void setupProjectUnderTest() {
@@ -320,6 +309,69 @@ EXPOSE 8080
     }
 
     private File dockerFile() {
-        new File(projectDir, 'build/docker/Dockerfile')
+        new File(buildContextDir(), 'Dockerfile')
+    }
+
+    private File buildContextDir() {
+        new File(projectDir, 'build/docker')
+    }
+
+    private void assertGeneratedDockerfile(ExpectedDockerfile expectedDockerfile = new ExpectedDockerfile()) {
+        File dockerfile = dockerFile()
+        assert dockerfile.exists()
+        assert dockerfile.text == generatedDockerfile(expectedDockerfile)
+    }
+
+    private String generatedDockerfile(ExpectedDockerfile expectedDockerfile) {
+        String dockerfileContent = """FROM $expectedDockerfile.baseImage
+LABEL maintainer=$expectedDockerfile.maintainer
+WORKDIR /app
+"""
+        if (expectedDockerfile.copyLibs) {
+            dockerfileContent += """COPY libs libs/
+"""
+        }
+
+        if (expectedDockerfile.copyResources) {
+            dockerfileContent += """COPY resources resources/
+"""
+        }
+
+        dockerfileContent += """COPY classes classes/
+ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmuschko.gradle.docker.application.JettyMain"]
+"""
+
+        if (!expectedDockerfile.exposedPorts.isEmpty()) {
+            dockerfileContent += """EXPOSE ${expectedDockerfile.exposedPorts.join(' ')}
+"""
+        }
+
+        dockerfileContent
+    }
+
+    private void assertBuildContextLibs() {
+        File libsDir = new File(buildContextDir(), 'libs')
+        assert libsDir.isDirectory()
+        assert libsDir.listFiles()*.name == ['javax.websocket-api-1.0.jar', 'jetty-all-9.2.5.v20141112.jar', 'javax.servlet-api-3.1.0.jar']
+    }
+
+    private void assertBuildContextResources() {
+        File resourcesDir = new File(buildContextDir(), 'resources')
+        assert resourcesDir.isDirectory()
+        assert new File(resourcesDir, 'my.properties').isFile()
+    }
+
+    private void assertBuildContextClasses() {
+        File classesDir = new File(buildContextDir(), 'classes')
+        assert classesDir.isDirectory()
+        assert new File(classesDir, 'com/bmuschko/gradle/docker/application/JettyMain.class').isFile()
+    }
+
+    private static class ExpectedDockerfile {
+        String baseImage = DEFAULT_BASE_IMAGE
+        String maintainer = System.getProperty('user.name')
+        boolean copyLibs = true
+        boolean copyResources = false
+        List<String> exposedPorts = [8080]
     }
 }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -352,7 +352,7 @@ ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmusc
     private void assertBuildContextLibs() {
         File libsDir = new File(buildContextDir(), 'libs')
         assert libsDir.isDirectory()
-        assert libsDir.listFiles()*.name == ['javax.websocket-api-1.0.jar', 'jetty-all-9.2.5.v20141112.jar', 'javax.servlet-api-3.1.0.jar']
+        assert libsDir.listFiles()*.name.containsAll(['javax.websocket-api-1.0.jar', 'jetty-all-9.2.5.v20141112.jar', 'javax.servlet-api-3.1.0.jar'])
     }
 
     private void assertBuildContextResources() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerJavaApplicationPluginFixture.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerJavaApplicationPluginFixture.groovy
@@ -6,11 +6,7 @@ final class DockerJavaApplicationPluginFixture {
 
     static void writeJettyMainClass(File projectDir) {
         File packageDir = new File(projectDir, 'src/main/java/com/bmuschko/gradle/docker/application')
-
-        if (!packageDir.mkdirs()) {
-            throw new IOException("Unable to create package directory $packageDir")
-        }
-
+        createDirectory(packageDir)
         File jettyMainClassFile = new File(packageDir, 'JettyMain.java')
         jettyMainClassFile.text = jettyMainClass()
     }
@@ -49,5 +45,17 @@ final class DockerJavaApplicationPluginFixture {
                 }
             }
         """
+    }
+
+    static void writePropertiesFile(File projectDir) {
+        File resourcesDir = new File(projectDir, 'src/main/resources')
+        createDirectory(resourcesDir)
+        new File(resourcesDir, 'my.properties').text = 'hello=world'
+    }
+
+    private static void createDirectory(File dir) {
+        if (!dir.mkdirs()) {
+            throw new IOException("Unable to create directory $dir")
+        }
     }
 }

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -19,7 +19,7 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         applyDockerJavaApplicationPluginWithoutApplicationPlugin(project)
 
         then:
-        !project.tasks.findByName(DockerJavaApplicationPlugin.SYNC_ARCHIVE_TASK_NAME)
+        !project.tasks.findByName(DockerJavaApplicationPlugin.SYNC_BUILD_CONTEXT_TASK_NAME)
         !project.tasks.findByName(DockerJavaApplicationPlugin.DOCKERFILE_TASK_NAME)
         !project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
         !project.tasks.findByName(DockerJavaApplicationPlugin.PUSH_IMAGE_TASK_NAME)
@@ -30,7 +30,7 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         applyDockerJavaApplicationPluginAndApplicationPlugin(project)
 
         then:
-        project.tasks.findByName(DockerJavaApplicationPlugin.SYNC_ARCHIVE_TASK_NAME)
+        project.tasks.findByName(DockerJavaApplicationPlugin.SYNC_BUILD_CONTEXT_TASK_NAME)
         project.tasks.findByName(DockerJavaApplicationPlugin.DOCKERFILE_TASK_NAME)
         project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
         project.tasks.findByName(DockerJavaApplicationPlugin.PUSH_IMAGE_TASK_NAME)

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ConventionPluginHelper.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ConventionPluginHelper.groovy
@@ -1,0 +1,31 @@
+package com.bmuschko.gradle.docker.utils
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.plugins.ApplicationPluginConvention
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.api.plugins.JavaPluginConvention
+import org.gradle.api.tasks.SourceSet
+import org.gradle.api.tasks.SourceSetOutput
+
+final class ConventionPluginHelper {
+
+    private ConventionPluginHelper() {}
+
+    static String getApplicationPluginName(Project project) {
+        project.convention.getPlugin(ApplicationPluginConvention).applicationName
+    }
+
+    static String getApplicationPluginMainClassName(Project project) {
+        project.convention.getPlugin(ApplicationPluginConvention).mainClassName
+    }
+
+    static SourceSetOutput getMainJavaSourceSetOutput(Project project) {
+        JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention)
+        javaConvention.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).output
+    }
+
+    static Configuration getRuntimeClasspathConfiguration(Project project) {
+        project.configurations.getByName(JavaPlugin.RUNTIME_CLASSPATH_CONFIGURATION_NAME)
+    }
+}


### PR DESCRIPTION
Layers can be cached much better than with a single layer for an archive which changes every time.

* Plugins do not have to build an archive anymore which should speed up the build time
* The image defines separate layers for libraries, resource files and class files in the order from less likely changes to the most frequent changes
* The main class name for Spring Boot application is determined automatically (which required a dependency on a Spring Boot lib)
* We could probably even get rid of dependency on the Gradle application plugin by searching for the main class name on the classpath as well
* Less clutter in the Docker registry as layers become more cacheable
* This is a breaking change and will be marked as such in the release notes

For more information see https://github.com/bmuschko/gradle-docker-plugin/issues/701