### PR TITLE
Use configuration avoidance API

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
@@ -45,7 +45,7 @@ final class DockerConventionPluginFixture {
 
             def createContainer = tasks.register('createContainer', DockerCreateContainer) {
                 dependsOn dockerBuildImage
-                targetImageId dockerBuildImage.get().getImageId()
+                targetImageId dockerBuildImage.getImageId()
             }
 
             def startContainer = tasks.register('startContainer', DockerStartContainer) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
@@ -45,22 +45,22 @@ final class DockerConventionPluginFixture {
 
             def createContainer = tasks.register('createContainer', DockerCreateContainer) {
                 dependsOn dockerBuildImage
-                targetImageId dockerBuildImage.getImageId()
+                targetImageId dockerBuildImage.get().getImageId()
             }
 
             def startContainer = tasks.register('startContainer', DockerStartContainer) {
                 dependsOn createContainer
-                targetContainerId createContainer.getContainerId()
+                targetContainerId createContainer.get().getContainerId()
             }
 
             def stopContainer = tasks.register('stopContainer', DockerStopContainer) {
                 dependsOn startContainer
-                targetContainerId startContainer.getContainerId()
+                targetContainerId startContainer.get().getContainerId()
             }
 
             def removeContainer = tasks.register('removeContainer', DockerRemoveContainer) {
                 dependsOn stopContainer
-                targetContainerId stopContainer.getContainerId()
+                targetContainerId stopContainer.get().getContainerId()
             }
 
             def startAndRemoveContainer = tasks.register('startAndRemoveContainer') {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
@@ -38,32 +38,34 @@ final class DockerConventionPluginFixture {
 
     static String containerTasks() {
         """
+            import org.gradle.api.Task
+            import org.gradle.api.tasks.TaskProvider
             import com.bmuschko.gradle.docker.tasks.container.DockerCreateContainer
             import com.bmuschko.gradle.docker.tasks.container.DockerStartContainer
             import com.bmuschko.gradle.docker.tasks.container.DockerStopContainer
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
-            def createContainer = tasks.register('createContainer', DockerCreateContainer) {
+            TaskProvider<DockerCreateContainer> createContainer = tasks.register('createContainer', DockerCreateContainer) {
                 dependsOn dockerBuildImage
                 targetImageId dockerBuildImage.getImageId()
             }
 
-            def startContainer = tasks.register('startContainer', DockerStartContainer) {
+            TaskProvider<DockerStartContainer> startContainer = tasks.register('startContainer', DockerStartContainer) {
                 dependsOn createContainer
                 targetContainerId createContainer.get().getContainerId()
             }
 
-            def stopContainer = tasks.register('stopContainer', DockerStopContainer) {
+            TaskProvider<DockerStopContainer> stopContainer = tasks.register('stopContainer', DockerStopContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.get().getContainerId()
             }
 
-            def removeContainer = tasks.register('removeContainer', DockerRemoveContainer) {
+            TaskProvider<DockerRemoveContainer> removeContainer = tasks.register('removeContainer', DockerRemoveContainer) {
                 dependsOn stopContainer
                 targetContainerId stopContainer.get().getContainerId()
             }
 
-            def startAndRemoveContainer = tasks.register('startAndRemoveContainer') {
+            TaskProvider<Task> startAndRemoveContainer = tasks.register('startAndRemoveContainer') {
                 dependsOn startContainer
                 finalizedBy removeContainer
             }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
@@ -17,19 +17,19 @@ final class DockerConventionPluginFixture {
     static String imageTasks() {
         """
             import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
-            
-            task removeImage(type: DockerRemoveImage) {
+
+            def removeImage = tasks.register('removeImage', DockerRemoveImage) {
                 dependsOn dockerBuildImage
                 targetImageId dockerBuildImage.getImageId()
                 force = true
             }
-            
-            task buildAndRemoveImage {
+
+            def buildAndRemoveImage = tasks.register('buildAndRemoveImage') {
                 dependsOn dockerBuildImage
                 finalizedBy removeImage
             }
-            
-            task pushAndRemoveImage {
+
+            def pushAndRemoveImage = tasks.register('pushAndRemoveImage') {
                 dependsOn dockerPushImage
                 finalizedBy removeImage
             }
@@ -43,27 +43,27 @@ final class DockerConventionPluginFixture {
             import com.bmuschko.gradle.docker.tasks.container.DockerStopContainer
             import com.bmuschko.gradle.docker.tasks.container.DockerRemoveContainer
 
-            task createContainer(type: DockerCreateContainer) {
+            def createContainer = tasks.register('createContainer', DockerCreateContainer) {
                 dependsOn dockerBuildImage
                 targetImageId dockerBuildImage.getImageId()
             }
 
-            task startContainer(type: DockerStartContainer) {
+            def startContainer = tasks.register('startContainer', DockerStartContainer) {
                 dependsOn createContainer
                 targetContainerId createContainer.getContainerId()
             }
-            
-            task stopContainer(type: DockerStopContainer) {
+
+            def stopContainer = tasks.register('stopContainer', DockerStopContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.getContainerId()
             }
-            
-            task removeContainer(type: DockerRemoveContainer) {
+
+            def removeContainer = tasks.register('removeContainer', DockerRemoveContainer) {
                 dependsOn stopContainer
                 targetContainerId stopContainer.getContainerId()
             }
-            
-            task startAndRemoveContainer {
+
+            def startAndRemoveContainer = tasks.register('startAndRemoveContainer') {
                 dependsOn startContainer
                 finalizedBy removeContainer
             }
@@ -72,9 +72,11 @@ final class DockerConventionPluginFixture {
 
     static String lifecycleTask() {
         """
-            removeImage.mustRunAfter removeContainer
+            removeImage.configure {
+                mustRunAfter removeContainer
+            }
 
-            task buildAndCleanResources {
+            tasks.register('buildAndCleanResources') {
                 dependsOn startAndRemoveContainer
                 finalizedBy removeImage
             }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
@@ -27,12 +27,12 @@ import groovy.transform.CompileStatic
 import org.gradle.api.Action
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.file.Directory
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
-
 /**
  * The abstract class for all conventional JVM application plugins.
  *
@@ -146,7 +146,12 @@ abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerConvention
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = "Copies the distribution resources to a temporary directory for image creation."
                     dependsOn project.tasks.getByName(JavaPlugin.CLASSES_TASK_NAME)
-                    into(createDockerfileTask.get().destDir)
+                    into(project.provider(new Callable<Provider<Directory>>() {
+                        @Override
+                        Provider<Directory> call() throws Exception {
+                            createDockerfileTask.get().destDir
+                        }
+                    }))
                     with(createAppFilesCopySpec(project))
                 }
             }

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
@@ -146,10 +146,10 @@ abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerConvention
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = "Copies the distribution resources to a temporary directory for image creation."
                     dependsOn project.tasks.getByName(JavaPlugin.CLASSES_TASK_NAME)
-                    into(project.provider(new Callable<Provider<Directory>>() {
+                    into(project.provider(new Callable<Directory>() {
                         @Override
-                        Provider<Directory> call() throws Exception {
-                            createDockerfileTask.get().destDir
+                        Directory call() throws Exception {
+                            createDockerfileTask.get().destDir.get()
                         }
                     }))
                     with(createAppFilesCopySpec(project))
@@ -195,7 +195,12 @@ abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerConvention
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Pushes created Docker image to the repository.'
                     dependsOn dockerBuildImageTask
-                    images.set(dockerBuildImageTask.get().getImages())
+                    images.convention(project.provider(new Callable<Set<String>>() {
+                        @Override
+                        Set<String> call() throws Exception {
+                            dockerBuildImageTask.get().getImages().get()
+                        }
+                    }))
                 }
             }
         })

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
@@ -15,6 +15,11 @@
  */
 package com.bmuschko.gradle.docker
 
+import static com.bmuschko.gradle.docker.internal.ConventionPluginHelper.createAppFilesCopySpec
+import static com.bmuschko.gradle.docker.internal.ConventionPluginHelper.getMainJavaSourceSetOutput
+
+import java.util.concurrent.Callable
+
 import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 import com.bmuschko.gradle.docker.tasks.image.DockerPushImage
 import com.bmuschko.gradle.docker.tasks.image.Dockerfile
@@ -26,11 +31,7 @@ import org.gradle.api.model.ObjectFactory
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.Sync
-
-import java.util.concurrent.Callable
-
-import static com.bmuschko.gradle.docker.internal.ConventionPluginHelper.createAppFilesCopySpec
-import static com.bmuschko.gradle.docker.internal.ConventionPluginHelper.getMainJavaSourceSetOutput
+import org.gradle.api.tasks.TaskProvider
 
 /**
  * The abstract class for all conventional JVM application plugins.
@@ -67,16 +68,21 @@ abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerConvention
         EXT extension = configureExtension(project.objects, dockerExtension)
 
         project.plugins.withType(JavaPlugin) {
-            Dockerfile createDockerfileTask = createDockerfileTask(project, extension)
-            Sync syncBuildContextTask = createSyncBuildContextTask(project, createDockerfileTask)
-            createDockerfileTask.dependsOn syncBuildContextTask
-            DockerBuildImage dockerBuildImageTask = createBuildImageTask(project, createDockerfileTask, extension)
-            createPushImageTask(project, dockerBuildImageTask)
+            TaskProvider<Dockerfile> createDockerfileTask = registerDockerfileTask(project, extension)
+            TaskProvider<Sync> syncBuildContextTask = registerSyncBuildContextTask(project, createDockerfileTask)
+            createDockerfileTask.configure(new Action<Dockerfile>() {
+                @Override
+                void execute(Dockerfile dockerfile) {
+                    dockerfile.dependsOn(syncBuildContextTask)
+                }
+            })
+            TaskProvider<DockerBuildImage> dockerBuildImageTask = registerBuildImageTask(project, createDockerfileTask, extension)
+            registerPushImageTask(project, dockerBuildImageTask)
         }
     }
 
-    private Dockerfile createDockerfileTask(Project project, EXT extension) {
-        project.tasks.create(DOCKERFILE_TASK_NAME, Dockerfile, new Action<Dockerfile>() {
+    private TaskProvider<Dockerfile> registerDockerfileTask(Project project, EXT extension) {
+        project.tasks.register(DOCKERFILE_TASK_NAME, Dockerfile, new Action<Dockerfile>() {
             @Override
             void execute(Dockerfile dockerfile) {
                 dockerfile.with {
@@ -132,23 +138,23 @@ abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerConvention
         })
     }
 
-    private static Sync createSyncBuildContextTask(Project project, Dockerfile createDockerfileTask) {
-        project.tasks.create(SYNC_BUILD_CONTEXT_TASK_NAME, Sync, new Action<Sync>() {
+    private static TaskProvider<Sync> registerSyncBuildContextTask(Project project, TaskProvider<Dockerfile> createDockerfileTask) {
+        project.tasks.register(SYNC_BUILD_CONTEXT_TASK_NAME, Sync, new Action<Sync>() {
             @Override
             void execute(Sync sync) {
                 sync.with {
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = "Copies the distribution resources to a temporary directory for image creation."
                     dependsOn project.tasks.getByName(JavaPlugin.CLASSES_TASK_NAME)
-                    into(createDockerfileTask.destDir)
+                    into(createDockerfileTask.get().destDir)
                     with(createAppFilesCopySpec(project))
                 }
             }
         })
     }
 
-    private DockerBuildImage createBuildImageTask(Project project, Dockerfile createDockerfileTask, EXT extension) {
-        project.tasks.create(BUILD_IMAGE_TASK_NAME, DockerBuildImage, new Action<DockerBuildImage>() {
+    private TaskProvider<DockerBuildImage> registerBuildImageTask(Project project, TaskProvider<Dockerfile> createDockerfileTask, EXT extension) {
+        project.tasks.register(BUILD_IMAGE_TASK_NAME, DockerBuildImage, new Action<DockerBuildImage>() {
             @Override
             void execute(DockerBuildImage dockerBuildImage) {
                 dockerBuildImage.with {
@@ -176,15 +182,15 @@ abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerConvention
         })
     }
 
-    private static void createPushImageTask(Project project, DockerBuildImage dockerBuildImageTask) {
-        project.tasks.create(PUSH_IMAGE_TASK_NAME, DockerPushImage, new Action<DockerPushImage>() {
+    private static void registerPushImageTask(Project project, TaskProvider<DockerBuildImage> dockerBuildImageTask) {
+        project.tasks.register(PUSH_IMAGE_TASK_NAME, DockerPushImage, new Action<DockerPushImage>() {
             @Override
             void execute(DockerPushImage pushImage) {
                 pushImage.with {
                     group = DockerRemoteApiPlugin.DEFAULT_TASK_GROUP
                     description = 'Pushes created Docker image to the repository.'
                     dependsOn dockerBuildImageTask
-                    images.set(dockerBuildImageTask.getImages())
+                    images.set(dockerBuildImageTask.get().getImages())
                 }
             }
         })

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -46,7 +46,7 @@ class DockerRemoteApiPlugin implements Plugin<Project> {
     }
 
     private void configureRegistryCredentialsAwareTasks(Project project, DockerRegistryCredentials extensionRegistryCredentials) {
-        project.tasks.withType(RegistryCredentialsAware, new Action<RegistryCredentialsAware>() {
+        project.tasks.withType(RegistryCredentialsAware).configureEach(new Action<RegistryCredentialsAware>() {
             @Override
             void execute(RegistryCredentialsAware task) {
                 task.registryCredentials.url.set(extensionRegistryCredentials.url)


### PR DESCRIPTION
closes #674

The plugin already implements all the necessary logic for configuration avoidance. However, all `RegistryCredentialsAware` were still eagerly configured.

As mentioned in [Configuration avoidance migration guide](https://docs.gradle.org/current/userguide/task_configuration_avoidance.html#sec:old_vs_new_configuration_api_overview), instead of 
```
withType(java.lang.Class, org.gradle.api.Action)
```
one should use 
```
withType(java.lang.Class).configureEach(org.gradle.api.Action)
```

Confirmed locally that tasks are no longer eagerly configured.