### PR TITLE
Multi-tag support for push operation and convention plugins

### DIFF
--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -8,7 +8,7 @@ The plugin defines an extension with the namespace `javaApplication` as a child 
 |`baseImage`     |`Property<String>`                 |`openjdk:jre-alpine`                                     |The Docker base image used for Java application.
 |`maintainer`    |`Property<String>`                 |Value of system property `user.name`                     |The maintainer of the image.
 |`ports`         |`ListProperty<Integer>`            |`[8080]`                                                 |The Docker image exposed ports.
-|`tag`           |`Property<String>`                 |`<project.group>/<applicationName>:<project.version>`    |The tag used for the Docker image.
+|`tags`          |`SetProperty<String>`              |`[<project.group>/<applicationName>:<project.version>]`    |The tags used for the Docker image.
 |`jvmArgs`       |`ListProperty<String>`             |`[]`                                                     |The JVM arguments passed to the `java` command.
 |=======
 

--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -8,7 +8,7 @@ The plugin defines an extension with the namespace `javaApplication` as a child 
 |`baseImage`     |`Property<String>`                 |`openjdk:jre-alpine`                                     |The Docker base image used for Java application.
 |`maintainer`    |`Property<String>`                 |Value of system property `user.name`                     |The maintainer of the image.
 |`ports`         |`ListProperty<Integer>`            |`[8080]`                                                 |The Docker image exposed ports.
-|`tags`          |`SetProperty<String>`              |`[<project.group>/<applicationName>:<project.version>]`    |The tags used for the Docker image.
+|`images`        |`SetProperty<String>`              |`[<project.group>/<applicationName>:<project.version>]`  |The images used for the build and push operation.
 |`jvmArgs`       |`ListProperty<String>`             |`[]`                                                     |The JVM arguments passed to the `java` command.
 |=======
 

--- a/src/docs/asciidoc/32-extension.adoc
+++ b/src/docs/asciidoc/32-extension.adoc
@@ -6,12 +6,12 @@ The following properties can be configured:
 
 [options="header"]
 |=======
-|Property name   |Type                    |Default value                                      |Description
-|`baseImage`     |`Property<String>`      |`openjdk:jre-alpine`                               |The Docker base image used for the Spring Boot application.
-|`maintainer`    |`Property<String>`      |Value of system property `user.name`               |The maintainer of the image.
-|`ports`         |`ListProperty<Integer>` |`[8080]`                                           |The Docker image exposed ports.
-|`tags`           |`SetProperty<String>`  |`[<project.group>/<project.name>:<project.version>]` |The tags used for the Docker image.
-|`jvmArgs`       |`ListProperty<String>`  |`[]`                                               |The JVM arguments passed to the `java` command.
+|Property name   |Type                    |Default value                                           |Description
+|`baseImage`     |`Property<String>`      |`openjdk:jre-alpine`                                    |The Docker base image used for the Spring Boot application.
+|`maintainer`    |`Property<String>`      |Value of system property `user.name`                    |The maintainer of the image.
+|`ports`         |`ListProperty<Integer>` |`[8080]`                                                |The Docker image exposed ports.
+|`images`        |`SetProperty<String>`   |`[<project.group>/<applicationName>:<project.version>]` |The images used for the build and push operation.
+|`jvmArgs`       |`ListProperty<String>`  |`[]`                                                    |The JVM arguments passed to the `java` command.
 |=======
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/docs/asciidoc/32-extension.adoc
+++ b/src/docs/asciidoc/32-extension.adoc
@@ -10,7 +10,7 @@ The following properties can be configured:
 |`baseImage`     |`Property<String>`      |`openjdk:jre-alpine`                               |The Docker base image used for the Spring Boot application.
 |`maintainer`    |`Property<String>`      |Value of system property `user.name`               |The maintainer of the image.
 |`ports`         |`ListProperty<Integer>` |`[8080]`                                           |The Docker image exposed ports.
-|`tag`           |`Property<String>`      |`<project.group>/<project.name>:<project.version>` |The tag used for the Docker image.
+|`tags`           |`SetProperty<String>`  |`[<project.group>/<project.name>:<project.version>]` |The tags used for the Docker image.
 |`jvmArgs`       |`ListProperty<String>`  |`[]`                                               |The JVM arguments passed to the `java` command.
 |=======
 

