### PR TITLE
Shade all dependencies expect Docker Java

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -10,9 +10,6 @@ link:http://docs.docker.io/reference/api/docker_remote_api/[Docker remote API]. 
 Docker remote API is handled by the link:https://github.com/docker-java/docker-java[Docker Java library]. Please
 refer to the library's documentation for more information on the supported Docker's client API and Docker server version.
 
-[IMPORTANT]
-As of version `3.2.5` of this plugin we are using the link:https://github.com/project-aries/docker-java-shaded[docker-java-shaded] library, in favor of `docker-java`, which itself is hosted on jcenter ONLY. This means that instead of resolving the multiple, potentially conflicting, dependencies of `docker-java` we will instead resolve 1 shaded/uber/fat jar with all dependencies baked in. The dependencies/classes themselves are now located under the `com.github.dockerjava.shaded` package. Please give things a go and report back any issues found. Thanks!
-
 == Documentation
 
 Read the https://bmuschko.github.io/gradle-docker-plugin/[user guide]!

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     com.bmuschko.gradle.docker.`functional-test`
     com.bmuschko.gradle.docker.`doc-test`
     com.bmuschko.gradle.docker.`additional-artifacts`
+    com.bmuschko.gradle.docker.`shaded-artifacts`
     com.bmuschko.gradle.docker.`user-guide`
     com.bmuschko.gradle.docker.documentation
     com.bmuschko.gradle.docker.publishing
