### PR TITLE
imageId must be set when task is up-to-date

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -151,6 +151,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             if(file.exists()) {
                 try {
                     getDockerClient().inspectImageCmd(file.text).exec()
+                    imageId.set(file.text)
                     return true
                 } catch (DockerException e) {
                     return false


### PR DESCRIPTION
Related to #818 
