### PR TITLE
#760: add parameter "target" to buildimage task

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -102,7 +102,14 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         BuildResult result = build('buildTarget')
 
         then:
+        noExceptionThrown()
+        // check the output for the built stages
+        result.output.contains("Step 2/4 : LABEL maintainer=\"stage1")
+        result.output.contains("Step 4/4 : LABEL maintainer=\"stage2")
+        result.output.contains("Removing intermediate container")
         result.output.contains("Successfully built")
+        //stage3 was not called
+        ! result.output.contains("stage3")
     }
 
     def "can build image using --cache-from with nothing in the cache"() {
@@ -514,6 +521,9 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
                 from '$TEST_IMAGE_WITH_TAG', 'stage2'
                 label(['maintainer': 'stage2 - ${UUID.randomUUID().toString()}'])
+
+                from '$TEST_IMAGE_WITH_TAG', 'stage3'
+                label(['maintainer': 'stage3 - ${UUID.randomUUID().toString()}'])
             }
             
             task buildTarget(type: DockerBuildImage) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -126,7 +126,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
      * Output file containing the image ID of the built image. 
      * Defaults to "$buildDir/.docker/$taskpath-imageId.txt".
      * If path contains ':' it will be replaced by '_'.
-     * @since 4.9.0
+     * @since 4.10.0
      */
     @OutputFile
     @PathSensitive(PathSensitivity.RELATIVE)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -109,6 +109,15 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     final Property<Long> shmSize = project.objects.property(Long)
 
     /**
+     * With this parameter it is possible to build a special
+     * stage in a multi stage Docker file. This is available with Docker 17.05
+     * @since 4.9.0
+     */
+    @Input
+    @Optional
+    final Property<String> target = project.objects.property(String)
+
+    /**
      * {@inheritDoc}
      */
     DockerRegistryCredentials registryCredentials
@@ -197,6 +206,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
         if(shmSize.getOrNull() != null) { // 0 is valid input
             buildImageCmd.withShmsize(shmSize.get())
+        }
+
+        if(target.getOrNull() != null) {
+            buildImageCmd.withTarget(target.get())
         }
 
         if (registryCredentials) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -111,7 +111,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     /**
      * With this parameter it is possible to build a special
      * stage in a multi stage Docker file. This is available with Docker 17.05
-     * @since 4.9.0
+     * @since 4.10.0
      */
     @Input
     @Optional
@@ -126,7 +126,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
      * Output file containing the image ID of the built image. 
      * Defaults to "$buildDir/.docker/$taskpath-imageId.txt".
      * If path contains ':' it will be replaced by '_'.
-     * @since 4.10.0
+     * @since 4.9.0
      */
     @OutputFile
     @PathSensitive(PathSensitivity.RELATIVE)


### PR DESCRIPTION
Add a parameter "target" to build image task. A test for this new parameter was added to functional tests. 
The parameter "target" is used to build an image from a multistage Dockerfile with different stages.

closes #760