### PR TITLE
ISSUE-834: Add multiple tags support application plugins

### DIFF
--- a/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
@@ -12,7 +12,7 @@ docker {
         baseImage = 'dockerfile/java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         ports = [9090, 5701]
-        tag = 'jettyapp:1.115'
+        tags = ['jettyapp:1.115']
         jvmArgs = ['-Xms256m', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ docker {
         baseImage.set("dockerfile/java:openjdk-7-jre")
         maintainer.set("Benjamin Muschko 'benjamin.muschko@gmail.com'")
         ports.set(listOf(9090, 5701))
-        tag.set("jettyapp:1.115")
+        tags.set(listOf("jettyapp:1.115"))
         jvmArgs.set(listOf("-Xms256m", "-Xmx2048m"))
     }
 }

--- a/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage = 'openjdk:8-alpine'
         ports = [9090, 8080]
-        tag = 'awesome-spring-boot:1.115'
+        tags = ['awesome-spring-boot:1.115']
         jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage.set("openjdk:8-alpine")
         ports.set(listOf(9090, 8080))
-        tag.set("awesome-spring-boot:1.115")
+        tags.set(listOf("awesome-spring-boot:1.115"))
         jvmArgs.set(listOf("-Dspring.profiles.active=production", "-Xmx2048m"))
     }
 }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -44,7 +44,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090]
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                     jvmArgs = ['-Xms256m', '-Xmx2048m']
                 }
             }
@@ -67,7 +67,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090, 8080]
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                 }
             }
         """
@@ -89,7 +89,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = []
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                 }
             }
         """
@@ -124,7 +124,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090]
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                 }
             }
         """
@@ -165,7 +165,7 @@ ADD file2.txt /other/dir/file2.txt
 
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = "\${docker.registryCredentials.username.get()}/javaapp".toString() 
+                    tags = [ "\${docker.registryCredentials.username.get()}/javaapp".toString() ]
                 }
             }
         """
@@ -186,7 +186,7 @@ ADD file2.txt /other/dir/file2.txt
             docker {
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = '${TestConfiguration.dockerPrivateRegistryDomain}/javaapp'
+                    tags = ['${TestConfiguration.dockerPrivateRegistryDomain}/javaapp']
                 }
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -47,7 +47,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090, 8080]
-                    tag = 'awesome-spring-boot:1.115'
+                    tags = ['awesome-spring-boot:1.115']
                     jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
                 }
             }
@@ -75,7 +75,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     ports = []
-                    tag = 'awesome-spring-boot:1.115'
+                    tags = ['awesome-spring-boot:1.115']
                 }
             }
         """
@@ -109,7 +109,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
 
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = "\${docker.registryCredentials.username.get()}/springbootapp".toString()
+                    tags = ["\${docker.registryCredentials.username.get()}/springbootapp".toString()]
                 }
             }
         """
