### PR TITLE
Improve DSL for configuring registry credentials for custom tasks

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractGroovyDslFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractGroovyDslFunctionalTest.groovy
@@ -68,8 +68,10 @@ abstract class AbstractGroovyDslFunctionalTest extends AbstractFunctionalTest {
 
         if (dockerPrivateRegistryUrl) {
             buildFile << """
-                docker.registryCredentials {
-                    url = '$dockerPrivateRegistryUrl'
+                docker {
+                    registryCredentials {
+                        url = '$dockerPrivateRegistryUrl'
+                    }
                 }
             """
         }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
@@ -16,6 +16,7 @@
 package com.bmuschko.gradle.docker
 
 import groovy.transform.CompileStatic
+import org.gradle.api.Action
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
@@ -58,6 +59,11 @@ class DockerExtension {
      */
     final Property<String> apiVersion
 
+    /**
+     * The target Docker registry credentials.
+     */
+    final DockerRegistryCredentials registryCredentials
+
     DockerExtension(ObjectFactory objectFactory) {
         url = objectFactory.property(String)
         url.set(getDefaultDockerUrl())
@@ -70,6 +76,17 @@ class DockerExtension {
         }
 
         apiVersion = objectFactory.property(String)
+        registryCredentials = objectFactory.newInstance(DockerRegistryCredentials, objectFactory)
+    }
+
+    /**
+     * Configures the target Docker registry credentials.
+     *
+     * @param action The action against the Docker registry credentials
+     * @since 6.0.0
+     */
+    void registryCredentials(Action<? super DockerRegistryCredentials> action) {
+        action.execute(registryCredentials)
     }
 
     private String getDefaultDockerUrl() {

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRegistryCredentials.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRegistryCredentials.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
 
 import javax.annotation.Nullable
+import javax.inject.Inject
 
 /**
  * The extension for configuring the Docker communication via the remote API through the {@link DockerRemoteApiPlugin}.
@@ -80,6 +81,7 @@ class DockerRegistryCredentials {
     @Optional
     final Property<String> email
 
+    @Inject
     DockerRegistryCredentials(ObjectFactory objectFactory) {
         url = objectFactory.property(String)
         url.set(DEFAULT_URL)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/RegistryCredentialsAware.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/RegistryCredentialsAware.groovy
@@ -17,9 +17,9 @@ package com.bmuschko.gradle.docker.tasks
 
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
 import groovy.transform.CompileStatic
+import org.gradle.api.Action
 import org.gradle.api.Task
 import org.gradle.api.tasks.Nested
-import org.gradle.api.tasks.Optional
 
 @CompileStatic
 interface RegistryCredentialsAware extends Task {
@@ -32,6 +32,13 @@ interface RegistryCredentialsAware extends Task {
      * The target Docker registry credentials for usage with a task.
      */
     @Nested
-    @Optional
     DockerRegistryCredentials getRegistryCredentials()
+
+    /**
+     * Configures the target Docker registry credentials for use with a task.
+     *
+     * @param action The action against the Docker registry credentials
+     * @since 6.0.0
+     */
+    void registryCredentials(Action<? super DockerRegistryCredentials> action)
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/RegistryCredentialsAware.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/RegistryCredentialsAware.groovy
@@ -24,11 +24,6 @@ import org.gradle.api.tasks.Nested
 @CompileStatic
 interface RegistryCredentialsAware extends Task {
     /**
-     * Sets the target Docker registry credentials for usage with a task.
-     */
-    void setRegistryCredentials(DockerRegistryCredentials registryCredentials)
-
-    /**
      * The target Docker registry credentials for usage with a task.
      */
     @Nested

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -165,7 +165,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     /**
      * {@inheritDoc}
      */
-    DockerRegistryCredentials registryCredentials
+    final DockerRegistryCredentials registryCredentials
 
     /**
      * Output file containing the image ID of the built image.

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -25,6 +25,7 @@ import com.github.dockerjava.api.model.AuthConfig
 import com.github.dockerjava.api.model.AuthConfigurations
 import com.github.dockerjava.api.model.BuildResponseItem
 import com.github.dockerjava.core.command.BuildImageResultCallback
+import org.gradle.api.Action
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.provider.MapProperty
@@ -191,6 +192,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
         pull.set(false)
         cacheFrom.empty()
         String safeTaskPath = path.replaceFirst("^:", "").replaceAll(":", "_")
+        registryCredentials = project.objects.newInstance(DockerRegistryCredentials)
         imageIdFile.set(project.layout.buildDirectory.file(".docker/${safeTaskPath}-imageId.txt"))
 
         outputs.upToDateWhen {
@@ -261,26 +263,9 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             buildImageCmd.withTarget(target.get())
         }
 
-        if (registryCredentials) {
-            AuthConfig authConfig = new AuthConfig()
-            authConfig.registryAddress = registryCredentials.url.get()
-
-            if (registryCredentials.username.isPresent()) {
-                authConfig.withUsername(registryCredentials.username.get())
-            }
-
-            if (registryCredentials.password.isPresent()) {
-                authConfig.withPassword(registryCredentials.password.get())
-            }
-
-            if (registryCredentials.email.isPresent()) {
-                authConfig.withEmail(registryCredentials.email.get())
-            }
-
-            AuthConfigurations authConfigurations = new AuthConfigurations()
-            authConfigurations.addConfig(authConfig)
-            buildImageCmd.withBuildAuthConfigs(authConfigurations)
-        }
+        AuthConfigurations authConfigurations = new AuthConfigurations()
+        authConfigurations.addConfig(createAuthConfig())
+        buildImageCmd.withBuildAuthConfigs(authConfigurations)
 
         if (buildArgs.getOrNull()) {
             buildArgs.get().each { arg, value ->
@@ -338,5 +323,35 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
                 super.close()
             }
         }
+    }
+
+    /**
+     * Configures the target Docker registry credentials.
+     *
+     * @param action The action against the Docker registry credentials
+     * @since 6.0.0
+     */
+    @Override
+    void registryCredentials(Action<? super DockerRegistryCredentials> action) {
+        action.execute(registryCredentials)
+    }
+
+    private AuthConfig createAuthConfig() {
+        AuthConfig authConfig = new AuthConfig()
+        authConfig.withRegistryAddress(registryCredentials.url.get())
+
+        if (registryCredentials.username.isPresent()) {
+            authConfig.withUsername(registryCredentials.username.get())
+        }
+
+        if (registryCredentials.password.isPresent()) {
+            authConfig.withPassword(registryCredentials.password.get())
+        }
+
+        if (registryCredentials.email.isPresent()) {
+            authConfig.withEmail(registryCredentials.email.get())
+        }
+
+        authConfig
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
@@ -39,7 +39,7 @@ class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCre
     /**
      * {@inheritDoc}
      */
-    DockerRegistryCredentials registryCredentials
+    final DockerRegistryCredentials registryCredentials
 
     DockerPullImage() {
         registryCredentials = project.objects.newInstance(DockerRegistryCredentials)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
@@ -22,6 +22,7 @@ import com.github.dockerjava.api.command.PullImageCmd
 import com.github.dockerjava.api.model.AuthConfig
 import com.github.dockerjava.api.model.PullResponseItem
 import com.github.dockerjava.core.command.PullImageResultCallback
+import org.gradle.api.Action
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 
@@ -40,29 +41,15 @@ class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCre
      */
     DockerRegistryCredentials registryCredentials
 
+    DockerPullImage() {
+        registryCredentials = project.objects.newInstance(DockerRegistryCredentials)
+    }
+
     @Override
     void runRemoteCommand() {
         logger.quiet "Pulling image '${image.get()}'."
         PullImageCmd pullImageCmd = dockerClient.pullImageCmd(image.get())
-
-        if(registryCredentials) {
-            AuthConfig authConfig = new AuthConfig()
-            authConfig.registryAddress = registryCredentials.url.get()
-
-            if (registryCredentials.username.isPresent()) {
-                authConfig.withUsername(registryCredentials.username.get())
-            }
-
-            if (registryCredentials.password.isPresent()) {
-                authConfig.withPassword(registryCredentials.password.get())
-            }
-
-            if (registryCredentials.email.isPresent()) {
-                authConfig.withEmail(registryCredentials.email.get())
-            }
-
-            pullImageCmd.withAuthConfig(authConfig)
-        }
+        pullImageCmd.withAuthConfig(createAuthConfig())
 
         PullImageResultCallback callback = new PullImageResultCallback() {
             @Override
@@ -80,5 +67,35 @@ class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCre
         }
 
         pullImageCmd.exec(callback).awaitCompletion()
+    }
+
+    /**
+     * Configures the target Docker registry credentials.
+     *
+     * @param action The action against the Docker registry credentials
+     * @since 6.0.0
+     */
+    @Override
+    void registryCredentials(Action<? super DockerRegistryCredentials> action) {
+        action.execute(registryCredentials)
+    }
+
+    private AuthConfig createAuthConfig() {
+        AuthConfig authConfig = new AuthConfig()
+        authConfig.withRegistryAddress(registryCredentials.url.get())
+
+        if (registryCredentials.username.isPresent()) {
+            authConfig.withUsername(registryCredentials.username.get())
+        }
+
+        if (registryCredentials.password.isPresent()) {
+            authConfig.withPassword(registryCredentials.password.get())
+        }
+
+        if (registryCredentials.email.isPresent()) {
+            authConfig.withEmail(registryCredentials.email.get())
+        }
+
+        authConfig
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -39,7 +39,7 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
     /**
      * {@inheritDoc}
      */
-    DockerRegistryCredentials registryCredentials
+    final DockerRegistryCredentials registryCredentials
 
     DockerPushImage() {
         registryCredentials = project.objects.newInstance(DockerRegistryCredentials)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -22,6 +22,7 @@ import com.github.dockerjava.api.command.PushImageCmd
 import com.github.dockerjava.api.model.AuthConfig
 import com.github.dockerjava.api.model.PushResponseItem
 import com.github.dockerjava.core.command.PushImageResultCallback
+import org.gradle.api.Action
 import org.gradle.api.provider.SetProperty
 import org.gradle.api.tasks.Input
 
@@ -40,9 +41,13 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
      */
     DockerRegistryCredentials registryCredentials
 
+    DockerPushImage() {
+        registryCredentials = project.objects.newInstance(DockerRegistryCredentials)
+    }
+
     @Override
     void runRemoteCommand() {
-        AuthConfig authConfig = registryCredentials ? createAuthConfig() : null
+        AuthConfig authConfig = createAuthConfig()
 
         images.get().each { image ->
             logger.quiet "Pushing image '${image}'."
@@ -88,5 +93,16 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
         }
 
         authConfig
+    }
+
+    /**
+     * Configures the target Docker registry credentials.
+     *
+     * @param action The action against the Docker registry credentials
+     * @since 6.0.0
+     */
+    @Override
+    void registryCredentials(Action<? super DockerRegistryCredentials> action) {
+        action.execute(registryCredentials)
     }
 }


### PR DESCRIPTION
* Always creates an instance of `DockerRegistryCredentials` for custom tasks
* Pass down values from extension
* Custom tasks can configure registry credential values with a DSL-like API