### PR TITLE
Expose extension property for configuring JVM arguments

### DIFF
--- a/src/docs/asciidoc/12-extension.adoc
+++ b/src/docs/asciidoc/12-extension.adoc
@@ -6,18 +6,9 @@ The following properties can be configured:
 [options="header"]
 |=======
 |Property name      |Type                |Default value              |Description
-|`url`              |`Property<String>`  |see below                  |The server URL to connect to via Docker's remote API.
-|`certPath`         |`DirectoryProperty` |`null`                     |The path to certificates for communicating with https://docs.docker.com/articles/https/[Docker over SSL].
-|`apiVersion`       |`Property<String>`            |`null`                     |The remote API version. For most cases this can be left null.
-|=======
-
-The default value is now generated based on a best guess attempt given the {uri-github}/blob/master/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy#L42[operating system and environment]:
-
-[options="header"]
-|=======
-|Operating system                            | Value
-|Unix-based machine                          | `unix:///var/run/docker.sock`
-|Windows-based machine (and everything else) | `tcp://127.0.0.1:2375`
+|`url`              |`Property<String>`  |`unix:///var/run/docker.sock` (Unix), `tcp://127.0.0.1:2375` (Windows)                  |The server URL to connect to via Docker's remote API.
+|`certPath`         |`DirectoryProperty` |Value of environment variable `DOCKER_CERT_PATH` if set                     |The path to certificates for communicating with https://docs.docker.com/articles/https/[Docker over SSL].
+|`apiVersion`       |`Property<String>`            |`null`                     |The https://docs.docker.com/develop/sdk/#view-the-api-reference[remote API version]. For most cases this can be left null.
 |=======
 
 Image pull or push operations against the public Docker Hub registry or a private registry may require authentication.

--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -6,8 +6,8 @@ The plugin defines an extension with the namespace `javaApplication` as a child 
 |=======
 |Property name   |Type                               |Default value                                            |Description
 |`baseImage`     |`Property<String>`                 |`openjdk:jre-alpine`                                     |The Docker base image used for Java application.
-|`exec`          |`Action<CompositeExecInstruction>` |-                                                        |Specifies the definitive ENTRYPOINT and/or CMD Dockerfile instructions
-|`ports`         |`ListProperty<Integer>`            |`[8080]`                                                     |The Docker image exposed ports (if provided, this values will override `port` configuration property)
+|`exec`          |`Action<CompositeExecInstruction>` |-                                                        |Specifies the definitive ENTRYPOINT and/or CMD Dockerfile instructions.
+|`ports`         |`ListProperty<Integer>`            |`[8080]`                                                     |The Docker image exposed ports.
 |`tag`           |`Property<String>`                 |`<project.group>/<applicationName>:<project.version>`    |The tag used for the Docker image.
 |=======
 

--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -9,7 +9,7 @@ The plugin defines an extension with the namespace `javaApplication` as a child 
 |`exec`          |`Action<CompositeExecInstruction>` |-                                                        |Specifies the definitive ENTRYPOINT and/or CMD Dockerfile instructions.
 |`ports`         |`ListProperty<Integer>`            |`[8080]`                                                 |The Docker image exposed ports.
 |`tag`           |`Property<String>`                 |`<project.group>/<applicationName>:<project.version>`    |The tag used for the Docker image.
-|`jvmArgs`       |`ListProperty<String>`             |empty                                                    |The JVM arguments passed to the `java` command.
+|`jvmArgs`       |`ListProperty<String>`             |`[]`                                                     |The JVM arguments passed to the `java` command.
 |=======
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -7,8 +7,9 @@ The plugin defines an extension with the namespace `javaApplication` as a child 
 |Property name   |Type                               |Default value                                            |Description
 |`baseImage`     |`Property<String>`                 |`openjdk:jre-alpine`                                     |The Docker base image used for Java application.
 |`exec`          |`Action<CompositeExecInstruction>` |-                                                        |Specifies the definitive ENTRYPOINT and/or CMD Dockerfile instructions.
