### PR TITLE
Default to communication transport to Apache HttpClient 5

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,8 @@ repositories {
 }
 
 dependencies {
-    shaded("com.github.docker-java:docker-java:3.2.0")
+    shaded("com.github.docker-java:docker-java:3.2.2")
+    shaded("com.github.docker-java:docker-java-transport-httpclient5:3.2.2")
     shaded("javax.activation:activation:1.1.1")
     shaded("org.ow2.asm:asm:7.3.1")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {

--- a/src/docs/asciidoc/12-extension.adoc
+++ b/src/docs/asciidoc/12-extension.adoc
@@ -73,5 +73,5 @@ include::{samplesCodeDir}/remote-api-plugin/basic/kotlin/build.gradle.kts[tags=e
 
 On Unix the Docker daemon listens by default on `unix:///var/run/docker.sock`.
 
-On Windows the Docker daemon listens by default on `npipe:////./pipe/docker_engine` though this is not currently supported.
-We instead fall back to `tcp://127.0.0.1:2375`.
+On Windows the Docker daemon listens by default on `npipe:////./pipe/docker_engine` if this exists.
+We fall back to `tcp://127.0.0.1:2375` where the pipe does not exist.

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerMultipleClientFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerMultipleClientFunctionalTest.groovy
@@ -16,7 +16,7 @@ class DockerMultipleClientFunctionalTest extends AbstractGroovyDslFunctionalTest
                 }
             }
             task dockerClient2(type: DockerOperation) {
-                url = 'tcp://docker.corp.com'
+                url = 'tcp://docker.corp.com:2375'
                 onNext { client ->
                     if (client != null) {
                         logger.quiet "config: " + client.dockerClientConfig.toString()
@@ -24,7 +24,7 @@ class DockerMultipleClientFunctionalTest extends AbstractGroovyDslFunctionalTest
                 }
             }
             task dockerClient3(type: DockerOperation) {
-                url = 'tcp://docker.school.edu'
+                url = 'tcp://docker.school.edu:2375'
                 certPath = new File('/tmp')
                 onNext { client ->
                     if (client != null) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -181,6 +181,10 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
             task createContainer(type: DockerCreateContainer) {
                 dependsOn pullImage
                 targetImageId pullImage.getImage()
+
+                // The sleep is to keep the container around to avoid the
+                // stopContainer task failing due to the container not existing.
+                cmd = ['sleep', '2']
             }
         """
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
@@ -97,13 +97,7 @@ class DockerExtension {
                 dockerUrl = 'unix:///var/run/docker.sock'
             } else {
                 if (isWindows && new File("\\\\.\\pipe\\docker_engine").exists()) {
-                    // TODO: re-enable once docker-java supports named pipes. Relevant links:
-                    //
-                    //     https://github.com/bmuschko/gradle-docker-plugin/pull/313
-                    //     https://github.com/docker-java/docker-java/issues/765
-                    //
-                    // dockerUrl = 'npipe:////./pipe/docker_engine'
-                    dockerUrl = 'tcp://127.0.0.1:2375'
+                    dockerUrl = 'npipe:////./pipe/docker_engine'
                 } else {
                     dockerUrl = 'tcp://127.0.0.1:2375'
                 }


### PR DESCRIPTION
replaces the default transport with okhttp to allow the use of npipes

this is a like for like swap and the existing tests exercise the transport
there are a couple of tweaks to the tests

closes #917 
