### PR TITLE
Set the dockerFile property in the constructor to update cache key

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -53,7 +53,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
     /**
      * The Dockerfile to use to build the image.  If null, will use 'Dockerfile' in the
-     * build context, i.e. "$inputDir/Dockerfile".
+     * build context, i.e. "$inputDir/Dockerfile". It must be within inputDir.
      */
     @InputFile
     @PathSensitive(PathSensitivity.RELATIVE)


### PR DESCRIPTION
#814 
Set the dockerFile property in the constructor to update cache key

* Remove the @Optional annotation since always set in constructor
* Remove logic in the execution that checks for dockerFile since always set