### PR TITLE
Removed duplicated code and extracted use of ItemJoiner from public API

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
@@ -165,7 +165,7 @@ LABEL maintainer=benjamin.muschko@gmail.com
 RUN echo deb http://archive.ubuntu.com/ubuntu precise universe >> /etc/apt/sources.list
 CMD ["echo", "some", "command"]
 EXPOSE 8080 14500
-ENV ENV_VAR_KEY envVarVal
+ENV ENV_VAR_KEY=envVarVal
 ENV ENV_VAR_A=val_a
 ENV ENV_VAR_B=val_b ENV_VAR_C=val_c
 ADD http://mirrors.jenkins-ci.org/war/1.563/jenkins.war /opt/jenkins.war

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -47,14 +47,14 @@ class DockerfileTest extends Specification {
         new DefaultCommandInstruction('ping google.com')                     | 'CMD'           | 'CMD ["ping google.com"]'
         new ExposePortInstruction(8080)                                          | 'EXPOSE'        | 'EXPOSE 8080'
         new ExposePortInstruction(8080, 9090)                                    | 'EXPOSE'        | 'EXPOSE 8080 9090'
-        new EnvironmentVariableInstruction('OS', 'Linux')                               | 'ENV'           | 'ENV OS Linux'
+        new EnvironmentVariableInstruction('OS', 'Linux')                               | 'ENV'           | 'ENV OS=Linux'
         new EnvironmentVariableInstruction('', 'Linux')                                 | 'ENV'           | IllegalArgumentException.class
         new EnvironmentVariableInstruction(' ', 'Linux')                                | 'ENV'           | IllegalArgumentException.class
-        new EnvironmentVariableInstruction('OS', '"Linux"')                             | 'ENV'           | 'ENV OS "Linux"'
-        new EnvironmentVariableInstruction('OS', 'Linux or Windows')                    | 'ENV'           | 'ENV OS Linux or Windows'
+        new EnvironmentVariableInstruction('OS', '"Linux"')                             | 'ENV'           | 'ENV OS="Linux"'
+        new EnvironmentVariableInstruction('OS', 'Linux or Windows')                    | 'ENV'           | 'ENV OS="Linux or Windows"'
         new EnvironmentVariableInstruction('long', '''Multiple line env 
-with linebreaks in between''')                                                          | 'ENV'           | "ENV long Multiple line env \\\n\
-with linebreaks in between"
+with linebreaks in between''')                                                          | 'ENV'           | "ENV long=\"Multiple line env \\\n\
+with linebreaks in between\""
         new EnvironmentVariableInstruction(['OS': 'Linux'])                             | 'ENV'           | 'ENV OS=Linux'
         new EnvironmentVariableInstruction(['long': '''Multiple line env 
 with linebreaks in between'''])                                                         | 'ENV'           | "ENV long=\"Multiple line env \\\n\


### PR DESCRIPTION
* There's no point in having different treatment for single vs. multiple items. Both notations are supported (see https://docs.docker.com/engine/reference/builder/#env).
* `SingleItemJoiner` duplicated most of the code from `MultiItemJoiner`
* `ItemJoiner` really is an implementation detail and shouldn't bleed into the public API (see constructor of `MapInstruction`)

Next question from my end: Why do we even have such complex escape logic? Couldn't the end user provide the proper syntax and escape on their end if needed? That's what you have to do in Java in general. We can address the question after reviewing/merging this PR.