### PR TITLE
ISSUE-887: Fix error logging on docker push task when auth config fil…

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
@@ -106,6 +106,9 @@ class RegistryAuthLocator {
             configFile.exists() ? 'exists' : 'does not exist',
             commandPathPrefix)
 
+        if (!(configFile.exists())) {
+            return defaultAuthConfig
+        }
         try {
             Map<String, Object> config = slurper.parse(configFile) as Map<String, Object>
 
@@ -127,7 +130,8 @@ class RegistryAuthLocator {
             }
 
         } catch(Exception ex) {
-            logger.error('Failure when attempting to lookup auth config ' +
+            logger.warn('Failure when attempting to lookup auth config ' +
+                // logger.warn('Failure when attempting to lookup auth config ' +
                 '(docker repository: {}, configFile: {}. ' +
                 'Falling back to docker-java default behaviour',
                 repository,

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -22,7 +22,7 @@ class RegistryAuthLocatorTest extends Specification {
         config.getRegistryAddress() == 'https://index.docker.io/v1/'
         !config.getUsername()
         !config.getPassword()
-        0 * logger.error(*_)
+        0 * logger.warn(*_)
     }
 
     def "AuthLocator works using store"() {
@@ -36,7 +36,7 @@ class RegistryAuthLocatorTest extends Specification {
         config.getRegistryAddress() == 'url'
         config.getUsername() == 'username'
         config.getPassword() == 'secret'
-        0 * logger.error(*_)
+        0 * logger.warn(*_)
     }
 
     def "AuthLocator works using helper and empty auth"() {
@@ -50,7 +50,7 @@ class RegistryAuthLocatorTest extends Specification {
         config.getRegistryAddress() == 'url'
         config.getUsername() == 'username'
         config.getPassword() == 'secret'
-        0 * logger.error(*_)
+        0 * logger.warn(*_)
     }
 
     def "AuthLocator works using auth"() {
@@ -63,7 +63,7 @@ class RegistryAuthLocatorTest extends Specification {
         then:
         config.getUsername() == null
         config.getAuth() == 'authkey'
-        0 * logger.error(*_)
+        0 * logger.warn(*_)
     }
 
     def "AuthLocator works using helper and existing auth"() {
@@ -78,7 +78,7 @@ class RegistryAuthLocatorTest extends Specification {
         !config.getUsername()
         config.getEmail() == 'not@val.id'
         config.getAuth() == 'encoded auth token'
-        0 * logger.error(*_)
+        0 * logger.warn(*_)
     }
 
     @PendingFeature
@@ -91,21 +91,21 @@ class RegistryAuthLocatorTest extends Specification {
 
         then:
         config == DEFAULT_AUTH_CONFIG
-        0 * logger.error(*_)
+        0 * logger.warn(*_)
     }
 
     def "AuthLocator returns default config when the file does not exist"() {
         given:
         RegistryAuthLocator locator = createAuthLocatorForMissingConfigFile('missing-file.json')
-        locator.setLogger(logger)
 
         when:
         AuthConfig config = locator.lookupAuthConfig('registry.example.com/org/repo')
 
         then:
         config == DEFAULT_AUTH_CONFIG
-        1 * logger.error(*_)
+        0 * logger.warn(*_)
     }
+
 
     def "AuthLocator returns default config when the file is invalid"() {
         given:
@@ -117,7 +117,8 @@ class RegistryAuthLocatorTest extends Specification {
 
         then:
         config == DEFAULT_AUTH_CONFIG
-        1 * logger.error(*_)
+        0 * logger.error(*_)
+        1 * logger.warn(*_)
     }
 
     def "AuthLocator returns default config when the credentials tool is missing"() {
@@ -129,7 +130,8 @@ class RegistryAuthLocatorTest extends Specification {
 
         then:
         config == DEFAULT_AUTH_CONFIG
-        2 * logger.error(*_)
+        1 * logger.error(*_)
+        1 * logger.warn(*_)
     }
 
     private RegistryAuthLocator createAuthLocatorForExistingConfigFile(String configName){


### PR DESCRIPTION
…e is not present

This fixes some of the problems mentioned in ISSUE-887, that logging 

* If the authentication configuration file cannot be found, just return the default configuration without logging (either loglevel warn or loglevel error)
* If the authentication configuration file cannot be parsed, we will go ahead with the registry push (as before) put log as a warn. The loglevel "warn" is correct for the situation "we found a problem but tried to continue"
* I have added tests that verify that logs are written to the correct log level.