### PR TITLE
Make Dockerfile.ItemJoinerUtil inner class static

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -1073,7 +1073,7 @@ class Dockerfile extends DefaultTask {
         }
     }
 
-    private class ItemJoinerUtil {
+    private static class ItemJoinerUtil {
         private static boolean isUnquotedStringWithWhitespaces(String str) {
             return !str.matches('["].*["]') &&
                 str.matches('.*(?: |(?:\r?\n)).*')


### PR DESCRIPTION
This inner class does not use any variables from the outer so it can be
made static. Eclipse report this as an error to have static methods in a
inner class that is not static.