### PR TITLE
Fixes Issue-648

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.groovy
@@ -83,9 +83,9 @@ class DockerCopyFileToContainer extends DockerExistingContainer {
         }
 
         if (copyFileToContainer.remotePath instanceof Closure) {
-            containerCommand.withRemotePath(copyFileToContainer.remotePath.call())
+            containerCommand.withRemotePath(copyFileToContainer.remotePath.call() as String)
         } else {
-            containerCommand.withRemotePath(copyFileToContainer.remotePath)
+            containerCommand.withRemotePath(copyFileToContainer.remotePath as String)
         }
 
         if (copyFileToContainer.isTar) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.groovy
@@ -82,14 +82,12 @@ class DockerCopyFileToContainer extends DockerExistingContainer {
             localHostPath = project.file(copyFileToContainer.hostPath)
         }
 
-        def localRemotePath
         if (copyFileToContainer.remotePath instanceof Closure) {
-            localRemotePath = project.file(copyFileToContainer.remotePath.call())
+            containerCommand.withRemotePath(copyFileToContainer.remotePath.call())
         } else {
-            localRemotePath = project.file(copyFileToContainer.remotePath)
+            containerCommand.withRemotePath(copyFileToContainer.remotePath)
         }
 
-        containerCommand.withRemotePath(localRemotePath.path)
         if (copyFileToContainer.isTar) {
             containerCommand.withTarInputStream(localHostPath.newInputStream())
         } else {


### PR DESCRIPTION
Hi,

this fixes the Issue-931.

The problem was that the remote path was passed to project.file() which will convert a relative path to an absolute path based on the project dir.

Under windows, a Linux path like '/tmp' will be interpreted as a relative path and converted to an absolute path like 'C:\code\project\tmp' which of course does not exist in the linux container.

So now the remote path is passed to the container without modification.
