### PR TITLE
Add property buildLabels to add build info to image

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -142,6 +142,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             if(file.exists()) {
                 try {
                     getDockerClient().inspectImageCmd(file.text).exec()
+                    imageId.set(file.text)
                     return true
                 } catch (DockerException e) {
                     return false


### PR DESCRIPTION
#816 
Adding labels into this property will not invalidate the cache key.
It might be useful to add manifest information without trigerring
a new build every time.
But when a build is triggered, the information goes in.

