### PR TITLE
ISSUE 887

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
@@ -249,6 +249,7 @@ class RegistryAuthLocator {
         String credentialHelperName = commandPathPrefix + credHelper
 
         String data = runCommand(hostName, credentialHelperName)
+        logger.debug('Credential helper response: {}', data)
         Map<String, String> helperResponse = slurper.parseText(data) as Map<String, String>
         logger.debug('Credential helper provided auth config for: {}', hostName)
 

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -80,6 +80,19 @@ class RegistryAuthLocatorTest extends Specification {
         0 * logger.error(*_)
     }
 
+    def "AuthLocator returns default config for Docker Desktop config without existing credentials"() {
+        given:
+        RegistryAuthLocator locator =
+            createAuthLocatorForExistingConfigFile('config-docker-desktop.json', false)
+
+        when:
+        AuthConfig config = locator.lookupAuthConfig('https://index.docker.io/v1/org/repo')
+
+        then:
+        config == DEFAULT_AUTH_CONFIG
+        2 * logger.error(*_)
+    }
+
     def "AuthLocator works for Docker Desktop config without existing credentials"() {
         given:
         RegistryAuthLocator locator = createAuthLocatorForExistingConfigFile('config-docker-desktop.json')
@@ -134,10 +147,15 @@ class RegistryAuthLocatorTest extends Specification {
         2 * logger.error(*_)
     }
 
-    private RegistryAuthLocator createAuthLocatorForExistingConfigFile(String configName){
+    private RegistryAuthLocator createAuthLocatorForExistingConfigFile(String configName, Boolean mockHelper = true){
         File configFile = new File(getClass().getResource(CONFIG_LOCATION + configName).toURI())
-        String command = configFile.getParentFile().getAbsolutePath() + '/docker-credential-'
-        RegistryAuthLocator locator = new RegistryAuthLocator(configFile, command)
+        RegistryAuthLocator locator
+        if (mockHelper) {
+            String command = configFile.getParentFile().getAbsolutePath() + '/docker-credential-'
+            locator = new RegistryAuthLocator(configFile, command)
+        } else {
+            locator = new RegistryAuthLocator(configFile)
+        }
         locator.setLogger(logger)
         locator
     }

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -81,7 +81,6 @@ class RegistryAuthLocatorTest extends Specification {
         0 * logger.error(*_)
     }
 
-    @PendingFeature
     def "AuthLocator works for Docker Desktop config without existing credentials"() {
         given:
         RegistryAuthLocator locator = createAuthLocatorForExistingConfigFile('config-docker-desktop.json')
@@ -90,7 +89,9 @@ class RegistryAuthLocatorTest extends Specification {
         AuthConfig config = locator.lookupAuthConfig('https://index.docker.io/v1/org/repo')
 
         then:
-        config == DEFAULT_AUTH_CONFIG
+        config.getRegistryAddress() == 'https://index.docker.io/v1/'
+        config.getUsername() == 'mac_user'
+        config.getPassword() == 'XXX'
         0 * logger.error(*_)
     }
 

--- a/src/test/resources/auth-config/docker-credential-desktop
+++ b/src/test/resources/auth-config/docker-credential-desktop
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $1 != "get" ]]; then
+    exit 1
+fi
+
+read > /dev/null
+
+echo '{"ServerURL":"https://index.docker.io/v1/","Username":"mac_user","Secret":"XXX"}'


### PR DESCRIPTION
Changes:
- Slightly improved the test case to be close to real ``docker-credential-desktop`` invocation. The response provided by the user is parsed with no error reported.
- Added a debug line so users can report the issue with credentials helper by  running the plugin with a debug flag and see the output 