### PR TITLE
Avoid memory leakage by replacing addShutdownHook with Gradle.buildFinished

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -160,11 +160,10 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
         // Create client
         DockerClient dockerClient = DockerClientBuilder.getInstance(dockerClientConfig).build()
 
-        // register shutdown-hook to close kubernetes client.
-        addShutdownHook {
+        // register buildFinished-hook to close kubernetes client.
+        project.gradle.buildFinished {
             dockerClient.close()
         }
-
         dockerClient
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -160,7 +160,7 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
         // Create client
         DockerClient dockerClient = DockerClientBuilder.getInstance(dockerClientConfig).build()
 
-        // register buildFinished-hook to close kubernetes client.
+        // register buildFinished-hook to close docker client.
         project.gradle.buildFinished {
             dockerClient.close()
         }


### PR DESCRIPTION
This PR fixes #809 

Replacing the `addShutdownHook` by a `Gradle.buildFinished` hook we can ensure the references is removed once the build has finished.

**On CI testing (currently using travis)**

Code will not be reviewed until CI passes.

**On automtatic closing of ISSUES**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).