### PR TITLE
#766 Only consider .class files when searching for main class

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
@@ -123,7 +123,7 @@ class MainClassFinder {
         stack.push(rootFolder)
         while (!stack.isEmpty()) {
             File file = stack.pop()
-            if (file.isFile()) {
+            if (file.isFile() && file.name.endsWith('.class')) {
                 InputStream inputStream = new FileInputStream(file)
                 ClassDescriptor classDescriptor = createClassDescriptor(inputStream)
                 if (classDescriptor != null && classDescriptor.isMainMethodFound()) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
@@ -138,13 +138,13 @@ class MainClassFinder {
                 pushAllSorted(stack, file.listFiles(new FileFilter() {
                     @Override
                     boolean accept(File pathname) {
-                        file.isDirectory() && !file.getName().startsWith(".")
+                        pathname.isDirectory() && !pathname.getName().startsWith(".")
                     }
                 }))
                 pushAllSorted(stack, file.listFiles(new FileFilter() {
                     @Override
                     boolean accept(File pathname) {
-                        file.isFile() && file.getName().endsWith(DOT_CLASS)
+                        pathname.isFile() && pathname.getName().endsWith(DOT_CLASS)
                     }
                 }))
             }

--- a/src/test/groovy/com/bmuschko/gradle/docker/utils/MainClassFinderTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/utils/MainClassFinderTest.groovy
@@ -56,4 +56,16 @@ class MainClassFinderTest extends Specification {
         then:
         !mainClass
     }
+
+    def "only consider .class files"() {
+        given:
+        testJarFile.addClass('a/b/c/E.class', AnnotatedClassWithMainMethod)
+        new File(testJarFile.jarSource, 'noClass.txt').createNewFile()
+
+        when:
+        MainClassFinder.findSingleMainClass(testJarFile.getJarSource(), ANNOTATION_CLASS_NAME)
+
+        then:
+        noExceptionThrown()
+    }
 }

--- a/src/test/groovy/com/bmuschko/gradle/docker/utils/MainClassFinderTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/utils/MainClassFinderTest.groovy
@@ -63,9 +63,9 @@ class MainClassFinderTest extends Specification {
         new File(testJarFile.jarSource, 'noClass.txt').createNewFile()
 
         when:
-        MainClassFinder.findSingleMainClass(testJarFile.getJarSource(), ANNOTATION_CLASS_NAME)
+        String mainClass = MainClassFinder.findSingleMainClass(testJarFile.getJarSource(), ANNOTATION_CLASS_NAME)
 
         then:
-        noExceptionThrown()
+        mainClass == 'a.b.c.E'
     }
 }


### PR DESCRIPTION
closes #766 

This fixes an ArrayIndexOutOfBoundsException when executing the `dockerBuildImage` task in a Kotlin project. This issue was caused by trying to create a ClassDescriptor from build/classes/kotlin/main/META-INF/<project_name>.kotlin_module. Which fails, because it's not a class file. It's a file used by the Kotlin compiler and Kotlin reflection.