### PR TITLE
:recycle: use task configuration avoidance apis in plugins

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -48,7 +48,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
     }
 
     private void configureRegistryAwareTasks(Project project, DockerRegistryCredentials dockerRegistryCredentials) {
-        project.tasks.withType(RegistryCredentialsAware, new Action<RegistryCredentialsAware>() {
+        project.tasks.withType(RegistryCredentialsAware).configureEach( new Action<RegistryCredentialsAware>() {
             @Override
             void execute(RegistryCredentialsAware registryCredentialsAware) {
                 registryCredentialsAware.setRegistryCredentials(dockerRegistryCredentials)


### PR DESCRIPTION
Please do not create a Pull Request without first creating an ISSUE.
Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the Pull Request.

Explain the **details** for making this change: What existing problem does the Pull Request solve? Why is this feature beneficial?
Details laid out in: https://github.com/bmuschko/gradle-docker-plugin/issues/674. Generally, I followed the guidelines in: https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:task_configuration_avoidance_migration_guidelines

**On adding new code**

Any new code added must contain relevant functionalTest(s) exercising all possible paths the code may take.

Since there were no functional changes, and all existing tests continued to pass, I believe the level of testing is sufficient.

**On CI testing (currently using travis)**

Code will not be reviewed until CI passes.
build passed on my forked repo: https://travis-ci.org/ryandens/gradle-docker-plugin/builds/576278545
**On automtatic closing of ISSUES**
closes #674 