@@ -23,12 +24,8 @@ repositories {
 }
 
 dependencies {
-    implementation("com.aries:docker-java-shaded:3.1.0-rc-7:cglib@jar") {
-        setTransitive(false)
-    }
-    implementation("org.slf4j:slf4j-simple:1.7.5")
-    implementation("javax.activation:activation:1.1.1")
-    implementation("org.ow2.asm:asm:7.0")
+    shaded("com.github.docker-java:docker-java:3.1.0-rc-7")
+    shaded("org.ow2.asm:asm:7.0")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {
         exclude(group = "org.codehaus.groovy")
     }

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     implementation("org.ajoberstar:gradle-git:1.7.1")
     implementation("org.ajoberstar:gradle-git-publish:0.3.3")
     implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
+    implementation("com.github.jengelman.gradle.plugins:shadow:4.0.4")
 }
 
 kotlinDslPluginOptions {
@@ -44,6 +45,10 @@ gradlePlugin {
         register("additional-artifacts-plugin") {
             id = "com.bmuschko.gradle.docker.additional-artifacts"
             implementationClass = "com.bmuschko.gradle.docker.AdditionalArtifactsPlugin"
+        }
+        register("shaded-artifacts-plugin") {
+            id = "com.bmuschko.gradle.docker.shaded-artifacts"
+            implementationClass = "com.bmuschko.gradle.docker.ShadedArtifactsPlugin"
         }
         register("user-guide-plugin") {
             id = "com.bmuschko.gradle.docker.user-guide"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     implementation("org.ajoberstar:gradle-git:1.7.1")
     implementation("org.ajoberstar:gradle-git-publish:0.3.3")
     implementation("com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4")
-    implementation("com.github.jengelman.gradle.plugins:shadow:4.0.4")
+    implementation("com.github.jengelman.gradle.plugins:shadow:5.0.0")
 }
 
 kotlinDslPluginOptions {

--- a/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/PublishingPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/PublishingPlugin.kt
@@ -1,5 +1,6 @@
 package com.bmuschko.gradle.docker
 
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
 import com.jfrog.bintray.gradle.BintrayExtension
 import com.jfrog.bintray.gradle.BintrayPlugin
 import org.gradle.api.Plugin
@@ -27,6 +28,7 @@ class PublishingPlugin : Plugin<Project> {
 
     private
     fun Project.configurePublishingExtension() {
+        val shadowJar: ShadowJar by tasks
         val sourcesJar: Jar by tasks
         val groovydocJar: Jar by tasks
         val javadocJar: Jar by tasks
@@ -34,7 +36,7 @@ class PublishingPlugin : Plugin<Project> {
         configure<PublishingExtension> {
             publications {
                 create<MavenPublication>("mavenJava") {
-                    from(components["java"])
+                    artifact(shadowJar)
                     artifact(sourcesJar)
                     artifact(groovydocJar)
                     artifact(javadocJar)
@@ -107,9 +109,9 @@ class PublishingPlugin : Plugin<Project> {
                 version(closureOf<BintrayExtension.VersionConfig> {
                     released = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZZ").format(Date())
                     vcsTag = "v${project.version}"
-                    setAttributes(mapOf("gradle-plugin" to listOf("com.bmuschko.docker-remote-api:${packageName}",
+                    attributes = mapOf("gradle-plugin" to listOf("com.bmuschko.docker-remote-api:${packageName}",
                             "com.bmuschko.docker-java-application:${packageName}",
-                            "com.bmuschko.docker-spring-boot-application:${packageName}")))
+                            "com.bmuschko.docker-spring-boot-application:${packageName}"))
 
                     gpg(closureOf<BintrayExtension.GpgConfig> {
                         sign = true

--- a/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
@@ -1,0 +1,69 @@
+package com.bmuschko.gradle.docker
+
+import com.github.jengelman.gradle.plugins.shadow.ShadowPlugin
+import com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.TaskProvider
+import org.gradle.api.tasks.bundling.Jar
+import org.gradle.kotlin.dsl.*
+
+class ShadedArtifactsPlugin: Plugin<Project> {
+    override fun apply(project: Project): Unit = project.run {
+        applyShadowPlugin()
+        val shaded = createShadedConfiguration()
+        val shadowJar = configureShadowJarTask(shaded)
+        wireShadowJarTaskInLifecycle(shadowJar)
+    }
+
+    private
+    fun Project.applyShadowPlugin() {
+        apply<ShadowPlugin>()
+    }
+
+    private
+    fun Project.createShadedConfiguration(): Configuration {
+        val shaded by configurations.creating
+        val implementation = configurations.getByName("implementation")
+        implementation.extendsFrom(shaded)
+        return shaded
+    }
+
+    private
+    fun Project.configureShadowJarTask(shaded: Configuration): TaskProvider<ShadowJar> {
+        return tasks.named<ShadowJar>("shadowJar") {
+            classifier = null
+            configurations = listOf(shaded)
+            mergeServiceFiles()
+            val packagesToRelocate = listOf(
+                    "javassist",
+                    "org.glassfish",
+                    "org.jvnet",
+                    "jersey.repackaged",
+                    "com.fasterxml",
+                    "io.netty",
+                    "org.bouncycastle",
+                    "org.apache",
+                    "org.aopalliance",
+                    "org.scijava",
+                    "com.google",
+                    "javax.annotation",
+                    "javax.inject",
+                    "javax.ws",
+                    "net.sf",
+                    "org.objectweb"
+            )
+            for (pkg in packagesToRelocate) {
+                relocate(pkg, "com.bmuschko.gradle.docker.shaded.$pkg")
+            }
+        }
+    }
+
+    private
+    fun Project.wireShadowJarTaskInLifecycle(shadowJar: TaskProvider<ShadowJar>) {
+        val jar: Jar by tasks
+        jar.enabled = false
+        tasks["assemble"].dependsOn(shadowJar)
+    }
+}

--- a/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
@@ -32,28 +32,28 @@ class ShadedArtifactsPlugin: Plugin<Project> {
 
     private
     fun Project.configureShadowJarTask(shaded: Configuration): TaskProvider<ShadowJar> {
+        val packagesToRelocate = listOf(
+                "javassist",
+                "org.glassfish",
+                "org.jvnet",
+                "jersey.repackaged",
+                "com.fasterxml",
+                "io.netty",
+                "org.bouncycastle",
+                "org.apache",
+                "org.aopalliance",
+                "org.scijava",
+                "com.google",
+                "javax.annotation",
+                "javax.inject",
+                "javax.ws",
+                "net.sf",
+                "org.objectweb"
+        )
         return tasks.named<ShadowJar>("shadowJar") {
             classifier = null
             configurations = listOf(shaded)
             mergeServiceFiles()
-            val packagesToRelocate = listOf(
-                    "javassist",
-                    "org.glassfish",
-                    "org.jvnet",
-                    "jersey.repackaged",
-                    "com.fasterxml",
-                    "io.netty",
-                    "org.bouncycastle",
-                    "org.apache",
-                    "org.aopalliance",
-                    "org.scijava",
-                    "com.google",
-                    "javax.annotation",
-                    "javax.inject",
-                    "javax.ws",
-                    "net.sf",
-                    "org.objectweb"
-            )
             for (pkg in packagesToRelocate) {
                 relocate(pkg, "com.bmuschko.gradle.docker.shaded.$pkg")
             }


### PR DESCRIPTION
Avoids runtime classpath conflict with other plugins.

With this change the project https://github.com/project-aries/docker-java-shaded is not needed anymore saving yet another roundtrip.

@cdancy @orzeh Please publish locally and test with your own projects.