### PR TITLE
Upgrade docker-java to fix symlink issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,7 @@ repositories {
 }
 
 dependencies {
-    shaded("com.github.docker-java:docker-java:3.1.2")
+    shaded("com.github.docker-java:docker-java:3.1.4")
     shaded("javax.activation:activation:1.1.1")
     shaded("org.ow2.asm:asm:7.0")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -46,7 +46,7 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         BuildResult result = buildAndFail(COMMIT_TASK_NAME)
 
         then:
-        result.output.contains('{"message":"No such container: idonotexist"}')
+        result.output.contains('No such container: idonotexist')
     }
 
     static String containerStart(containerCommitImageExecutionTask) {
@@ -74,9 +74,9 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 dependsOn createContainer
                 targetContainerId createContainer.getContainerId()
             }
-            
+
             ${containerCommitImageExecutionTask}
-            
+
             task removeContainer(type: DockerRemoveContainer) {
                 removeVolumes = true
                 force = true


### PR DESCRIPTION
When the DockerBuildImage input dir contained symlinks, the symlinks
were not sent to the docker daemon. This caused docker build to fail or
succeed but with missing symlinks depending if the DockerFile uses the
expected symlinks directly of if it uses a folder containing the symlinks.

The docker-java version 3.1.3 fixes this issue and now the symbolic
links are sent as is to the docker daemon, same as what native docker
client does.

Also adjust one test to the new behavior in 3.1.4. The error message
when a container does not exist used to be:
{"message":"No such container: idonotexist"}
and now is :
No such container: idonotexist

Resolves #837