### PR TITLE
Remove remaining use of Application Plugin in convention plugins

### DIFF
--- a/src/docs/asciidoc/20-java-application-plugin.adoc
+++ b/src/docs/asciidoc/20-java-application-plugin.adoc
@@ -1,8 +1,8 @@
 [[java-application-plugin]]
 == Java Application Plugin
 
-The plugin `com.bmuschko.docker-java-application` is a highly opinionated plugin for projects applying the {uri-gradle-docs}/userguide/application_plugin.html[application plugin].
-Under the covers the plugin preconfigures tasks for creating and pushing Docker images for your Java application.
+The plugin `com.bmuschko.docker-java-application` is a highly opinionated plugin for projects applying the {uri-gradle-docs}/userguide/java_plugin.html[Java plugin].
+Under the hood the plugin preconfigures tasks for creating and pushing Docker images for your Java application.
 The default configuration is tweakable via an exposed extension.
 
 include::21-usage.adoc[]

--- a/src/docs/asciidoc/30-spring-boot-application-plugin.adoc
+++ b/src/docs/asciidoc/30-spring-boot-application-plugin.adoc
@@ -1,7 +1,7 @@
 == Spring Boot Application Plugin
 
 The plugin `com.bmuschko.docker-spring-boot-application` is a highly opinionated plugin for projects applying the https://docs.spring.io/spring-boot/docs/current/reference/html/build-tool-plugins-gradle-plugin.html[Spring Boot plugin].
-Under the covers the plugin preconfigures tasks for creating and pushing Docker images for your Spring Boot application.
+Under the hood the plugin preconfigures tasks for creating and pushing Docker images for your Spring Boot application.
 The default configuration is tweakable via an exposed extension. The plugin https://docs.spring.io/spring-boot/docs/current/gradle-plugin/reference/html/#reacting-to-other-plugins[reacts] to either the `java` or `war` plugin.
 
 [IMPORTANT]

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -156,8 +156,6 @@ ADD file2.txt /other/dir/file2.txt
         given:
         DockerHubCredentials credentials = TestPrecondition.readDockerHubCredentials()
         buildFile << """
-            applicationName = 'javaapp'
-
             docker {
                 registryCredentials {
                     username = '$credentials.username'
@@ -185,8 +183,6 @@ ADD file2.txt /other/dir/file2.txt
     def "Can create image for Java application and push to private registry"() {
         given:
         buildFile << """
-            applicationName = 'javaapp'
-
             docker {
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
@@ -218,7 +214,6 @@ ADD file2.txt /other/dir/file2.txt
     private void writeBasicSetupToBuildFile() {
         buildFile << """
             apply plugin: 'java'
-            apply plugin: 'application'
             apply plugin: com.bmuschko.gradle.docker.DockerJavaApplicationPlugin
 
             version = '1.0'
@@ -231,8 +226,6 @@ ADD file2.txt /other/dir/file2.txt
             dependencies {
                 compile 'org.eclipse.jetty.aggregate:jetty-all:9.2.5.v20141112'
             }
-
-            mainClassName = 'com.bmuschko.gradle.docker.application.JettyMain'
         """
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPlugin.groovy
@@ -141,7 +141,7 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
                                 entrypoint.addAll(jvmArgs)
                             }
 
-                            entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", getSpringApplicationMainClassName(project)])
+                            entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", getApplicationMainClassName(project)])
                             entrypoint
                         }
                     }))
@@ -199,7 +199,7 @@ class DockerSpringBootApplicationPlugin implements Plugin<Project> {
         })
     }
 
-    private static String getSpringApplicationMainClassName(Project project) {
+    private static String getApplicationMainClassName(Project project) {
         for (File classesDir : getMainJavaSourceSetOutput(project).classesDirs) {
             String mainClassName = MainClassFinder.findSingleMainClass(classesDir, SPRING_BOOT_APP_ANNOTATION)
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/ConventionPluginHelper.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/ConventionPluginHelper.groovy
@@ -5,7 +5,6 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.artifacts.Configuration
 import org.gradle.api.file.CopySpec
-import org.gradle.api.plugins.ApplicationPluginConvention
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.plugins.JavaPluginConvention
 import org.gradle.api.tasks.SourceSet
@@ -15,14 +14,6 @@ import org.gradle.api.tasks.SourceSetOutput
 final class ConventionPluginHelper {
 
     private ConventionPluginHelper() {}
-
-    static String getApplicationPluginName(Project project) {
-        project.convention.getPlugin(ApplicationPluginConvention).applicationName
-    }
-
-    static String getApplicationPluginMainClassName(Project project) {
-        project.convention.getPlugin(ApplicationPluginConvention).mainClassName
-    }
 
     static SourceSetOutput getMainJavaSourceSetOutput(Project project) {
         JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention)

--- a/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/utils/MainClassFinder.groovy
@@ -18,6 +18,10 @@ class MainClassFinder {
     private static final Type STRING_ARRAY_TYPE = Type.getType(String[].class)
     private static final Type MAIN_METHOD_TYPE = Type.getMethodType(Type.VOID_TYPE, STRING_ARRAY_TYPE)
 
+    static String findSingleMainClass(File rootFolder) throws IOException {
+        findSingleMainClass(rootFolder, null)
+    }
+
     static String findSingleMainClass(File rootFolder, String annotationName) throws IOException {
         SingleMainClassCallback callback = new SingleMainClassCallback(annotationName)
         MainClassFinder.doWithMainClasses(rootFolder, callback)

--- a/src/test/groovy/com/bmuschko/gradle/docker/utils/MainClassFinderTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/utils/MainClassFinderTest.groovy
@@ -20,6 +20,18 @@ class MainClassFinderTest extends Specification {
         testJarFile = new TestJarFile(temporaryFolder)
     }
 
+    def "can find main class without annotation"() {
+        given:
+        testJarFile.addClass('a/B.class', ClassWithMainMethod)
+        testJarFile.addClass('a/b/c/E.class', ClassWithoutMainMethod)
+
+        when:
+        String mainClass = MainClassFinder.findSingleMainClass(testJarFile.getJarSource())
+
+        then:
+        mainClass == 'a.B'
+    }
+
     def "can find annotated main class"() {
         given:
         testJarFile.addClass('a/B.class', ClassWithMainMethod)


### PR DESCRIPTION
For more information, see https://github.com/bmuschko/gradle-docker-plugin/issues/846#issuecomment-520658950. There's no more benefit to using the Application Plugin. It can work just fine without it and we can avoid having to build a JAR file for every code change.