--- a/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
@@ -12,7 +12,7 @@ docker {
         baseImage = 'dockerfile/java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         ports = [9090, 5701]
-        tag = 'jettyapp:1.115'
+        tags = ['jettyapp:1.115']
         jvmArgs = ['-Xms256m', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
@@ -12,7 +12,7 @@ docker {
         baseImage = 'dockerfile/java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         ports = [9090, 5701]
-        tags = ['jettyapp:1.115']
+        images = ['jettyapp:1.115']
         jvmArgs = ['-Xms256m', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/application-plugin/basic/groovy/build.gradle
@@ -12,7 +12,7 @@ docker {
         baseImage = 'dockerfile/java:openjdk-7-jre'
         maintainer = 'Benjamin Muschko "benjamin.muschko@gmail.com"'
         ports = [9090, 5701]
-        images = ['jettyapp:1.115']
+        images = ['jettyapp:1.115', 'jettyapp:latest']
         jvmArgs = ['-Xms256m', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ docker {
         baseImage.set("dockerfile/java:openjdk-7-jre")
         maintainer.set("Benjamin Muschko 'benjamin.muschko@gmail.com'")
         ports.set(listOf(9090, 5701))
-        tags.set(setOf("jettyapp:1.115"))
+        images.set(setOf("jettyapp:1.115"))
         jvmArgs.set(listOf("-Xms256m", "-Xmx2048m"))
     }
 }

--- a/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ docker {
         baseImage.set("dockerfile/java:openjdk-7-jre")
         maintainer.set("Benjamin Muschko 'benjamin.muschko@gmail.com'")
         ports.set(listOf(9090, 5701))
-        tag.set("jettyapp:1.115")
+        tags.set(setOf("jettyapp:1.115"))
         jvmArgs.set(listOf("-Xms256m", "-Xmx2048m"))
     }
 }

--- a/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/application-plugin/basic/kotlin/build.gradle.kts
@@ -14,7 +14,7 @@ docker {
         baseImage.set("dockerfile/java:openjdk-7-jre")
         maintainer.set("Benjamin Muschko 'benjamin.muschko@gmail.com'")
         ports.set(listOf(9090, 5701))
-        images.set(setOf("jettyapp:1.115"))
+        images.set(setOf("jettyapp:1.115", "jettyapp:latest"))
         jvmArgs.set(listOf("-Xms256m", "-Xmx2048m"))
     }
 }

--- a/src/docs/samples/code/remote-api-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/remote-api-plugin/basic/groovy/build.gradle
@@ -9,7 +9,7 @@ import com.bmuschko.gradle.docker.tasks.image.*
 // Use task types
 task buildMyAppImage(type: DockerBuildImage) {
     inputDir = file('docker/myapp')
-    tags.add('test/myapp:latest')
+    images.add('test/myapp:latest')
 }
 // end::create-task[]
 

--- a/src/docs/samples/code/remote-api-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/remote-api-plugin/basic/kotlin/build.gradle.kts
@@ -9,7 +9,7 @@ import com.bmuschko.gradle.docker.tasks.image.*
 // Use task types
 tasks.create("buildMyAppImage", DockerBuildImage::class) {
     inputDir.set(file("docker/myapp"))
-    tags.add("test/myapp:latest")
+    images.add("test/myapp:latest")
 }
 // end::create-task[]
 

--- a/src/docs/samples/code/remote-api-plugin/build-image/groovy/build.gradle
+++ b/src/docs/samples/code/remote-api-plugin/build-image/groovy/build.gradle
@@ -12,5 +12,5 @@ task createDockerfile(type: Dockerfile) {
 
 task buildImage(type: DockerBuildImage) {
     dependsOn createDockerfile
-    tags.add('bmuschko/myimage:latest')
+    images.add('bmuschko/myimage:latest')
 }

--- a/src/docs/samples/code/remote-api-plugin/build-image/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/remote-api-plugin/build-image/kotlin/build.gradle.kts
@@ -12,5 +12,5 @@ val createDockerfile by tasks.creating(Dockerfile::class) {
 
 tasks.create("buildImage", DockerBuildImage::class) {
     dependsOn(createDockerfile)
-    tags.add("bmuschko/myimage:latest")
+    images.add("bmuschko/myimage:latest")
 }

--- a/src/docs/samples/code/remote-api-plugin/custom-task-type/groovy/build.gradle
+++ b/src/docs/samples/code/remote-api-plugin/custom-task-type/groovy/build.gradle
@@ -19,7 +19,7 @@ task printImageId {
 // end::task-type-usage[]
 
 task pullImage(type: DockerPullImage) {
-    tag = 'alpine:3.4'
+    image = 'alpine:3.4'
 }
 
 imageIdForName.dependsOn pullImage

--- a/src/docs/samples/code/remote-api-plugin/custom-task-type/groovy/build.gradle
+++ b/src/docs/samples/code/remote-api-plugin/custom-task-type/groovy/build.gradle
@@ -19,8 +19,7 @@ task printImageId {
 // end::task-type-usage[]
 
 task pullImage(type: DockerPullImage) {
-    repository = 'alpine'
-    tag = '3.4'
+    tag = 'alpine:3.4'
 }
 
 imageIdForName.dependsOn pullImage

--- a/src/docs/samples/code/remote-api-plugin/custom-task-type/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/remote-api-plugin/custom-task-type/kotlin/build.gradle.kts
@@ -19,8 +19,7 @@ val printImageId by tasks.creating {
 // end::task-type-usage[]
 
 val pullImage by tasks.creating(DockerPullImage::class) {
-    repository.set("alpine")
-    tag.set("3.4")
+    tag.set("alpine:3.4")
 }
 
 imageIdForName.dependsOn(pullImage)

--- a/src/docs/samples/code/remote-api-plugin/custom-task-type/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/remote-api-plugin/custom-task-type/kotlin/build.gradle.kts
@@ -19,7 +19,7 @@ val printImageId by tasks.creating {
 // end::task-type-usage[]
 
 val pullImage by tasks.creating(DockerPullImage::class) {
-    tag.set("alpine:3.4")
+    image.set("alpine:3.4")
 }
 
 imageIdForName.dependsOn(pullImage)

--- a/src/docs/samples/code/remote-api-plugin/functional-test/groovy/build.gradle
+++ b/src/docs/samples/code/remote-api-plugin/functional-test/groovy/build.gradle
@@ -7,7 +7,7 @@ import com.bmuschko.gradle.docker.tasks.image.*
 
 task buildMyAppImage(type: DockerBuildImage) {
     inputDir = file('docker/myapp')
-    tags.add('test/myapp:latest')
+    images.add('test/myapp:latest')
 }
 
 task createMyAppContainer(type: DockerCreateContainer) {

--- a/src/docs/samples/code/remote-api-plugin/functional-test/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/remote-api-plugin/functional-test/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ import com.bmuschko.gradle.docker.tasks.image.*
 
 val buildMyAppImage by tasks.creating(DockerBuildImage::class) {
     inputDir.set(file("docker/myapp"))
-    tags.add("test/myapp:latest")
+    images.add("test/myapp:latest")
 }
 
 val createMyAppContainer by tasks.creating(DockerCreateContainer::class) {

--- a/src/docs/samples/code/remote-api-plugin/linking-containers/groovy/build.gradle
+++ b/src/docs/samples/code/remote-api-plugin/linking-containers/groovy/build.gradle
@@ -7,7 +7,7 @@ import com.bmuschko.gradle.docker.tasks.image.*
 
 task buildMyAppImage(type: DockerBuildImage) {
     inputDir = file('docker/myapp')
-    tags.add('test/myapp')
+    images.add('test/myapp')
 }
 
 task createDBContainer(type: DockerCreateContainer) {

--- a/src/docs/samples/code/remote-api-plugin/linking-containers/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/remote-api-plugin/linking-containers/kotlin/build.gradle.kts
@@ -7,7 +7,7 @@ import com.bmuschko.gradle.docker.tasks.image.*
 
 val buildMyAppImage by tasks.creating(DockerBuildImage::class) {
     inputDir.set(file("docker/myapp"))
-    tags.add("test/myapp")
+    images.add("test/myapp")
 }
 
 val createDBContainer by tasks.creating(DockerCreateContainer::class) {

--- a/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage = 'openjdk:8-alpine'
         ports = [9090, 8080]
-        tag = 'awesome-spring-boot:1.115'
+        tags = ['awesome-spring-boot:1.115']
         jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage = 'openjdk:8-alpine'
         ports = [9090, 8080]
-        images = ['awesome-spring-boot:1.115']
+        images = ['awesome-spring-boot:1.115', 'awesome-spring-boot:latest']
         jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
+++ b/src/docs/samples/code/spring-boot-plugin/basic/groovy/build.gradle
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage = 'openjdk:8-alpine'
         ports = [9090, 8080]
-        tags = ['awesome-spring-boot:1.115']
+        images = ['awesome-spring-boot:1.115']
         jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
     }
 }

--- a/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage.set("openjdk:8-alpine")
         ports.set(listOf(9090, 8080))
-        tags.set(setOf("awesome-spring-boot:1.115"))
+        images.set(setOf("awesome-spring-boot:1.115"))
         jvmArgs.set(listOf("-Dspring.profiles.active=production", "-Xmx2048m"))
     }
 }

--- a/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage.set("openjdk:8-alpine")
         ports.set(listOf(9090, 8080))
-        tag.set("awesome-spring-boot:1.115")
+        tags.set(setOf("awesome-spring-boot:1.115"))
         jvmArgs.set(listOf("-Dspring.profiles.active=production", "-Xmx2048m"))
     }
 }

--- a/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
+++ b/src/docs/samples/code/spring-boot-plugin/basic/kotlin/build.gradle.kts
@@ -11,7 +11,7 @@ docker {
     springBootApplication {
         baseImage.set("openjdk:8-alpine")
         ports.set(listOf(9090, 8080))
-        images.set(setOf("awesome-spring-boot:1.115"))
+        images.set(setOf("awesome-spring-boot:1.115", "awesome-spring-boot:latest"))
         jvmArgs.set(listOf("-Dspring.profiles.active=production", "-Xmx2048m"))
     }
 }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -165,7 +165,7 @@ ADD file2.txt /other/dir/file2.txt
 
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    images = ["\${docker.registryCredentials.username.get()}/javaapp".toString()] 
+                    images = ["\${docker.registryCredentials.username.get()}/javaapp:1.2.3".toString(), "\${docker.registryCredentials.username.get()}/javaapp:latest".toString()] 
                 }
             }
         """
@@ -186,7 +186,7 @@ ADD file2.txt /other/dir/file2.txt
             docker {
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    images = ['${TestConfiguration.dockerPrivateRegistryDomain}/javaapp']
+                    images = ['${TestConfiguration.dockerPrivateRegistryDomain}/javaapp:1.2.3', '${TestConfiguration.dockerPrivateRegistryDomain}/javaapp:latest']
                 }
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -44,7 +44,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090]
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                     jvmArgs = ['-Xms256m', '-Xmx2048m']
                 }
             }
@@ -67,7 +67,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090, 8080]
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                 }
             }
         """
@@ -89,7 +89,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = []
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                 }
             }
         """
@@ -124,7 +124,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090]
-                    tag = 'jettyapp:1.115'
+                    tags = ['jettyapp:1.115']
                 }
             }
         """
@@ -165,7 +165,7 @@ ADD file2.txt /other/dir/file2.txt
 
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = "\${docker.registryCredentials.username.get()}/javaapp".toString() 
+                    tags = ["\${docker.registryCredentials.username.get()}/javaapp".toString()] 
                 }
             }
         """
@@ -186,7 +186,7 @@ ADD file2.txt /other/dir/file2.txt
             docker {
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = '${TestConfiguration.dockerPrivateRegistryDomain}/javaapp'
+                    tags = ['${TestConfiguration.dockerPrivateRegistryDomain}/javaapp']
                 }
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -44,7 +44,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090]
-                    tags = ['jettyapp:1.115']
+                    images = ['jettyapp:1.115']
                     jvmArgs = ['-Xms256m', '-Xmx2048m']
                 }
             }
@@ -67,7 +67,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090, 8080]
-                    tags = ['jettyapp:1.115']
+                    images = ['jettyapp:1.115']
                 }
             }
         """
@@ -89,7 +89,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = []
-                    tags = ['jettyapp:1.115']
+                    images = ['jettyapp:1.115']
                 }
             }
         """
@@ -124,7 +124,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090]
-                    tags = ['jettyapp:1.115']
+                    images = ['jettyapp:1.115']
                 }
             }
         """
