### PR TITLE
Check the correct file in the pushAllSorted FileFilters

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
@@ -123,7 +123,7 @@ class MainClassFinder {
         stack.push(rootFolder)
         while (!stack.isEmpty()) {
             File file = stack.pop()
-            if (file.isFile() && file.name.endsWith(DOT_CLASS)) {
+            if (file.isFile()) {
                 InputStream inputStream = new FileInputStream(file)
                 ClassDescriptor classDescriptor = createClassDescriptor(inputStream)
                 if (classDescriptor != null && classDescriptor.isMainMethodFound()) {
@@ -138,13 +138,13 @@ class MainClassFinder {
                 pushAllSorted(stack, file.listFiles(new FileFilter() {
                     @Override
                     boolean accept(File pathname) {
-                        file.isDirectory() && !file.getName().startsWith(".")
+                        pathname.isDirectory() && !pathname.getName().startsWith(".")
                     }
                 }))
                 pushAllSorted(stack, file.listFiles(new FileFilter() {
                     @Override
                     boolean accept(File pathname) {
-                        file.isFile() && file.getName().endsWith(DOT_CLASS)
+                        pathname.isFile() && pathname.getName().endsWith(DOT_CLASS)
                     }
                 }))
             }


### PR DESCRIPTION
This fix makes sure the FileFilters that are used to created the stack with class files to consider when searching for a main class are working properly. This makes the .class check for the files on the stack unnecessary.

This is the intended solution to fix #766.