### PR TITLE
Fix intermittent test failure within DockerCreateContainerFunctionalTest

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -144,6 +144,10 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
                 dependsOn pullImage
                 targetImageId pullImage.getImageId()
                 autoRemove = true
+
+                // The sleep is to keep the container around to avoid the
+                // stopContainer task failing due to the container not existing.
+                cmd = ['sleep', '2']
             }
         """
 


### PR DESCRIPTION
Within the ci system occasionally the "with autoRemove set, the
container is removed after stopping" test would fail with a
NullPointerException

```
... > with autoRemove set, the container is removed after stopping FAILED
org.spockframework.runtime.ConditionFailedWithExceptionError at DockerCreateContainerFunctionalTest.groovy:170
Caused by: java.lang.NullPointerException at DockerCreateContainerFunctionalTest.groovy:170
```

The problem was a race condition, if the container was removed prior
to the stopContainer task being executed, it would fail and the
inspectStoppedContainer task would never be executed hence the
result.task('inspectStoppedContainer') returning null.

Repeated executions of the test also exposed that the docker-java api
throws NotFoundException or NotModifiedException. The
NotModifiedException as has a null message which nullifies any easier
string comparision on the exception's message and why we check for the
exceptions using instanceof checks.