### PR TITLE
Bumped slf4j-simple

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ dependencies {
     implementation("com.aries:docker-java-shaded:3.1.0-rc-7:cglib@jar") {
         setTransitive(false)
     }
-    implementation("org.slf4j:slf4j-simple:1.7.5")
+    implementation("org.slf4j:slf4j-simple:1.7.26")
     implementation("javax.activation:activation:1.1.1")
     implementation("org.ow2.asm:asm:7.0")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {


### PR DESCRIPTION
Catching up on about six years of updates of SLF4J. This also resolves warnings resulting from the versions gradle  plugin about available updates in projects that depend on this plugin.