@@ -165,7 +165,7 @@ ADD file2.txt /other/dir/file2.txt
 
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tags = ["\${docker.registryCredentials.username.get()}/javaapp".toString()] 
+                    images = ["\${docker.registryCredentials.username.get()}/javaapp".toString()] 
                 }
             }
         """
@@ -186,7 +186,7 @@ ADD file2.txt /other/dir/file2.txt
             docker {
                 javaApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tags = ['${TestConfiguration.dockerPrivateRegistryDomain}/javaapp']
+                    images = ['${TestConfiguration.dockerPrivateRegistryDomain}/javaapp']
                 }
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -47,7 +47,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090, 8080]
-                    tag = 'awesome-spring-boot:1.115'
+                    tags = ['awesome-spring-boot:1.115']
                     jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
                 }
             }
@@ -75,7 +75,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     ports = []
-                    tag = 'awesome-spring-boot:1.115'
+                    tags = ['awesome-spring-boot:1.115']
                 }
             }
         """
@@ -109,7 +109,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
 
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = "\${docker.registryCredentials.username.get()}/springbootapp".toString()
+                    tags = ["\${docker.registryCredentials.username.get()}/springbootapp".toString()]
                 }
             }
         """
@@ -136,7 +136,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
             docker {
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tag = '${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp'
+                    tags = ['${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp']
                 }
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -109,7 +109,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
 
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    images = ["\${docker.registryCredentials.username.get()}/springbootapp".toString()]
+                    images = ["\${docker.registryCredentials.username.get()}/springbootapp:1.2.3".toString(), "\${docker.registryCredentials.username.get()}/springbootapp:latest".toString()]
                 }
             }
         """
@@ -136,7 +136,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
             docker {
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    images = ['${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp']
+                    images = ['${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp:1.2.3', '${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp:latest']
                 }
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -47,7 +47,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     maintainer = 'benjamin.muschko@gmail.com'
                     ports = [9090, 8080]
-                    tags = ['awesome-spring-boot:1.115']
+                    images = ['awesome-spring-boot:1.115']
                     jvmArgs = ['-Dspring.profiles.active=production', '-Xmx2048m']
                 }
             }
@@ -75,7 +75,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
                     ports = []
-                    tags = ['awesome-spring-boot:1.115']
+                    images = ['awesome-spring-boot:1.115']
                 }
             }
         """
@@ -109,7 +109,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
 
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tags = ["\${docker.registryCredentials.username.get()}/springbootapp".toString()]
+                    images = ["\${docker.registryCredentials.username.get()}/springbootapp".toString()]
                 }
             }
         """
