### PR TITLE
ISSUE-931: use a MapProperty for volumesFrom, allowing access modes

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -271,7 +271,7 @@ class DockerCreateContainer extends DockerExistingImage {
         }
 
         if(hostConfig.volumesFrom.getOrNull()) {
-            List<VolumesFrom> createdVolumes = hostConfig.volumesFrom.get().collect { new VolumesFrom(it) }
+            List<VolumesFrom> createdVolumes = hostConfig.volumesFrom.get().collect { VolumesFrom.parse([it.key, it.value].join(':')) }
             containerCommand.hostConfig.withVolumesFrom(createdVolumes)
         }
 
@@ -405,7 +405,7 @@ class DockerCreateContainer extends DockerExistingImage {
 
         @Input
         @Optional
-        final ListProperty<String> volumesFrom
+        final MapProperty<String, String> volumesFrom
 
         @Input
         @Optional
@@ -498,8 +498,7 @@ class DockerCreateContainer extends DockerExistingImage {
             network = objectFactory.property(String)
             links = objectFactory.listProperty(String)
             links.empty()
-            volumesFrom = objectFactory.listProperty(String)
-            volumesFrom.empty()
+            volumesFrom = objectFactory.mapProperty(String, String)
             portBindings = objectFactory.listProperty(String)
             portBindings.empty()
             publishAll = objectFactory.property(Boolean)


### PR DESCRIPTION
This allows users of the plugin to mount volumes from running containers (using the volumesFrom / 
`--volumes-from` functionality) in read-only mode as well, instead of only the default read-write access mode. They can do this by specifying the desired access mode, either `"ro"` or `"rw"`, in the map passed assigned to `hostConfig.volumesFrom`.
An example would be:
```
task createContainer(type: DockerCreateContainer) {
    imageId = exampleImage
    hostConfig.volumesFrom = ['anotherContainer':'ro']
    containerName = exampleContainer
}
```