### PR TITLE
Retrieve all known credentials for DockerBuildImage custom task

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -267,9 +267,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
             buildImageCmd.withTarget(target.get())
         }
 
-        AuthConfigurations authConfigurations = new AuthConfigurations()
-        AuthConfig authConfig = getRegistryAuthLocator().createAuthConfig(registryCredentials)
-        authConfigurations.addConfig(authConfig)
+        AuthConfigurations authConfigurations = getRegistryAuthLocator().lookupAllAuthConfigs(registryCredentials);
         buildImageCmd.withBuildAuthConfigs(authConfigurations)
 
         if (buildArgs.getOrNull()) {

--- a/src/test/resources/auth-config/docker-credential-desktop
+++ b/src/test/resources/auth-config/docker-credential-desktop
@@ -1,9 +1,11 @@
 #!/bin/bash
 
-if [[ $1 != "get" ]]; then
+if [[ $1 == "get" ]]; then
+    read > /dev/null
+
+    echo '{"ServerURL":"https://index.docker.io/v1/","Username":"mac_user","Secret":"XXX"}'
+elif [[ $1 == "list" ]]; then
+    echo '{"https://index.docker.io/v1/": "mac_user"}'
+else
     exit 1
 fi
-
-read > /dev/null
-
-echo '{"ServerURL":"https://index.docker.io/v1/","Username":"mac_user","Secret":"XXX"}'

--- a/src/test/resources/auth-config/docker-credential-fake
+++ b/src/test/resources/auth-config/docker-credential-fake
@@ -1,13 +1,17 @@
 #!/bin/bash
 
-if [[ $1 != "get" ]]; then
+if [[ $1 == "get" ]]; then
+    read > /dev/null
+
+    echo '{' \
+         '  "ServerURL": "url",' \
+         '  "Username": "username",' \
+         '  "Secret": "secret"' \
+         '}'
+elif [[ $1 == "list" ]]; then
+    echo '{' \
+         '  "url": "username"' \
+         '}'
+else
     exit 1
 fi
-
-read > /dev/null
-
-echo '{' \
-     '  "ServerURL": "url",' \
-     '  "Username": "username",' \
-     '  "Secret": "secret"' \
-     '}'


### PR DESCRIPTION
Extend RegistryAuthLocator to retrieve all credentials known in .docker/config.json and the credentials store.

Fixes #908 