### PR TITLE
Always set imageId within DockerBuildImage on success (#818)

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -177,7 +177,9 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             File file = imageIdFile.get().asFile
             if(file.exists()) {
                 try {
-                    getDockerClient().inspectImageCmd(file.text).exec()
+                    def fileImageId = file.text
+                    getDockerClient().inspectImageCmd(fileImageId).exec()
+                    imageId.set(fileImageId)
                     return true
                 } catch (DockerException e) {
                     return false


### PR DESCRIPTION
 - Add a unit test that exposes the issue when the DockerBuildImage
   task is considered up to date an another task attempts to fetch
   the imageId value.
 - When the task is considered up-to-date, use the image id that was
   persisted to the file to set the value of imageId and return to
   other tasks to use it

closes #818 