### PR TITLE
Fix DockerBuildImageFunctionalTest failing when re-executing them

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -326,7 +326,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task dockerfile(type: Dockerfile) {
                 from '$TEST_IMAGE_WITH_TAG'
-                runCommand('pwd')
+                runCommand("echo ${UUID.randomUUID()}")
             }
 
             task buildImage(type: DockerBuildImage) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -382,7 +382,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task dockerfile(type: Dockerfile) {
                 from '$TEST_IMAGE_WITH_TAG'
             }
-            
+
             task buildImage(type: DockerBuildImage) {
                 dependsOn dockerfile
                 labels = ['label1':'test1', 'label2':'test2', 'label3':"\$project.name"]
@@ -410,7 +410,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 dependsOn dockerfile
                 tags = ['test/image:123', "registry.com:5000/test/image:\$project.version"]
             }
-            
+
             task buildImageWithTag(type: DockerBuildImage) {
                 dependsOn dockerfile
                 tags.add('test/image:123')
@@ -521,17 +521,17 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 from '$TEST_IMAGE_WITH_TAG', 'stage3'
                 label(['maintainer': 'stage3'])
             }
-            
+
             task buildTarget(type: DockerBuildImage) {
                 dependsOn dockerfile
                 target = "stage2"
             }
-            
+
             task removeImage(type: DockerRemoveImage) {
                 force = true
                 targetImageId buildTarget.getImageId()
             }
-            
+
             buildTarget.finalizedBy tasks.removeImage
         """
     }


### PR DESCRIPTION
When re-executing the tests for the seconds time, the test "task not
up-to-date when image not in registry" was failing with the following
error:
```
Task :removeImage FAILED
Removing image with ID 'd90aa9bfe0e6'.

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':removeImage'.
> {"message":"conflict: unable to delete d90aa9bfe0e6 (cannot be forced) - image has dependent child images"}
```

The problem was that the tests are interfering with each other because
the images created were not unique. Make sure the image definition
created by imageCreation() method will be unique by adding a layer which
echo a UUID.