### PR TITLE
Replace usage of deprecated DefaultTask.newOutputFile method

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -173,7 +173,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
      */
     @OutputFile
     @PathSensitive(PathSensitivity.RELATIVE)
-    final RegularFileProperty imageIdFile = newOutputFile()
+    final RegularFileProperty imageIdFile = project.objects.fileProperty()
 
     /**
      * The id of the image built.


### PR DESCRIPTION
Resolves #831