@@ -136,7 +136,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
             docker {
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = '${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp'
+                    tags = ['${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp']
                 }
             }
         """

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -111,7 +111,7 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         when:
         ExtensionAware dockerExtension = (ExtensionAware) project.extensions.getByType(DockerExtension)
         DockerJavaApplication dockerJavaApplicationExtension = dockerExtension.extensions.getByType(DockerJavaApplication)
-        dockerJavaApplicationExtension.tag.set("some-test-tag")
+        dockerJavaApplicationExtension.tags.set(["some-test-tag"])
 
         then:
         DockerBuildImage task = project
@@ -128,13 +128,30 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         applyDockerJavaApplicationPluginAndApplicationPlugin(project)
         when:
         project.docker.javaApplication {
-            tag.set(testTagName)
+            tags.set([testTagName])
         }
         then:
         DockerBuildImage task = project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
         Set<String> tags = task.tags.get()
         tags.size() == 1
         tags.first() == testTagName
+    }
+
+    def "Can configure the dockerJava.javaApplication extension dynamically and set multiple tags"() {
+        given:
+        String testTagName1 = "some-test-tag"
+        String testTagName2 = "another-test-tag"
+        applyDockerJavaApplicationPluginAndApplicationPlugin(project)
+        when:
+        project.docker.javaApplication {
+            tags.set([testTagName1, testTagName2])
+        }
+        then:
+        DockerBuildImage task = project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
+        Set<String> tags = task.tags.get()
+        tags.size() == 2
+        tags.contains(testTagName1)
+        tags.contains(testTagName2)
     }
 
     private void applyDockerJavaApplicationPluginWithoutApplicationPlugin(Project project) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -64,11 +64,11 @@ class DockerJavaApplication {
     final ListProperty<Integer> ports
 
     /**
-     * The tag used for the Docker image.
+     * The tags used for the Docker image.
      * <p>
-     * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
+     * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
      */
-    final Property<String> tag
+    final ListProperty<String> tags
 
     /**
      * The JVM arguments used to start the Java program.
@@ -86,7 +86,7 @@ class DockerJavaApplication {
         maintainer.set(System.getProperty('user.name'))
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
-        tag = objectFactory.property(String)
+        tags = objectFactory.listProperty(String)
         jvmArgs = objectFactory.listProperty(String).empty()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -15,12 +15,10 @@
  */
 package com.bmuschko.gradle.docker
 
-
 import groovy.transform.CompileStatic
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
-
 /**
  * The extension for configuring a Java application via the {@link DockerJavaApplicationPlugin}.
  * <p>
@@ -67,7 +65,7 @@ class DockerJavaApplication {
      * The tag used for the Docker image.
      * <p>
      * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
-     * @deprecated use {@link #tags}
+     * @deprecated use {@link #tags} - will be removed in 6.0.0
      */
     @Deprecated
     final Property<String> tag
@@ -78,6 +76,16 @@ class DockerJavaApplication {
      * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
      */
     final ListProperty<String> tags
+
+    /**
+     * Tags that will be used for building the Docker image, but will not be pushed to the repo.
+     * In order for these tags to be built, they should be specified in the {@link #tags} property.
+     * e.g. for rapid local development, "busybox:latest" would be useful, but becomes confusing when
+     * pushed to a remote repo
+     * <p>
+     * Defaults to {@code []}
+     */
+    final ListProperty<String> localOnlyTags
 
 
     /**
@@ -98,6 +106,7 @@ class DockerJavaApplication {
         ports.set([8080])
         tag = objectFactory.property(String)
         tags = objectFactory.listProperty(String)
+        localOnlyTags = objectFactory.listProperty(String).empty()
         jvmArgs = objectFactory.listProperty(String).empty()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplication.groovy
@@ -64,11 +64,21 @@ class DockerJavaApplication {
     final ListProperty<Integer> ports
 
     /**
-     * The tags used for the Docker image.
+     * The tag used for the Docker image.
+     * <p>
+     * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
+     * @deprecated use {@link #tags}
+     */
+    @Deprecated
+    final Property<String> tag
+
+    /**
+     * The tag used for the Docker image.
      * <p>
      * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
      */
     final ListProperty<String> tags
+
 
     /**
      * The JVM arguments used to start the Java program.
@@ -86,6 +96,7 @@ class DockerJavaApplication {
         maintainer.set(System.getProperty('user.name'))
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
+        tag = objectFactory.property(String)
         tags = objectFactory.listProperty(String)
         jvmArgs = objectFactory.listProperty(String).empty()
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -204,8 +204,11 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
                     imageNames.set(dockerBuildImageTask.getTags().map(new Transformer<Set<String>, Set<String>>() {
                         @Override
                         Set<String> transform(Set<String> tags) {
-                            tags.removeAll(dockerJavaApplication.localOnlyTags.getOrNull())
-                            return tags
+                            // The Set that is passed in is immutable,
+                            // and throws an exception if we try to call .removeAll() directly on it
+                            Set<String> mutableTags = new HashSet<>(tags)
+                            mutableTags.removeAll(dockerJavaApplication.localOnlyTags.getOrNull())
+                            return mutableTags
                         }
                     }))
                 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -167,16 +167,21 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Builds the Docker image for the Java application.'
                     dependsOn createDockerfileTask
-                    tags.addAll(determineImageTag(project, dockerJavaApplication))
+                    tags.addAll(determineImageTags(project, dockerJavaApplication))
                 }
             }
         })
     }
 
-    private static Provider<List<String>> determineImageTag(Project project, DockerJavaApplication dockerJavaApplication) {
+    private static Provider<List<String>> determineImageTags(Project project, DockerJavaApplication dockerJavaApplication) {
         project.provider(new Callable<List<String>>() {
             @Override
             List<String> call() throws Exception {
+                // To preserve backwards compatibility, if `tag` is set,
+                // use that instead of tags
+                if (dockerJavaApplication.tag.getOrNull()) {
+                    return [dockerJavaApplication.tag.get()]
+                }
                 if (dockerJavaApplication.tags.getOrNull()) {
                     return dockerJavaApplication.tags.get()
                 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPlugin.groovy
@@ -167,23 +167,23 @@ class DockerJavaApplicationPlugin implements Plugin<Project> {
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Builds the Docker image for the Java application.'
                     dependsOn createDockerfileTask
-                    tags.add(determineImageTag(project, dockerJavaApplication))
+                    tags.addAll(determineImageTag(project, dockerJavaApplication))
                 }
             }
         })
     }
 
-    private static Provider<String> determineImageTag(Project project, DockerJavaApplication dockerJavaApplication) {
-        project.provider(new Callable<String>() {
+    private static Provider<List<String>> determineImageTag(Project project, DockerJavaApplication dockerJavaApplication) {
+        project.provider(new Callable<List<String>>() {
             @Override
-            String call() throws Exception {
-                if (dockerJavaApplication.tag.getOrNull()) {
-                    return dockerJavaApplication.tag.get()
+            List<String> call() throws Exception {
+                if (dockerJavaApplication.tags.getOrNull()) {
+                    return dockerJavaApplication.tags.get()
                 }
 
                 String tagVersion = project.version == 'unspecified' ? 'latest' : project.version
-                String artifactAndVersion = "${project.name}:${tagVersion}".toLowerCase().toString()
-                project.group ? "$project.group/$artifactAndVersion".toString() : artifactAndVersion
+                String artifactAndVersion = "${applicationName}:${tagVersion}".toLowerCase().toString()
+                [project.group ? "$project.group/$artifactAndVersion".toString() : artifactAndVersion]
             }
         })
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
@@ -52,11 +52,11 @@ class DockerSpringBootApplication {
     final ListProperty<Integer> ports
 
     /**
-     * The tag used for the Docker image.
+     * The tags used for the Docker image.
      * <p>
-     * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
+     * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
      */
-    final Property<String> tag
+    final ListProperty<String> tags
 
     /**
      * The JVM arguments used to start the Java program.
@@ -74,7 +74,7 @@ class DockerSpringBootApplication {
         maintainer.set(System.getProperty('user.name'))
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
-        tag = objectFactory.property(String)
+        tags = objectFactory.listProperty(String)
         jvmArgs = objectFactory.listProperty(String).empty()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
@@ -52,6 +52,15 @@ class DockerSpringBootApplication {
     final ListProperty<Integer> ports
 
     /**
+     * The tag used for the Docker image.
+     * <p>
+     * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
+     * @deprecated use {@link #tags}
+     */
+    @Deprecated
+    final Property<String> tag
+
+    /**
      * The tags used for the Docker image.
      * <p>
      * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
@@ -74,6 +83,7 @@ class DockerSpringBootApplication {
         maintainer.set(System.getProperty('user.name'))
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
+        tag = objectFactory.property(String)
         tags = objectFactory.listProperty(String)
         jvmArgs = objectFactory.listProperty(String).empty()
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplication.groovy
@@ -55,7 +55,7 @@ class DockerSpringBootApplication {
      * The tag used for the Docker image.
      * <p>
      * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
-     * @deprecated use {@link #tags}
+     * @deprecated use {@link #tags} - will be removed in 6.0.0
      */
     @Deprecated
     final Property<String> tag
@@ -66,6 +66,16 @@ class DockerSpringBootApplication {
      * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
      */
     final ListProperty<String> tags
+
+    /**
+     * Tags that will be used for building the Docker image, but will not be pushed to the repo.
+     * In order for these tags to be built, they should be specified in the {@link #tags} property.
+     * e.g. for rapid local development, "busybox:latest" would be useful, but becomes confusing when
+     * pushed to a remote repo
+     * <p>
+     * Defaults to {@code []}
+     */
+    final ListProperty<String> localOnlyTags
 
     /**
      * The JVM arguments used to start the Java program.
@@ -85,6 +95,7 @@ class DockerSpringBootApplication {
         ports.set([8080])
         tag = objectFactory.property(String)
         tags = objectFactory.listProperty(String)
+        localOnlyTags = objectFactory.listProperty(String).empty()
         jvmArgs = objectFactory.listProperty(String).empty()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
@@ -159,23 +159,23 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Builds the Docker image for the Spring Boot application.'
                     dependsOn createDockerfileTask
-                    tags.add(determineImageTag(project, dockerSpringBootApplication))
+                    tags.addAll(determineImageTags(project, dockerSpringBootApplication))
                 }
             }
         })
     }
 
-    private static Provider<String> determineImageTag(Project project, DockerSpringBootApplication dockerSpringBootApplication) {
-        project.provider(new Callable<String>() {
+    private static Provider<List<String>> determineImageTags(Project project, DockerSpringBootApplication dockerSpringBootApplication) {
+        project.provider(new Callable<List<String>>() {
             @Override
-            String call() throws Exception {
-                if (dockerSpringBootApplication.tag.getOrNull()) {
-                    return dockerSpringBootApplication.tag.get()
+            List<String> call() throws Exception {
+                if (dockerSpringBootApplication.tags.getOrNull()) {
+                    return dockerSpringBootApplication.tags.get()
                 }
 
                 String tagVersion = project.version == 'unspecified' ? 'latest' : project.version
                 String artifactAndVersion = "${project.name}:${tagVersion}".toLowerCase().toString()
-                project.group ? "$project.group/$artifactAndVersion".toString() : artifactAndVersion
+                [project.group ? "$project.group/$artifactAndVersion".toString() : artifactAndVersion]
             }
         })
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
@@ -194,8 +194,11 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
                     imageNames.set(dockerBuildImageTask.getTags().map(new Transformer<Set<String>, Set<String>>() {
                         @Override
                         Set<String> transform(Set<String> tags) {
-                            tags.removeAll(dockerSpringBootApplication.localOnlyTags.getOrNull())
-                            return tags
+                            // The Set that is passed in is immutable,
+                            // and throws an exception if we try to call .removeAll() directly on it
+                            Set<String> mutableTags = new HashSet<>(tags)
+                            mutableTags.removeAll(dockerSpringBootApplication.localOnlyTags.getOrNull())
+                            return mutableTags
                         }
                     }))
                 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
@@ -169,6 +169,9 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
         project.provider(new Callable<List<String>>() {
             @Override
             List<String> call() throws Exception {
+                if (dockerSpringBootApplication.tag.getOrNull()) {
+                    return [dockerSpringBootApplication.tag.get()]
+                }
                 if (dockerSpringBootApplication.tags.getOrNull()) {
                     return dockerSpringBootApplication.tags.get()
                 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
@@ -70,7 +70,7 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
                 Sync syncBuildContextTask = createSyncBuildContextTask(project, createDockerfileTask)
                 createDockerfileTask.dependsOn syncBuildContextTask
                 DockerBuildImage dockerBuildImageTask = createBuildImageTask(project, createDockerfileTask, dockerSpringBootApplication)
-                createPushImageTask(project, dockerBuildImageTask)
+                createPushImageTask(project, dockerBuildImageTask, dockerSpringBootApplication)
             }
         }
     }
@@ -183,7 +183,7 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
         })
     }
 
-    private static void createPushImageTask(Project project, DockerBuildImage dockerBuildImageTask) {
+    private static void createPushImageTask(Project project, DockerBuildImage dockerBuildImageTask, DockerSpringBootApplication dockerSpringBootApplication) {
         project.tasks.create(PUSH_IMAGE_TASK_NAME, DockerPushImage, new Action<DockerPushImage>() {
             @Override
             void execute(DockerPushImage dockerPushImage) {
@@ -191,10 +191,11 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Pushes created Docker image to the repository.'
                     dependsOn dockerBuildImageTask
-                    imageName.set(dockerBuildImageTask.getTags().map(new Transformer<String, Set<String>>() {
+                    imageNames.set(dockerBuildImageTask.getTags().map(new Transformer<Set<String>, Set<String>>() {
                         @Override
-                        String transform(Set<String> tags) {
-                            tags.first()
+                        Set<String> transform(Set<String> tags) {
+                            tags.removeAll(dockerSpringBootApplication.localOnlyTags.getOrNull())
+                            return tags
                         }
                     }))
                 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -32,6 +32,7 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
      * The image name e.g. "bmuschko/busybox" or just "busybox" if you want to default.
      */
     @Input
+    @Optional
     final Property<String> imageName = project.objects.property(String)
 
     /**
@@ -53,11 +54,14 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
     DockerRegistryCredentials registryCredentials
 
     private List<String> getAllImageNames() {
-        List<String> imageNames = imageNames.getOrElse([])
-        if (imageName.getOrNull()) {
-            imageNames.add(imageName.get())
+        List<String> allImageNames = new ArrayList<>()
+        if (imageNames.getOrNull()) {
+            allImageNames.addAll(imageNames.get())
         }
-        return imageNames
+        if (imageName.getOrNull()) {
+            allImageNames.add(imageName.get())
+        }
+        return allImageNames
     }
 
     @Override


### PR DESCRIPTION
Only being able to specify one tag for these projects when you can
specify multiple in the DockerBuildImage tasks is a real drag. It means
you would have to add a custom DockerBuildImage or DockerTagImage task
when the whole point of the plugin is to abstract all that out.

Tested by:
    `./gradlew clean build`