-|`ports`         |`ListProperty<Integer>`            |`[8080]`                                                     |The Docker image exposed ports.
+|`ports`         |`ListProperty<Integer>`            |`[8080]`                                                 |The Docker image exposed ports.
 |`tag`           |`Property<String>`                 |`<project.group>/<applicationName>:<project.version>`    |The tag used for the Docker image.
+|`jvmArgs`       |`ListProperty<String>`             |empty                                                    |The JVM arguments passed to the `java` command.
 |=======
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/docs/asciidoc/32-extension.adoc
+++ b/src/docs/asciidoc/32-extension.adoc
@@ -9,7 +9,7 @@ The following properties can be configured:
 |`baseImage`     |`Property<String>`      |`openjdk:jre-alpine`                               |The Docker base image used for the Spring Boot application.
 |`ports`         |`ListProperty<Integer>` |`[8080]`                                           |The Docker image exposed ports.
 |`tag`           |`Property<String>`      |`<project.group>/<project.name>:<project.version>` |The tag used for the Docker image.
-|`jvmArgs`       |`ListProperty<String>`  |empty                                              |The JVM arguments passed to the `java` command.
+|`jvmArgs`       |`ListProperty<String>`  |`[]`                                               |The JVM arguments passed to the `java` command.
 |=======
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/docs/asciidoc/32-extension.adoc
+++ b/src/docs/asciidoc/32-extension.adoc
@@ -9,6 +9,7 @@ The following properties can be configured:
 |`baseImage`     |`Property<String>`      |`openjdk:jre-alpine`                               |The Docker base image used for the Spring Boot application.
 |`ports`         |`ListProperty<Integer>` |`[8080]`                                           |The Docker image exposed ports.
 |`tag`           |`Property<String>`      |`<project.group>/<project.name>:<project.version>` |The tag used for the Docker image.
+|`jvmArgs`       |`ListProperty<String>`  |empty                                              |The JVM arguments passed to the `java` command.
 |=======
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
@@ -13,6 +13,7 @@ docker {
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         ports = [9090, 5701]
         tag = 'jettyapp:1.115'
+        jvmArgs = ['-Xms256m', '-Xmx2048m']
     }
 }
 // end::extension[]

--- a/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
@@ -15,6 +15,7 @@ docker {
         maintainer.set("Benjamin Muschko 'benjamin.muschko@gmail.com'")
         ports.set(listOf(9090, 5701))
         tag.set("jettyapp:1.115")
+        jvmArgs.set(listOf("-Xms256m", "-Xmx2048m"))
     }
 }
 // end::extension[]

--- a/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
@@ -12,6 +12,7 @@ docker {
         baseImage = 'openjdk:8-alpine'
         ports = [9090, 8080]
         tag = 'awesome-spring-boot:1.115'
+        jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
     }
 }
 // end::extension[]

--- a/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
@@ -12,6 +12,7 @@ docker {
         baseImage.set("openjdk:8-alpine")
         ports.set(listOf(9090, 8080))
         tag.set("awesome-spring-boot:1.115")
+        jvmArgs.set(listOf("-Dspring.profiles.active=production", "-Xmx2048m"))
     }
 }
 // end::extension[]

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -339,13 +339,8 @@ WORKDIR /app
         }
 
         dockerfileContent += """COPY classes classes/
-ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmuschko.gradle.docker.application.JettyMain"]
+ENTRYPOINT ${buildEntrypoint(expectedDockerfile.jmvArgs).collect { '"' + it + '"'}}
 """
