### PR TITLE
Rename timeout properties to waitTime so as not to clobber the exiting timeout property on gradles Task.

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerRestartContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerRestartContainer.groovy
@@ -27,15 +27,15 @@ class DockerRestartContainer extends DockerExistingContainer {
      */
     @Input
     @Optional
-    final Property<Integer> timeout = project.objects.property(Integer)
+    final Property<Integer> waitTime = project.objects.property(Integer)
 
     @Override
     void runRemoteCommand(DockerClient dockerClient) {
         logger.quiet "Restarting container with ID '${containerId.get()}'."
         RestartContainerCmd restartContainerCmd = dockerClient.restartContainerCmd(containerId.get())
 
-        if(timeout.getOrNull()) {
-            restartContainerCmd.withtTimeout(timeout.get())
+        if(waitTime.getOrNull()) {
+            restartContainerCmd.withtTimeout(waitTime.get())
         }
 
         restartContainerCmd.exec()

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStopContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerStopContainer.groovy
@@ -28,18 +28,17 @@ class DockerStopContainer extends DockerExistingContainer {
      */
     @Input
     @Optional
-    final Property<Integer> timeout = project.objects.property(Integer)
+    final Property<Integer> waitTime = project.objects.property(Integer)
 
     @Override
     void runRemoteCommand(DockerClient dockerClient) {
         logger.quiet "Stopping container with ID '${containerId.get()}'."
-        _runRemoteCommand(dockerClient, containerId.get(), timeout.getOrNull())
+        _runRemoteCommand(dockerClient, containerId.get(), waitTime.getOrNull())
     }
 
     // overloaded method used by sub-classes and ad-hoc processes
     static void _runRemoteCommand(DockerClient dockerClient, String containerId, Integer optionalTimeout) {
         StopContainerCmd stopContainerCmd = dockerClient.stopContainerCmd(containerId)
-
         if(optionalTimeout) {
             stopContainerCmd.withTimeout(optionalTimeout)
         }


### PR DESCRIPTION
More fallout from: https://docs.gradle.org/5.0/userguide/more_about_tasks.html#sec:task_timeouts