### PR TITLE
Support for Java 13 and 14

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,7 +26,7 @@ repositories {
 dependencies {
     shaded("com.github.docker-java:docker-java:3.2.0")
     shaded("javax.activation:activation:1.1.1")
-    shaded("org.ow2.asm:asm:7.0")
+    shaded("org.ow2.asm:asm:7.3.1")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {
         exclude(group = "org.codehaus.groovy")
     }


### PR DESCRIPTION
Should close #912 which is closed right now though it should not be.
See details in the comments there:
- https://github.com/bmuschko/gradle-docker-plugin/issues/912#issuecomment-601934449
- https://github.com/bmuschko/gradle-docker-plugin/issues/912#issuecomment-602113145

Please notice that the issue is only present in the `docker-spring-boot-application` plugin only if you don't specify the `mainClassName` and the plugin needs to find it.

I tested locally with
- `OpenJDK 13.0.2` using `Gradle 6.2.2`
- `AdoptOpenJDK 13.0.2 HotSpot` using `Gradle 6.2.2`
- `AdoptOpenJDK 14.0.0 HotSpot` using `Gradle 6.3-rc-4` (6.2.2 does not support 14)

So after Gradle 6.3 will be released this plugin will automatically support Java 14 too.