-
-        if (!expectedDockerfile.jmvArgs.empty) {
-            dockerfileContent += """CMD ["${expectedDockerfile.jmvArgs.join('", "')}"]
-"""
-        }
 
         if (!expectedDockerfile.exposedPorts.isEmpty()) {
             dockerfileContent += """EXPOSE ${expectedDockerfile.exposedPorts.join(' ')}
@@ -353,6 +348,17 @@ ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmusc
         }
 
         dockerfileContent
+    }
+
+    private static List<String> buildEntrypoint(List<String> jvmArgs) {
+        List<String> entrypoint = ["java"]
+
+        if (!jvmArgs.empty) {
+            entrypoint.addAll(jvmArgs)
+        }
+
+        entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmuschko.gradle.docker.application.JettyMain"])
+        entrypoint
     }
 
     private void assertBuildContextLibs() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -214,13 +214,8 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
 WORKDIR /app
 COPY libs libs/
 COPY classes classes/
-ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmuschko.gradle.docker.springboot.Application"]
+ENTRYPOINT ${buildEntrypoint(jvmArgs).collect { '"' + it + '"'} }
 """
-
-        if (!jvmArgs.empty) {
-            dockerFileContent += """CMD ["${jvmArgs.join('", "')}"]
-"""
-        }
 
         if(!ports.empty) {
             dockerFileContent += """EXPOSE ${ports.join(' ')}
@@ -228,5 +223,16 @@ ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmusc
         }
 
         dockerFileContent
+    }
+
+    private static List<String> buildEntrypoint(List<String> jvmArgs) {
+        List<String> entrypoint = ["java"]
+
+        if (!jvmArgs.empty) {
+            entrypoint.addAll(jvmArgs)
+        }
+
+        entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmuschko.gradle.docker.springboot.Application"])
+        entrypoint
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
@@ -25,8 +25,24 @@ import org.gradle.api.provider.Property
 @CompileStatic
 class DockerExtension {
     private final Logger logger = Logging.getLogger(DockerExtension)
+
+    /**
+     * The server URL to connect to via Docker’s remote API.
+     * <p>
+     * Defaults to {@code unix:///var/run/docker.sock} for Unix systems and {@code tcp://127.0.0.1:2375} for Windows systems.
+     */
     final Property<String> url
+
+    /**
+     * The path to certificates for communicating with Docker over SSL.
+     * <p>
+     * Defaults to value of environment variable {@code DOCKER_CERT_PATH} if set.
+     */
     final DirectoryProperty certPath
+
+    /**
+     * The remote API version. For most cases this can be left null.
+     */
     final Property<String> apiVersion
 
     DockerExtension(ObjectFactory objectFactory) {
@@ -43,7 +59,7 @@ class DockerExtension {
         apiVersion = objectFactory.property(String)
     }
 
-    String getDefaultDockerUrl() {
+    private String getDefaultDockerUrl() {
         String dockerUrl = System.getenv("DOCKER_HOST")
         if (!dockerUrl) {
             boolean isWindows = System.getProperty("os.name").toLowerCase().contains("win")
@@ -67,7 +83,7 @@ class DockerExtension {
         dockerUrl
     }
 
-    File getDefaultDockerCert() {
+    private File getDefaultDockerCert() {
         String dockerCertPath = System.getenv("DOCKER_CERT_PATH")
         if(dockerCertPath) {
             File certFile = new File(dockerCertPath)

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -27,10 +27,38 @@ import org.gradle.api.tasks.Nested
 
 @CompileStatic
 class DockerJavaApplication {
+    /**
+     * The Docker base image used for Java application.
+     * <p>
+     * Defaults to {@code openjdk:jre-alpine}.
+     */
     final Property<String> baseImage
+
+    /**
+     * The maintainer of the image.
+     * <p>
+     * Defaults to the value of the system property {@code user.name}.
+     */
     final Property<String> maintainer
+
+    /**
+     * The Docker image exposed ports.
+     * <p>
+     * Defaults to {@code [8080]}.
+     */
     final ListProperty<Integer> ports
+
+    /**
+     * The tag used for the Docker image.
+     * <p>
+     * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
+     */
     final Property<String> tag
+
+    /**
+     * The JVM arguments used to start the Java program.
+     */
+    final ListProperty<String> jvmArgs
 
     private final CompositeExecInstruction compositeExecInstruction
 
@@ -42,15 +70,27 @@ class DockerJavaApplication {
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
         tag = objectFactory.property(String)
+        jvmArgs = objectFactory.listProperty(String).empty()
         compositeExecInstruction = new CompositeExecInstruction(objectFactory)
     }
 
+    /**
+     * Specifies the definitive ENTRYPOINT and/or CMD Dockerfile instructions.
+     *
+     * @param action Action
+     * @return The instruction
+     */
     CompositeExecInstruction exec(Action<CompositeExecInstruction> action) {
         compositeExecInstruction.clear()
         action.execute(compositeExecInstruction)
         return compositeExecInstruction
     }
 
+    /**
+     * Returns the definitive ENTRYPOINT and/or CMD Dockerfile instructions.
+     *
+     * @return The instruction
+     */
     CompositeExecInstruction getExecInstruction() {
         compositeExecInstruction
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -113,6 +113,7 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
                     }))
                     copyFile('classes', 'classes/')
                     instructions.add(dockerJavaApplication.execInstruction)
+                    defaultCommand(dockerJavaApplication.jvmArgs)
                     exposePort(dockerJavaApplication.ports)
                 }
             }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -58,7 +58,15 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
                     compositeExecInstruction.entryPoint(project.provider(new Callable<List<String>>() {
                         @Override
                         List<String> call() throws Exception {
-                            ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", getApplicationPluginMainClassName(project)]
+                            List<String> entrypoint = ["java"]
+                            List<String> jvmArgs = dockerJavaApplication.jvmArgs.get()
+
+                            if (!jvmArgs.empty) {
+                                entrypoint.addAll(jvmArgs)
+                            }
+
+                            entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", getApplicationPluginMainClassName(project)])
+                            entrypoint
                         }
                     }))
                 }
@@ -113,7 +121,6 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
                     }))
                     copyFile('classes', 'classes/')
                     instructions.add(dockerJavaApplication.execInstruction)
-                    defaultCommand(dockerJavaApplication.jvmArgs)
                     exposePort(dockerJavaApplication.ports)
                 }
             }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
@@ -10,9 +10,31 @@ import org.gradle.api.provider.Property
  */
 @CompileStatic
 class DockerSpringBootApplication {
+    /**
+     * The Docker base image used for the Spring Boot application.
+     * <p>
+     * Defaults to {@code openjdk:jre-alpine}.
+     */
     final Property<String> baseImage
+
+    /**
+     * The Docker image exposed ports.
+     * <p>
+     * Defaults to {@code [8080]}.
+     */
     final ListProperty<Integer> ports
+
+    /**
+     * The tag used for the Docker image.
+     * <p>
+     * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
+     */
     final Property<String> tag
+
+    /**
+     * The JVM arguments used to start the Java program.
+     */
+    final ListProperty<String> jvmArgs
 
     DockerSpringBootApplication(ObjectFactory objectFactory) {
         baseImage = objectFactory.property(String)
@@ -20,5 +42,6 @@ class DockerSpringBootApplication {
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
         tag = objectFactory.property(String)
+        jvmArgs = objectFactory.listProperty(String).empty()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
@@ -118,10 +118,17 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
                     entryPoint(project.provider(new Callable<List<String>>() {
                         @Override
                         List<String> call() throws Exception {
-                            ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", getSpringApplicationMainClassName(project)]
+                            List<String> entrypoint = ["java"]
+                            List<String> jvmArgs = dockerSpringBootApplication.jvmArgs.get()
+
+                            if (!jvmArgs.empty) {
+                                entrypoint.addAll(jvmArgs)
+                            }
+
+                            entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", getSpringApplicationMainClassName(project)])
+                            entrypoint
                         }
                     }))
-                    defaultCommand(dockerSpringBootApplication.jvmArgs)
                     exposePort(dockerSpringBootApplication.ports)
                 }
             }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
@@ -121,6 +121,7 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
                             ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", getSpringApplicationMainClassName(project)]
                         }
                     }))
+                    defaultCommand(dockerSpringBootApplication.jvmArgs)
                     exposePort(dockerSpringBootApplication.ports)
                 }
             }


### PR DESCRIPTION
Essentially passes the JVM arguments to `java` command in the generated Dockerfile (see https://github.com/bmuschko/gradle-docker-plugin/issues/761). This PR also adds more Javadocs to the extensions.