### PR TITLE
 Dockerfile.FileInstruction does not use flags if Dockerfile.File is passed in using a Provider (Issue #747)

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
@@ -144,6 +144,7 @@ LABEL maintainer=benjamin.muschko@gmail.com
                 environmentVariable ENV_VAR_A: 'val_a'
                 environmentVariable ENV_VAR_B: 'val_b', ENV_VAR_C: 'val_c'
                 addFile 'http://mirrors.jenkins-ci.org/war/1.563/jenkins.war', '/opt/jenkins.war'
+                addFile project.provider({new Dockerfile.File('localpath/my-file.tar', '/tmp', '--chown=user')})
                 copyFile 'http://hsql.sourceforge.net/m2-repo/com/h2database/h2/1.4.184/h2-1.4.184.jar', '/opt/h2.jar'
                 entryPoint 'java', '-jar', '/opt/jenkins.war'
                 volume '/jenkins', '/myApp'
@@ -167,6 +168,7 @@ ENV ENV_VAR_KEY envVarVal
 ENV ENV_VAR_A=val_a
 ENV ENV_VAR_B=val_b ENV_VAR_C=val_c
 ADD http://mirrors.jenkins-ci.org/war/1.563/jenkins.war /opt/jenkins.war
+ADD --chown=user localpath/my-file.tar /tmp
 COPY http://hsql.sourceforge.net/m2-repo/com/h2database/h2/1.4.184/h2-1.4.184.jar /opt/h2.jar
 ENTRYPOINT ["java", "-jar", "/opt/jenkins.war"]
 VOLUME ["/jenkins", "/myApp"]

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -1056,7 +1056,7 @@ class Dockerfile extends DefaultTask {
 
             if (file) {
                 if (file.flags) {
-                    keyword += " $flags"
+                    keyword += " $file.flags"
                 }
                 if (file.src && file.dest) {
                     "$keyword $file.src $file.dest"


### PR DESCRIPTION
closes #747

Fixes a bug where `flags` are unused in `FileInstruction`s if passed using `Provider`.
Also adds a functional test verifying this.

I did *not* add a unit test in `DockerfileTest` as this test does not have access to the gradle `Provider` factories, and directly instantiating one would be use of an internal API. However, I'm open to doing so if you think it's the right way to go.

