### PR TITLE
Allow configuring the main class name for convention plugins

### DIFF
--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -1,15 +1,18 @@
 === Extension
 
-The plugin defines an extension with the namespace `javaApplication` as a child of the `docker` namespace. The following properties can be configured:
+The plugin defines an extension with the namespace `javaApplication` as a child of the `docker` namespace. By default, the main class will be configured automatically by looking for a class with a `public static void main(String[])` method available in the classpath of the main source set.
+
+The following properties can be configured:
 
 [options="header"]
 |=======
-|Property name   |Type                               |Default value                                            |Description
-|`baseImage`     |`Property<String>`                 |`openjdk:jre-alpine`                                     |The Docker base image used for Java application.
-|`maintainer`    |`Property<String>`                 |Value of system property `user.name`                     |The maintainer of the image.
-|`ports`         |`ListProperty<Integer>`            |`[8080]`                                                 |The Docker image exposed ports.
-|`images`        |`SetProperty<String>`              |`[<project.group>/<applicationName>:<project.version>]`  |The images used for the build and push operation.
-|`jvmArgs`       |`ListProperty<String>`             |`[]`                                                     |The JVM arguments passed to the `java` command.
+|Property name   |Type                               |Default value                                                 |Description
+|`baseImage`     |`Property<String>`                 |`openjdk:jre-alpine`                                          |The Docker base image used for Java application.
+|`maintainer`    |`Property<String>`                 |Value of system property `user.name`                          |The maintainer of the image.
+|`ports`         |`ListProperty<Integer>`            |`[8080]`                                                      |The Docker image exposed ports.
+|`images`        |`SetProperty<String>`              |`[<project.group>/<applicationName>:<project.version>]`       |The images used for the build and push operation.
+|`jvmArgs`       |`ListProperty<String>`             |`[]`                                                          |The JVM arguments passed to the `java` command.
+|`mainClassName` |`Property<String>`                 |A unique main class name discovered by scanning the classpath |The main class name to use for starting the application. Setting an explicit value for this option is useful if your source code contains multiple main class files.
 |=======
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/docs/asciidoc/32-extension.adoc
+++ b/src/docs/asciidoc/32-extension.adoc
@@ -1,17 +1,19 @@
 [[spring-boot-plugin-extension]]
 === Extension
 
-The plugin defines an extension with the namespace `springBootApplication` as a child of the `docker` namespace.
+The plugin defines an extension with the namespace `springBootApplication` as a child of the `docker` namespace. By default, the main class will be configured automatically by looking for a class with a `public static void main(String[])` method available in the classpath of the main source set. The main class needs to use the https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/autoconfigure/SpringBootApplication.html[`org.springframework.boot.autoconfigure.SpringBootApplication`] annotation to be discoverable.
+
 The following properties can be configured:
 
 [options="header"]
 |=======
-|Property name   |Type                    |Default value                                           |Description
-|`baseImage`     |`Property<String>`      |`openjdk:jre-alpine`                                    |The Docker base image used for the Spring Boot application.
-|`maintainer`    |`Property<String>`      |Value of system property `user.name`                    |The maintainer of the image.
-|`ports`         |`ListProperty<Integer>` |`[8080]`                                                |The Docker image exposed ports.
-|`images`        |`SetProperty<String>`   |`[<project.group>/<applicationName>:<project.version>]` |The images used for the build and push operation.
-|`jvmArgs`       |`ListProperty<String>`  |`[]`                                                    |The JVM arguments passed to the `java` command.
+|Property name   |Type                    |Default value                                                 |Description
+|`baseImage`     |`Property<String>`      |`openjdk:jre-alpine`                                          |The Docker base image used for the Spring Boot application.
+|`maintainer`    |`Property<String>`      |Value of system property `user.name`                          |The maintainer of the image.
+|`ports`         |`ListProperty<Integer>` |`[8080]`                                                      |The Docker image exposed ports.
+|`images`        |`SetProperty<String>`   |`[<project.group>/<applicationName>:<project.version>]`       |The images used for the build and push operation.
+|`jvmArgs`       |`ListProperty<String>`  |`[]`                                                          |The JVM arguments passed to the `java` command.
+|`mainClassName` |`Property<String>`      |A unique main class name discovered by scanning the classpath |The main class name to use for starting the application. Setting an explicit value for this option is useful if your source code contains multiple main class files.
 |=======
 
 [source,groovy,indent=0,subs="verbatim,attributes",role="primary"]

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationExtension.groovy
@@ -68,6 +68,16 @@ class DockerConventionApplicationExtension {
      */
     final ListProperty<String> jvmArgs
 
+    /**
+     * The main class name to use for starting the application e.g. {@code com.bmuschko.app.Main}.
+     * <p>
+     * By default tries to automatically find the main class by scanning the classpath.
+     * The value of this property takes precedence and circumvents classpath scanning.
+     *
+     * @since 6.1.0
+     */
+    final Property<String> mainClassName
+
     DockerConventionApplicationExtension(ObjectFactory objectFactory) {
         baseImage = objectFactory.property(String)
         baseImage.set('openjdk:jre-alpine')
@@ -77,5 +87,6 @@ class DockerConventionApplicationExtension {
         ports.set([8080])
         images = objectFactory.setProperty(String).empty()
         jvmArgs = objectFactory.listProperty(String).empty()
+        mainClassName = objectFactory.property(String)
     }
 }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionApplicationPlugin.groovy
@@ -122,7 +122,7 @@ abstract class DockerConventionApplicationPlugin<EXT extends DockerConventionApp
                                 entrypoint.addAll(jvmArgs)
                             }
 
-                            entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", getApplicationMainClassName(project)])
+                            entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", getApplicationMainClassName(project, extension)])
                             entrypoint
                         }
                     }))
@@ -190,7 +190,11 @@ abstract class DockerConventionApplicationPlugin<EXT extends DockerConventionApp
         })
     }
 
-    private String getApplicationMainClassName(Project project) {
+    private String getApplicationMainClassName(Project project, EXT extension) {
+        if (extension.mainClassName.isPresent()) {
+            return extension.mainClassName.get()
+        }
+
         for (File classesDir : getMainJavaSourceSetOutput(project).classesDirs) {
             String mainClassName = findMainClassName(classesDir)
 


### PR DESCRIPTION
Covers the corner case where a project's main source set contains more than one main class file. In those situations, the end user will want to select which main class to use for starting the application.

For more information, see https://github.com/bmuschko/gradle-docker-plugin/issues/891.