### PR TITLE
Having debug log-level for json parsing issues

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
@@ -196,7 +196,10 @@ class RegistryAuthLocator {
             Map authMap = entry.getValue() as Map
             if (authMap.size() > 0) {
                 String authJson = JsonOutput.toJson(entry.getValue())
-                AuthConfig authCfg = new JsonSlurper().parseText(authJson) as AuthConfig
+                AuthConfig authCfg = parseText(authJson) as AuthConfig
+                if (authCfg == null) {
+                    return null
+                }
                 return authCfg.withRegistryAddress(entry.getKey())
             }
         }
@@ -253,7 +256,10 @@ class RegistryAuthLocator {
 
         String data = runCommand(hostName, credentialHelperName)
         logger.debug('Credential helper response: {}', data)
-        Map<String, String> helperResponse = slurper.parseText(data) as Map<String, String>
+        Map<String, String> helperResponse = parseText(data) as Map<String, String>
+        if (helperResponse == null) {
+            return null
+        }
         logger.debug('Credential helper provided auth config for: {}', hostName)
 
         return new AuthConfig()
@@ -317,6 +323,15 @@ class RegistryAuthLocator {
         config.withPassword(parts[1])
         config.withAuth(null)
         return config
+    }
+
+    private Object parseText(String data) {
+        try {
+            return slurper.parseText(data)
+        } catch (Exception e) {
+            logger.debug('Failure parsing the json response {}', data, e)
+            return null
+        }
     }
 
     @PackageScope

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -149,6 +149,20 @@ class RegistryAuthLocatorTest extends Specification {
         2 * logger.error(*_)
     }
 
+    def "AuthLocator uses default config then store does not contain the credentials"() {
+        given:
+        RegistryAuthLocator locator =
+            createAuthLocatorForExistingConfigFile('config-auth-store.json')
+
+        when:
+        AuthConfig config = locator.lookupAuthConfig('https://index.docker.io/v1/org/repo')
+
+        then:
+        config == DEFAULT_AUTH_CONFIG
+        0 * logger.error(*_)
+        7 * logger.debug(*_)
+    }
+
     private RegistryAuthLocator createAuthLocatorForExistingConfigFile(String configName, Boolean mockHelper = true){
         File configFile = new File(getClass().getResource(CONFIG_LOCATION + configName).toURI())
         RegistryAuthLocator locator

--- a/src/test/resources/auth-config/config-auth-store.json
+++ b/src/test/resources/auth-config/config-auth-store.json
@@ -1,0 +1,9 @@
+{
+    "auths": {
+        "https://index.docker.io/v1/": {}
+    },
+    "HttpHeaders": {
+        "User-Agent": "Docker-Client/18.09.7 (linux)"
+    },
+    "credsStore": "secretservice"
+}

--- a/src/test/resources/auth-config/docker-credential-secretservice
+++ b/src/test/resources/auth-config/docker-credential-secretservice
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+if [[ $1 != "get" ]]; then
+    exit 1
+fi
+
+read > /dev/null
+
+echo 'credentials not found in native keychain'


### PR DESCRIPTION
closes #899 

The issue handles the parsing of the credential-helper output which is expected to be a JSON in most of the cases, however, it could sometimes be a plan text. 

In this case, the expected behaviour is not to rollback right there to a default AuthConfig, but keep looking for the auth credentials further