### PR TITLE
Add support for setting custom workingDir in DockerExecContainer task

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -124,6 +124,26 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
         result.output.contains('10000\n10001')
     }
 
+    def "Execute command with custom working directory within a running container"() {
+        given:
+        String containerExecutionTask = """
+            task execContainer(type: DockerExecContainer) {
+                dependsOn startContainer
+                finalizedBy removeContainer
+                targetContainerId startContainer.getContainerId()
+                withCommand(['pwd'])
+                workingDir = '/usr/local/bin/'
+            }
+        """
+        buildFile << containerUsage(containerExecutionTask)
+
+        when:
+        BuildResult result = build('execContainer')
+
+        then:
+        result.output.contains('/usr/local/bin')
+    }
+
     def "Fail if exitCode is not within allowed bounds"() {
         given:
         String containerExecutionTask = """
@@ -191,7 +211,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
                 dependsOn createContainer
                 targetContainerId createContainer.getContainerId()
             }
-            
+
             task removeContainer(type: DockerRemoveContainer) {
                 removeVolumes = true
                 force = true

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
@@ -59,6 +59,16 @@ class DockerExecContainer extends DockerExistingContainer {
     @Optional
     final Property<String> user = project.objects.property(String)
 
+    /**
+     * Working directory in which the command is going to be executed.
+     * Defaults to the WORKDIR set in docker file.
+     *
+     * @since 6.3.0
+     */
+    @Input
+    @Optional
+    final Property<String> workingDir = project.objects.property(String)
+
     // if set will check exit code of exec to ensure it's
     // within this list of allowed values otherwise through exception
     @Input
@@ -179,6 +189,10 @@ class DockerExecContainer extends DockerExistingContainer {
 
         if (user.getOrNull()) {
             containerCommand.withUser(user.get())
+        }
+
+        if (workingDir.getOrNull()) {
+            containerCommand.withWorkingDir(workingDir.get())
         }
     }
 


### PR DESCRIPTION
This allows to set a different workingDir for the exec task which overrides the WORKDIR set in the Dockerfile.

closes #924
