### PR TITLE
Issue 905 fix with 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,8 +23,13 @@ repositories {
     jcenter()
 }
 
+configurations.all {
+    resolutionStrategy.force("com.kohlschutter.junixsocket:junixsocket-core:2.2.1")
+}
+
 dependencies {
     shaded("com.github.docker-java:docker-java:3.1.5")
+    shaded("com.kohlschutter.junixsocket:junixsocket-core:2.2.1")
     shaded("javax.activation:activation:1.1.1")
     shaded("org.ow2.asm:asm:7.0")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {


### PR DESCRIPTION
Fix for https://github.com/bmuschko/gradle-docker-plugin/issues/905

Forcing version of junixsocket-core to 2.2.1
Exactly same thing as https://github.com/docker-java/docker-java/pull/1280/commits, but without next release of  docker-java.