### PR TITLE
Set publishAll through hostConfig

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -167,6 +167,48 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         build('inspectStoppedContainer')
     }
 
+    def "with publishAll set, all ports get a host binding"() {
+        given:
+        def exposedPorts = [1234, 2345]
+        String containerCreationTask = """
+            task createContainer(type: DockerCreateContainer) {
+                dependsOn pullImage
+                targetImageId pullImage.getImageId()
+                autoRemove = true
+                
+                cmd = ['sleep', '10']
+                exposePorts 'tcp', $exposedPorts
+                publishAll = true
+            }
+        """
+
+        String containerInspect = '''
+            task inspectContainer(type: DockerInspectContainer) {
+                dependsOn startContainer
+                targetContainerId startContainer.getContainerId()
+                
+                onNext { container ->
+                  container.networkSettings.ports.bindings.forEach { exposedPort, bindings ->
+                    logger.quiet "$exposedPort.port -> ${bindings.first().hostPortSpec}"
+                  }
+                }
+                finalizedBy stopContainer
+            }
+        '''
+
+        buildFile << containerStart(containerCreationTask)
+        buildFile << containerStop()
+        buildFile << containerInspect
+
+        when:
+        BuildResult buildResult = build('inspectContainer')
+
+        then:
+        exposedPorts.every {
+            buildResult.output.find(/$it -> \d+/) != null
+        }
+    }
+
     static String containerStart(String containerCreationTask) {
         // Starts with the union of all needed imports.
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -185,14 +185,15 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerInspect = '''
             task inspectContainer(type: DockerInspectContainer) {
                 dependsOn startContainer
+                finalizedBy stopContainer
+
                 targetContainerId startContainer.getContainerId()
                 
                 onNext { container ->
-                  container.networkSettings.ports.bindings.forEach { exposedPort, bindings ->
-                    logger.quiet "$exposedPort.port -> ${bindings.first().hostPortSpec}"
-                  }
+                    container.networkSettings.ports.bindings.forEach { exposedPort, bindings ->
+                        logger.quiet "$exposedPort.port -> ${bindings.first().hostPortSpec}"
+                    }
                 }
-                finalizedBy stopContainer
             }
         '''
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -383,7 +383,7 @@ class DockerCreateContainer extends DockerExistingImage {
         }
 
         if(publishAll.getOrNull()) {
-            containerCommand.withPublishAllPorts(publishAll.get())
+            containerCommand.hostConfig.withPublishAllPorts(publishAll.get())
         }
 
         if(binds.getOrNull()) {


### PR DESCRIPTION
Closes #741 
This sets publishAll via hostConfig instead of directly on the create container command, as that option was removed in docker-java recently.