@@ -136,7 +136,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
             docker {
                 springBootApplication {
                     baseImage = '$CUSTOM_BASE_IMAGE'
-                    tags = ['${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp']
+                    images = ['${TestConfiguration.dockerPrivateRegistryDomain}/springbootapp']
                 }
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -38,7 +38,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file('images/minimal')
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -106,7 +106,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file('images/minimal')
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer1(type: DockerCreateContainer) {
@@ -154,7 +154,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file('images/minimal')
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer1(type: DockerCreateContainer) {
@@ -204,12 +204,12 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task buildImage(type: DockerBuildImage) {
                 dependsOn createDockerfile
                 inputDir = createDockerfile.destFile.get().asFile.parentFile
-                tags.add('${TestConfiguration.dockerPrivateRegistryDomain}/${createUniqueImageId()}')
+                images.add('${TestConfiguration.dockerPrivateRegistryDomain}/${createUniqueImageId()}')
             }
 
             task pushImage(type: DockerPushImage) {
                 dependsOn buildImage
-                tags.set(buildImage.tags)
+                images.set(buildImage.images)
             }
 
             task workflow {
@@ -242,7 +242,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file('images/minimal')
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -301,7 +301,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -340,7 +340,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -379,7 +379,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -418,7 +418,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -457,7 +457,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -516,7 +516,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -563,7 +563,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -607,7 +607,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${createUniqueImageId()}")
+                images.add("${createUniqueImageId()}")
             }
 
             task createContainer(type: DockerCreateContainer) {
@@ -653,12 +653,12 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
             
             task buildImage(type: DockerBuildImage) {
                 inputDir = file("${dockerFile.parentFile.path}")
-                tags.add("${imageName}")
+                images.add("${imageName}")
             }
 
             task saveImage(type: DockerSaveImage) {
                 dependsOn buildImage
-                tag = "${imageName}"
+                image = "${imageName}"
                 destFile = new File("${savedImagePath}")
             }
             

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -209,7 +209,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task pushImage(type: DockerPushImage) {
                 dependsOn buildImage
-                imageName = buildImage.tags.get().first()
+                tags.set(buildImage.tags)
             }
 
             task workflow {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerWorkflowFunctionalTest.groovy
@@ -658,7 +658,7 @@ class DockerWorkflowFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task saveImage(type: DockerSaveImage) {
                 dependsOn buildImage
-                repository = "${imageName}"
+                tag = "${imageName}"
                 destFile = new File("${savedImagePath}")
             }
             

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
@@ -21,6 +21,7 @@ final class DockerConventionPluginFixture {
             task removeImage(type: DockerRemoveImage) {
                 dependsOn dockerBuildImage
                 targetImageId dockerBuildImage.getImageId()
+                force = true
             }
             
             task buildAndRemoveImage {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerReactiveMethodsFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerReactiveMethodsFunctionalTest.groovy
@@ -116,12 +116,12 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ["/bin/sh","-c","echo Hello World"]
             }
 
@@ -162,7 +162,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
     
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task listImages(type: DockerListImages) {
@@ -387,12 +387,12 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.image.DockerInspectImage
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task inspectImage(type: DockerInspectImage) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 
                 onNext { image ->
                     logger.quiet 'Cmd:        ' + image.config.cmd
@@ -423,7 +423,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
 
             task pullImage(type: DockerPullImage) {
                 dependsOn removeImage
-                tag = 'busybox:musl'
+                image = 'busybox:musl'
                 
                 onNext { p ->
                     logger.quiet p.status + ' ' + (p.progress ?: '')
@@ -457,7 +457,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             task buildImage(type: DockerBuildImage) {
                 dependsOn createDockerfile
                 inputDir = createDockerfile.destFile.get().asFile.parentFile
-                tags.add('${dockerPrivateRegistryDomain}/${createUniqueImageId()}')
+                images.add('${dockerPrivateRegistryDomain}/${createUniqueImageId()}')
             }
 
             task removeImage(type: DockerRemoveImage) {
@@ -468,7 +468,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             task pushImage(type: DockerPushImage) {
                 dependsOn buildImage
                 finalizedBy removeImage
-                tags.set(buildImage.tags)
+                images.set(buildImage.images)
                 
                 onNext { p ->
                     logger.quiet p.status + ' ' + (p.progress ?: '')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerReactiveMethodsFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerReactiveMethodsFunctionalTest.groovy
@@ -116,13 +116,12 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ["/bin/sh","-c","echo Hello World"]
             }
 
@@ -163,8 +162,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
     
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task listImages(type: DockerListImages) {
@@ -389,13 +387,12 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.image.DockerInspectImage
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task inspectImage(type: DockerInspectImage) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 
                 onNext { image ->
                     logger.quiet 'Cmd:        ' + image.config.cmd
@@ -426,8 +423,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
 
             task pullImage(type: DockerPullImage) {
                 dependsOn removeImage
-                repository = 'busybox'
-                tag = 'musl'
+                tag = 'busybox:musl'
                 
                 onNext { p ->
                     logger.quiet p.status + ' ' + (p.progress ?: '')
@@ -472,7 +468,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
             task pushImage(type: DockerPushImage) {
                 dependsOn buildImage
                 finalizedBy removeImage
-                imageName = buildImage.tags.get().first()
+                tags.set(buildImage.tags)
                 
                 onNext { p ->
                     logger.quiet p.status + ' ' + (p.progress ?: '')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
@@ -134,12 +134,12 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractGroovyDslFunctiona
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['echo', 'Hello World']
             }
             

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
@@ -134,13 +134,12 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractGroovyDslFunctiona
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['echo', 'Hello World']
             }
             

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -26,7 +26,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['groups']
                 groups = ['postgres']
             }
@@ -57,7 +57,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 binds = ['/tmp': '/testdata']
             }
         """
@@ -87,7 +87,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['ifconfig']
                 macAddress = '02:03:04:05:06:07'
                 cpuset = '1'
@@ -110,7 +110,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['env']
                 
                 // add by appending new map to current map
@@ -142,7 +142,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 autoRemove = true
 
                 // The sleep is to keep the container around to avoid the
@@ -180,7 +180,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
             }
         """
 
@@ -207,7 +207,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 autoRemove = true
                 
                 cmd = ['sleep', '10']
@@ -257,8 +257,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             ${containerCreationTask}

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -26,7 +26,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['groups']
                 groups = ['postgres']
             }
@@ -57,7 +57,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 binds = ['/tmp': '/testdata']
             }
         """
@@ -87,7 +87,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['ifconfig']
                 macAddress = '02:03:04:05:06:07'
                 cpuset = '1'
@@ -110,7 +110,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['env']
                 
                 // add by appending new map to current map
@@ -142,7 +142,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 autoRemove = true
 
                 // The sleep is to keep the container around to avoid the
@@ -180,7 +180,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
             }
         """
 
@@ -207,7 +207,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         String containerCreationTask = """
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 autoRemove = true
                 
                 cmd = ['sleep', '10']
@@ -257,7 +257,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             ${containerCreationTask}

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -178,13 +178,12 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['sleep','$sleep']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -178,12 +178,12 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['sleep','$sleep']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecStopFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecStopFunctionalTest.groovy
@@ -86,13 +86,12 @@ class DockerExecStopFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.container.extras.DockerExecStopContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = 'postgres'
-                tag = 'alpine'
+                tag = 'postgres:alpine'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
             }
 
             task startContainer(type: DockerStartContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecStopFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecStopFunctionalTest.groovy
@@ -86,12 +86,12 @@ class DockerExecStopFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.container.extras.DockerExecStopContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = 'postgres:alpine'
+                image = 'postgres:alpine'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
             }
 
             task startContainer(type: DockerStartContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectExecContainerFunctionalTest.groovy
@@ -71,12 +71,12 @@ class DockerInspectExecContainerFunctionalTest extends AbstractGroovyDslFunction
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['sleep','10']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectExecContainerFunctionalTest.groovy
@@ -71,13 +71,12 @@ class DockerInspectExecContainerFunctionalTest extends AbstractGroovyDslFunction
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['sleep','10']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLivenessFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLivenessFunctionalTest.groovy
@@ -117,13 +117,12 @@ class DockerLivenessFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.container.extras.DockerExecStopContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = 'postgres'
-                tag = 'alpine'
+                tag = 'postgres:alpine'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
             }
 
             task startContainer(type: DockerStartContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLivenessFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLivenessFunctionalTest.groovy
@@ -117,12 +117,12 @@ class DockerLivenessFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.container.extras.DockerExecStopContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = 'postgres:alpine'
+                image = 'postgres:alpine'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
             }
 
             task startContainer(type: DockerStartContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
@@ -189,13 +189,12 @@ class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['/bin/sh','-c','echo -e "Hello World\\n  indent"']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
@@ -189,12 +189,12 @@ class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['/bin/sh','-c','echo -e "Hello World\\n  indent"']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerRenameContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerRenameContainerFunctionalTest.groovy
@@ -61,12 +61,12 @@ class DockerRenameContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.container.*
     
             task pullImage(type: DockerPullImage) {
-                tag = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE:$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
+                image = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE:$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
             }
     
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
             }
     
             task removeContainer(type: DockerRemoveContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerRenameContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerRenameContainerFunctionalTest.groovy
@@ -61,13 +61,12 @@ class DockerRenameContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
             import com.bmuschko.gradle.docker.tasks.container.*
     
             task pullImage(type: DockerPullImage) {
-                repository = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE'
-                tag = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
+                tag = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE:$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
             }
     
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
             }
     
             task removeContainer(type: DockerRemoveContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainerFunctionalTest.groovy
@@ -95,12 +95,12 @@ class DockerWaitContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             import com.bmuschko.gradle.docker.tasks.container.DockerWaitContainer
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer){
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd.addAll($containerCommand)
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitContainerFunctionalTest.groovy
@@ -95,13 +95,12 @@ class DockerWaitContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             import com.bmuschko.gradle.docker.tasks.container.DockerWaitContainer
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer){
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd.addAll($containerCommand)
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitHealthyContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitHealthyContainerFunctionalTest.groovy
@@ -76,13 +76,12 @@ class DockerWaitHealthyContainerFunctionalTest extends AbstractGroovyDslFunction
             import com.bmuschko.gradle.docker.tasks.container.extras.*
 
             task pullImage(type: DockerPullImage) {
-                repository = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE'
-                tag = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
+                tag = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE:$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 cmd = ['sleep','60']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitHealthyContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerWaitHealthyContainerFunctionalTest.groovy
@@ -76,12 +76,12 @@ class DockerWaitHealthyContainerFunctionalTest extends AbstractGroovyDslFunction
             import com.bmuschko.gradle.docker.tasks.container.extras.*
 
             task pullImage(type: DockerPullImage) {
-                tag = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE:$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
+                image = '$AbstractGroovyDslFunctionalTest.TEST_IMAGE:$AbstractGroovyDslFunctionalTest.TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 cmd = ['sleep','60']
             }
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -521,7 +521,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task pushImage(type: DockerPushImage) {
                 dependsOn buildImage
-                tags.set(buildImage.tags.get())
+                tags.set(buildImage.tags)
             }
 
             task removeImage(type: DockerRemoveImage) {
@@ -532,7 +532,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task pullImage(type: DockerPullImage) {
                 dependsOn removeImage
-                tag = '$uniqueTag'
+                tag = '$uniqueTag:latest'
             }
 
             task buildImageWithCacheFrom(type: DockerBuildImage) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -116,8 +116,8 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         BuildResult result = build('buildImageWithTags', 'buildImageWithTag')
 
         then:
-        result.output.contains("Using tags 'test/image:123', 'registry.com:5000/test/image:123' for image.")
-        result.output.contains("Using tags 'test/image:123' for image.")
+        result.output.contains("Using images 'test/image:123', 'registry.com:5000/test/image:123'.")
+        result.output.contains("Using images 'test/image:123'.")
     }
 
 
@@ -460,12 +460,12 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task buildImageWithTags(type: DockerBuildImage) {
                 dependsOn dockerfile
-                tags = ['test/image:123', "registry.com:5000/test/image:\$project.version"]
+                images = ['test/image:123', "registry.com:5000/test/image:\$project.version"]
             }
 
             task buildImageWithTag(type: DockerBuildImage) {
                 dependsOn dockerfile
-                tags.add('test/image:123')
+                images.add('test/image:123')
             }
 
             ${imageIdValidation()}
@@ -489,7 +489,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task buildImageWithCacheFrom(type: DockerBuildImage) {
                 dependsOn dockerfile
                 cacheFrom.add('$uniqueTag:latest')
-                tags.add('$uniqueTag:latest')
+                images.add('$uniqueTag:latest')
             }
 
             ${imageIdValidation()}
@@ -516,12 +516,12 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task buildImage(type: DockerBuildImage) {
                 dependsOn dockerfile
                 cacheFrom.add('$TEST_IMAGE_WITH_TAG') // no effect
-                tags.add('$uniqueTag')
+                images.add('$uniqueTag')
             }
 
             task pushImage(type: DockerPushImage) {
                 dependsOn buildImage
-                tags.set(buildImage.tags)
+                images.set(buildImage.images)
             }
 
             task removeImage(type: DockerRemoveImage) {
@@ -532,7 +532,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task pullImage(type: DockerPullImage) {
                 dependsOn removeImage
-                tag = '$uniqueTag:latest'
+                image = '$uniqueTag:latest'
             }
 
             task buildImageWithCacheFrom(type: DockerBuildImage) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -521,8 +521,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task pushImage(type: DockerPushImage) {
                 dependsOn buildImage
-                imageName = buildImage.tags.get().first()
-                tag = 'latest'
+                tags.set(buildImage.tags.get())
             }
 
             task removeImage(type: DockerRemoveImage) {
@@ -533,8 +532,7 @@ class DockerBuildImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task pullImage(type: DockerPullImage) {
                 dependsOn removeImage
-                repository = '$uniqueTag'
-                tag = 'latest'
+                tag = '$uniqueTag'
             }
 
             task buildImageWithCacheFrom(type: DockerBuildImage) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -59,13 +59,12 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 
             task pullImage(type: DockerPullImage) {
-                repository = '$TEST_IMAGE'
-                tag = '$TEST_IMAGE_TAG'
+                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getImageId()
+                targetImageId pullImage.getTag()
                 autoRemove = true
                 entrypoint = ['tail', '-f', '/dev/null']
             }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -15,7 +15,7 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 targetContainerId createContainer.getContainerId()
                 author = "john doe"
                 message = "My image created"
-                tag = "myimage:latest"
+                image = "myimage:latest"
             }
         """
 
@@ -37,7 +37,7 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task $COMMIT_TASK_NAME(type: DockerCommitImage) {
                 dependsOn startContainer
                 targetContainerId "idonotexist"
-                tag = "myimage:latest"
+                image = "myimage:latest"
             }
         """
 
@@ -60,12 +60,12 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.image.DockerPullImage
 
             task pullImage(type: DockerPullImage) {
-                tag = '$TEST_IMAGE:$TEST_IMAGE_TAG'
+                image = '$TEST_IMAGE:$TEST_IMAGE_TAG'
             }
 
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
-                targetImageId pullImage.getTag()
+                targetImageId pullImage.getImage()
                 autoRemove = true
                 entrypoint = ['tail', '-f', '/dev/null']
             }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -37,6 +37,7 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task $COMMIT_TASK_NAME(type: DockerCommitImage) {
                 dependsOn startContainer
                 targetContainerId "idonotexist"
+                tag = "myimage:latest"
             }
         """
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerListImagesFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerListImagesFunctionalTest.groovy
@@ -106,7 +106,7 @@ class DockerListImagesFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task buildImage(type: DockerBuildImage) {
                 dependsOn dockerfile
                 inputDir = file("build/docker")
-                tags.add("${IMAGE_ID}")
+                images.add("${IMAGE_ID}")
                 labels = ["setup":"${IMAGE_ID}"]
             }
             

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
@@ -15,7 +15,7 @@ class DockerSaveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.image.DockerSaveImage
 
             task saveImage(type: DockerSaveImage) {
-                tag = "${IMAGE}"
+                image = "${IMAGE}"
                 destFile = file("${IMAGE_FILE}")
             }
         """
@@ -32,14 +32,14 @@ class DockerSaveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.image.DockerSaveImage
 
             task saveImageControl(type: DockerSaveImage) {
-                tag = "${IMAGE}"
+                image = "${IMAGE}"
                 destFile = file("${CONTROL_SAVED_IMAGE}")
             }
 
             task saveImage(type: DockerSaveImage) {
                 dependsOn saveImageControl
                 useCompression = true
-                tag = "${IMAGE}"
+                image = "${IMAGE}"
                 destFile = file("${COMPRESSED_IMAGE_FILE}")
             }
         """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
@@ -4,20 +4,18 @@ import com.bmuschko.gradle.docker.AbstractGroovyDslFunctionalTest
 
 class DockerSaveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
-    private static final String REPOSITORY = "alpine"
-    private static final String TAG = "3.4"
+    private static final String IMAGE = "alpine:3.4"
     private static final String BUILD_DIR = 'build/docker'
-    private static final String CONTROL_SAVED_IMAGE = "$BUILD_DIR/$REPOSITORY-docker-image-control.tar"
-    private static final String IMAGE_FILE = "$BUILD_DIR/$REPOSITORY-docker-image.tar"
-    private static final String COMPRESSED_IMAGE_FILE = "$BUILD_DIR/$REPOSITORY-compressed-docker-image.tar.gz"
-    
+    private static final String CONTROL_SAVED_IMAGE = "$BUILD_DIR/alpine-3.4-docker-image-control.tar"
+    private static final String IMAGE_FILE = "$BUILD_DIR/alpine-3.4-docker-image.tar"
+    private static final String COMPRESSED_IMAGE_FILE = "$BUILD_DIR/alpine-3.4-compressed-docker-image.tar.gz"
+
     def "can save Docker image without compression"() {
         buildFile << """
             import com.bmuschko.gradle.docker.tasks.image.DockerSaveImage
 
             task saveImage(type: DockerSaveImage) {
-                repository = "${REPOSITORY}"
-                tag = "${TAG}"
+                tag = "${IMAGE}"
                 destFile = file("${IMAGE_FILE}")
             }
         """
@@ -34,16 +32,14 @@ class DockerSaveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             import com.bmuschko.gradle.docker.tasks.image.DockerSaveImage
 
             task saveImageControl(type: DockerSaveImage) {
-                repository = "${REPOSITORY}"
-                tag = "${TAG}"
+                tag = "${IMAGE}"
                 destFile = file("${CONTROL_SAVED_IMAGE}")
             }
 
             task saveImage(type: DockerSaveImage) {
                 dependsOn saveImageControl
                 useCompression = true
-                repository = "${REPOSITORY}"
-                tag = "${TAG}"
+                tag = "${IMAGE}"
                 destFile = file("${COMPRESSED_IMAGE_FILE}")
             }
         """

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -43,9 +43,9 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
 
         then:
         DockerBuildImage task = project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
-        Set<String> tags = task.tags.get()
-        tags.size() == 1
-        tags.first() == "${project.applicationName}:latest"
+        Set<String> images = task.images.get()
+        images.size() == 1
+        images.first() == "${project.applicationName}:latest"
     }
 
     def "Configures image task without project group and but with version"() {
@@ -58,9 +58,9 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
 
         then:
         DockerBuildImage task = project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
-        Set<String> tags = task.tags.get()
-        tags.size() == 1
-        tags.first() == "${project.applicationName}:${projectVersion}"
+        Set<String> images = task.images.get()
+        images.size() == 1
+        images.first() == "${project.applicationName}:${projectVersion}"
     }
 
     def "Configures image task with project group and version"() {
@@ -75,9 +75,9 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
 
         then:
         DockerBuildImage task = project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
-        Set<String> tags = task.tags.get()
-        tags.size() == 1
-        tags.first() == "${projectGroup}/${project.applicationName}:${projectVersion}"
+        Set<String> images = task.images.get()
+        images.size() == 1
+        images.first() == "${projectGroup}/${project.applicationName}:${projectVersion}"
     }
 
     def "Can access the dockerJava.javaApplication extension dynamically"() {
@@ -111,15 +111,15 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         when:
         ExtensionAware dockerExtension = (ExtensionAware) project.extensions.getByType(DockerExtension)
         DockerJavaApplication dockerJavaApplicationExtension = dockerExtension.extensions.getByType(DockerJavaApplication)
-        dockerJavaApplicationExtension.tags.add("some-test-tag")
+        dockerJavaApplicationExtension.images.add("some-test-tag")
 
         then:
         DockerBuildImage task = project
             .tasks
             .findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME) as DockerBuildImage
-        Set<String> tags = task.tags.get()
-        tags.size() == 1
-        tags.first() == testTagName
+        Set<String> images = task.images.get()
+        images.size() == 1
+        images.first() == testTagName
     }
 
     def "Can configure the dockerJava.javaApplication extension dynamically"() {
@@ -128,13 +128,13 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         applyDockerJavaApplicationPluginAndApplicationPlugin(project)
         when:
         project.docker.javaApplication {
-            tags.add(testTagName)
+            images.add(testTagName)
         }
         then:
         DockerBuildImage task = project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)
-        Set<String> tags = task.tags.get()
-        tags.size() == 1
-        tags.first() == testTagName
+        Set<String> images = task.images.get()
+        images.size() == 1
+        images.first() == testTagName
     }
 
     private void applyDockerJavaApplicationPluginWithoutApplicationPlugin(Project project) {

--- a/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
+++ b/src/integTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginIntegrationTest.groovy
@@ -111,7 +111,7 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         when:
         ExtensionAware dockerExtension = (ExtensionAware) project.extensions.getByType(DockerExtension)
         DockerJavaApplication dockerJavaApplicationExtension = dockerExtension.extensions.getByType(DockerJavaApplication)
-        dockerJavaApplicationExtension.tag.set("some-test-tag")
+        dockerJavaApplicationExtension.tags.add("some-test-tag")
 
         then:
         DockerBuildImage task = project
@@ -128,7 +128,7 @@ class DockerJavaApplicationPluginIntegrationTest extends AbstractIntegrationTest
         applyDockerJavaApplicationPluginAndApplicationPlugin(project)
         when:
         project.docker.javaApplication {
-            tag.set(testTagName)
+            tags.add(testTagName)
         }
         then:
         DockerBuildImage task = project.tasks.findByName(DockerJavaApplicationPlugin.BUILD_IMAGE_TASK_NAME)

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationExtension.groovy
@@ -19,6 +19,7 @@ import groovy.transform.CompileStatic
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 
 /**
  * The extension for configuring a conventional Docker plugin.
@@ -50,11 +51,13 @@ class DockerConventionApplicationExtension {
     final ListProperty<Integer> ports
 
     /**
-     * The tag used for the Docker image.
+     * The tags used for the Docker image e.g. {@code my-java-app:1.2.3}.
      * <p>
-     * Defaults to {@code <project.group>/<applicationName>:<project.version>}.
+     * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
+     *
+     * @since 6.0.0
      */
-    final Property<String> tag
+    final SetProperty<String> tags
 
     /**
      * The JVM arguments used to start the Java program.
@@ -72,7 +75,7 @@ class DockerConventionApplicationExtension {
         maintainer.set(System.getProperty('user.name'))
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
-        tag = objectFactory.property(String)
+        tags = objectFactory.setProperty(String).empty()
         jvmArgs = objectFactory.listProperty(String).empty()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationExtension.groovy
@@ -51,13 +51,13 @@ class DockerConventionApplicationExtension {
     final ListProperty<Integer> ports
 
     /**
-     * The tags used for the Docker image e.g. {@code my-java-app:1.2.3}.
+     * The images used for the build and push operation e.g. {@code vieux/apache:2.0}.
      * <p>
      * Defaults to {@code [<project.group>/<applicationName>:<project.version>]}.
      *
      * @since 6.0.0
      */
-    final SetProperty<String> tags
+    final SetProperty<String> images
 
     /**
      * The JVM arguments used to start the Java program.
@@ -75,7 +75,7 @@ class DockerConventionApplicationExtension {
         maintainer.set(System.getProperty('user.name'))
         ports = objectFactory.listProperty(Integer)
         ports.set([8080])
-        tags = objectFactory.setProperty(String).empty()
+        images = objectFactory.setProperty(String).empty()
         jvmArgs = objectFactory.listProperty(String).empty()
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationPlugin.groovy
@@ -155,18 +155,18 @@ abstract class DockerConventionApplicationPlugin<EXT extends DockerConventionApp
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Builds the Docker image for the application.'
                     dependsOn createDockerfileTask
-                    tags.addAll(determineImageTags(project, extension))
+                    images.addAll(determineImages(project, extension))
                 }
             }
         })
     }
 
-    private Provider<Set<String>> determineImageTags(Project project, EXT extension) {
+    private Provider<Set<String>> determineImages(Project project, EXT extension) {
         project.provider(new Callable<Set<String>>() {
             @Override
             Set<String> call() throws Exception {
-                if (extension.tags.getOrNull()) {
-                    return extension.tags.get()
+                if (extension.images.getOrNull()) {
+                    return extension.images.get()
                 }
 
                 String tagVersion = project.version == 'unspecified' ? 'latest' : project.version
@@ -184,7 +184,7 @@ abstract class DockerConventionApplicationPlugin<EXT extends DockerConventionApp
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Pushes created Docker image to the repository.'
                     dependsOn dockerBuildImageTask
-                    tags.set(dockerBuildImageTask.getTags())
+                    images.set(dockerBuildImageTask.getImages())
                 }
             }
         })

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -58,7 +58,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     final RegularFileProperty dockerFile = project.objects.fileProperty()
 
     /**
-     * Tags for image.
+     * The tags to build e.g. {@code my-java-app:1.2.3}.
      */
     @Input
     @Optional

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -58,11 +58,13 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     final RegularFileProperty dockerFile = project.objects.fileProperty()
 
     /**
-     * The tags to build e.g. {@code my-java-app:1.2.3}.
+     * The images including repository, image name and tag used e.g. {@code vieux/apache:2.0}.
+     *
+     * @since 6.0.0
      */
     @Input
     @Optional
-    final SetProperty<String> tags = project.objects.setProperty(String)
+    final SetProperty<String> images = project.objects.setProperty(String)
 
     /**
      * When {@code true}, do not use docker cache when building the image.
@@ -182,7 +184,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
     DockerBuildImage() {
         inputDir.set(project.layout.buildDirectory.dir('docker'))
-        tags.empty()
+        images.empty()
         noCache.set(false)
         remove.set(false)
         quiet.set(false)
@@ -221,10 +223,10 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             buildImageCmd = dockerClient.buildImageCmd(inputDir.get().asFile)
         }
 
-        if (tags.getOrNull()) {
-            def tagListString = tags.get().collect {"'${it}'"}.join(", ")
-            logger.quiet "Using tags ${tagListString} for image."
-            buildImageCmd.withTags(tags.get().collect { it.toString() }.toSet() )
+        if (images.getOrNull()) {
+            def tagListString = images.get().collect {"'${it}'"}.join(", ")
+            logger.quiet "Using images ${tagListString}."
+            buildImageCmd.withTags(images.get())
         }
 
         if (noCache.getOrNull()) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
@@ -23,18 +23,11 @@ import org.gradle.api.tasks.Internal
 import org.gradle.api.tasks.Optional
 
 class DockerCommitImage extends DockerExistingContainer {
-    /**
-     * Repository.
-     */
-    @Input
-    @Optional
-    final Property<String> repository = project.objects.property(String)
 
     /**
-     * Commit tag.
+     * The tag used to save the image e.g. {@code my-java-app:1.2.3}.
      */
     @Input
-    @Optional
     final Property<String> tag = project.objects.property(String)
 
     /**
@@ -70,14 +63,7 @@ class DockerCommitImage extends DockerExistingContainer {
     void runRemoteCommand() {
         logger.quiet "Committing image for container '${getContainerId().get()}'."
         CommitCmd commitCmd = dockerClient.commitCmd(getContainerId().get())
-
-        if(repository.getOrNull()) {
-            commitCmd.withRepository(repository.get())
-        }
-
-        if(tag.getOrNull()) {
-            commitCmd.withTag(tag.get())
-        }
+        commitCmd.withTag(tag.get())
 
         if(message.getOrNull()) {
             commitCmd.withMessage(message.get())

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
@@ -25,10 +25,12 @@ import org.gradle.api.tasks.Optional
 class DockerCommitImage extends DockerExistingContainer {
 
     /**
-     * The tag used to save the image e.g. {@code my-java-app:1.2.3}.
+     * The image including repository, image name and tag used e.g. {@code vieux/apache:2.0}.
+     *
+     * @since 6.0.0
      */
     @Input
-    final Property<String> tag = project.objects.property(String)
+    final Property<String> image = project.objects.property(String)
 
     /**
      * Commit message.
@@ -63,7 +65,7 @@ class DockerCommitImage extends DockerExistingContainer {
     void runRemoteCommand() {
         logger.quiet "Committing image for container '${getContainerId().get()}'."
         CommitCmd commitCmd = dockerClient.commitCmd(getContainerId().get())
-        commitCmd.withTag(tag.get())
+        commitCmd.withTag(image.get())
 
         if(message.getOrNull()) {
             commitCmd.withMessage(message.get())

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerExistingImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerExistingImage.groovy
@@ -43,7 +43,7 @@ abstract class DockerExistingImage extends AbstractDockerRemoteApiTask {
     }
 
     /**
-     * Sets the target container ID or name.
+     * Sets the target image ID or name.
      *
      * @param imageId Image ID or name as Callable
      * @see #targetImageId(String)
@@ -54,7 +54,7 @@ abstract class DockerExistingImage extends AbstractDockerRemoteApiTask {
     }
 
     /**
-     * Sets the target container ID or name.
+     * Sets the target image ID or name.
      *
      * @param imageId Image ID or name as Provider
      * @see #targetImageId(String)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
@@ -28,10 +28,12 @@ import org.gradle.api.tasks.Input
 class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCredentialsAware {
 
     /**
-     * The tag to pull e.g. {@code my-java-app:1.2.3}. The tag may include the repository.
+     * The image including repository, image name and tag used e.g. {@code vieux/apache:2.0}.
+     *
+     * @since 6.0.0
      */
     @Input
-    final Property<String> tag = project.objects.property(String)
+    final Property<String> image = project.objects.property(String)
 
     /**
      * {@inheritDoc}
@@ -40,8 +42,8 @@ class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCre
 
     @Override
     void runRemoteCommand() {
-        logger.quiet "Pulling image '${tag.get()}'."
-        PullImageCmd pullImageCmd = dockerClient.pullImageCmd(tag.get())
+        logger.quiet "Pulling image '${image.get()}'."
+        PullImageCmd pullImageCmd = dockerClient.pullImageCmd(image.get())
 
         if(registryCredentials) {
             AuthConfig authConfig = new AuthConfig()

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
@@ -26,8 +26,9 @@ import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 
 class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCredentialsAware {
+
     /**
-     * The tag to pull e.g. {@code my-java-app:1.2.3}. The tag should include the repository as needed.
+     * The tag to pull e.g. {@code my-java-app:1.2.3}. The tag may include the repository.
      */
     @Input
     final Property<String> tag = project.objects.property(String)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -26,13 +26,14 @@ import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 
 class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCredentialsAware {
+
     /**
-     * The tags to push e.g. {@code my-java-app:1.2.3}.
+     * The images including repository, image name and tag used e.g. {@code vieux/apache:2.0}.
      *
      * @since 6.0.0
      */
     @Input
-    final SetProperty<String> tags = project.objects.setProperty(String).empty()
+    final SetProperty<String> images = project.objects.setProperty(String).empty()
 
     /**
      * {@inheritDoc}
@@ -43,9 +44,9 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
     void runRemoteCommand() {
         AuthConfig authConfig = registryCredentials ? createAuthConfig() : null
 
-        tags.get().each { currentTag ->
-            logger.quiet "Pushing image with name '${currentTag}'."
-            PushImageCmd pushImageCmd = dockerClient.pushImageCmd(currentTag)
+        images.get().each { image ->
+            logger.quiet "Pushing image '${image}'."
+            PushImageCmd pushImageCmd = dockerClient.pushImageCmd(image)
 
             if(authConfig) {
                 pushImageCmd.withAuthConfig(authConfig)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -22,23 +22,17 @@ import com.github.dockerjava.api.command.PushImageCmd
 import com.github.dockerjava.api.model.AuthConfig
 import com.github.dockerjava.api.model.PushResponseItem
 import com.github.dockerjava.core.command.PushImageResultCallback
-import org.gradle.api.provider.Property
+import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.Optional
 
 class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCredentialsAware {
     /**
-     * The image name e.g. "bmuschko/busybox" or just "busybox" if you want to default.
+     * The tags to push e.g. {@code my-java-app:1.2.3}.
+     *
+     * @since 6.0.0
      */
     @Input
-    final Property<String> imageName = project.objects.property(String)
-
-    /**
-     * The image's tag.
-     */
-    @Input
-    @Optional
-    final Property<String> tag = project.objects.property(String)
+    final SetProperty<String> tags = project.objects.setProperty(String).empty()
 
     /**
      * {@inheritDoc}
@@ -47,49 +41,45 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
 
     @Override
     void runRemoteCommand() {
-        PushImageCmd pushImageCmd = dockerClient.pushImageCmd(imageName.get())
+        tags.get().each { currentTag ->
+            logger.quiet "Pushing image with name '${currentTag}'."
+            PushImageCmd pushImageCmd = dockerClient.pushImageCmd(currentTag)
 
-        if(tag.getOrNull()) {
-            pushImageCmd.withTag(tag.get())
-            logger.quiet "Pushing image with name '${imageName.get()}:${tag.get()}'."
-        } else {
-            logger.quiet "Pushing image with name '${imageName.get()}'."
-        }
+            if(registryCredentials) {
+                AuthConfig authConfig = new AuthConfig()
+                authConfig.registryAddress = registryCredentials.url.get()
 
-        if(registryCredentials) {
-            AuthConfig authConfig = new AuthConfig()
-            authConfig.registryAddress = registryCredentials.url.get()
-
-            if (registryCredentials.username.isPresent()) {
-                authConfig.withUsername(registryCredentials.username.get())
-            }
-
-            if (registryCredentials.password.isPresent()) {
-                authConfig.withPassword(registryCredentials.password.get())
-            }
-
-            if (registryCredentials.email.isPresent()) {
-                authConfig.withEmail(registryCredentials.email.get())
-            }
-
-            pushImageCmd.withAuthConfig(authConfig)
-        }
-
-        PushImageResultCallback callback = new PushImageResultCallback() {
-            @Override
-            void onNext(PushResponseItem item) {
-                if (nextHandler) {
-                    try {
-                        nextHandler.execute(item)
-                    } catch (Exception e) {
-                        logger.error('Failed to handle push response', e)
-                        return
-                    }
+                if (registryCredentials.username.isPresent()) {
+                    authConfig.withUsername(registryCredentials.username.get())
                 }
-                super.onNext(item)
-            }
-        }
 
-        pushImageCmd.exec(callback).awaitSuccess()
+                if (registryCredentials.password.isPresent()) {
+                    authConfig.withPassword(registryCredentials.password.get())
+                }
+
+                if (registryCredentials.email.isPresent()) {
+                    authConfig.withEmail(registryCredentials.email.get())
+                }
+
+                pushImageCmd.withAuthConfig(authConfig)
+            }
+
+            PushImageResultCallback callback = new PushImageResultCallback() {
+                @Override
+                void onNext(PushResponseItem item) {
+                    if (nextHandler) {
+                        try {
+                            nextHandler.execute(item)
+                        } catch (Exception e) {
+                            logger.error('Failed to handle push response', e)
+                            return
+                        }
+                    }
+                    super.onNext(item)
+                }
+            }
+
+            pushImageCmd.exec(callback).awaitCompletion()
+        }
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -41,26 +41,13 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
 
     @Override
     void runRemoteCommand() {
+        AuthConfig authConfig = registryCredentials ? createAuthConfig() : null
+
         tags.get().each { currentTag ->
             logger.quiet "Pushing image with name '${currentTag}'."
             PushImageCmd pushImageCmd = dockerClient.pushImageCmd(currentTag)
 
-            if(registryCredentials) {
-                AuthConfig authConfig = new AuthConfig()
-                authConfig.registryAddress = registryCredentials.url.get()
-
-                if (registryCredentials.username.isPresent()) {
-                    authConfig.withUsername(registryCredentials.username.get())
-                }
-
-                if (registryCredentials.password.isPresent()) {
-                    authConfig.withPassword(registryCredentials.password.get())
-                }
-
-                if (registryCredentials.email.isPresent()) {
-                    authConfig.withEmail(registryCredentials.email.get())
-                }
-
+            if(authConfig) {
                 pushImageCmd.withAuthConfig(authConfig)
             }
 
@@ -81,5 +68,24 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
 
             pushImageCmd.exec(callback).awaitCompletion()
         }
+    }
+
+    private AuthConfig createAuthConfig() {
+        AuthConfig authConfig = new AuthConfig()
+        authConfig.withRegistryAddress(registryCredentials.url.get())
+
+        if (registryCredentials.username.isPresent()) {
+            authConfig.withUsername(registryCredentials.username.get())
+        }
+
+        if (registryCredentials.password.isPresent()) {
+            authConfig.withPassword(registryCredentials.password.get())
+        }
+
+        if (registryCredentials.email.isPresent()) {
+            authConfig.withEmail(registryCredentials.email.get())
+        }
+
+        authConfig
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
@@ -15,16 +15,9 @@ import java.util.zip.GZIPOutputStream
 class DockerSaveImage extends AbstractDockerRemoteApiTask {
 
     /**
-     * The image repository.
+     * The tag used to save the image e.g. {@code my-java-app:1.2.3}.
      */
     @Input
-    final Property<String> repository = project.objects.property(String)
-
-    /**
-     * The image's tag.
-     */
-    @Input
-    @Optional
     final Property<String> tag = project.objects.property(String)
 
     @Input
@@ -43,11 +36,7 @@ class DockerSaveImage extends AbstractDockerRemoteApiTask {
 
     @Override
     void runRemoteCommand() {
-        SaveImageCmd saveImageCmd = dockerClient.saveImageCmd(repository.get())
-
-        if (tag.getOrNull()) {
-            saveImageCmd.withTag(tag.get())
-        }
+        SaveImageCmd saveImageCmd = dockerClient.saveImageCmd(tag.get())
         InputStream image = saveImageCmd.exec()
         OutputStream os
         try {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
@@ -15,10 +15,12 @@ import java.util.zip.GZIPOutputStream
 class DockerSaveImage extends AbstractDockerRemoteApiTask {
 
     /**
-     * The tag used to save the image e.g. {@code my-java-app:1.2.3}.
+     * The image including repository, image name and tag used e.g. {@code vieux/apache:2.0}.
+     *
+     * @since 6.0.0
      */
     @Input
-    final Property<String> tag = project.objects.property(String)
+    final Property<String> image = project.objects.property(String)
 
     @Input
     @Optional
@@ -36,7 +38,7 @@ class DockerSaveImage extends AbstractDockerRemoteApiTask {
 
     @Override
     void runRemoteCommand() {
-        SaveImageCmd saveImageCmd = dockerClient.saveImageCmd(tag.get())
+        SaveImageCmd saveImageCmd = dockerClient.saveImageCmd(image.get())
         InputStream image = saveImageCmd.exec()
         OutputStream os
         try {


### PR DESCRIPTION
This change takes a step-wise approach for the work started in https://github.com/bmuschko/gradle-docker-plugin/pull/835.

This is a breaking change and will be delivered with the next major version. The property for defining a single tag has been removed without a deprecation cycle. Unify other custom tasks to simplify and unify API.

- In its current implementation there's a one to one map from built tags to pushed tags. A later PR might introduce logic to make the push operation more selective about which tags to push.
- The API of the push task didn't align with the build task. Separating the repository from the tag led to misunderstandings from end users. Unifying both APIs makes a much easier to hand over the tags property values. The same goes for other tasks.
- Removed the method `DockerPullImage.getImageId()`. The returned value didn't really represent the image ID and therefore wasn't accurate. In fact you'd have to represent a list of image IDs if done right. You can simply ask for the Provider value of the `tag` property if required.