### PR TITLE
Handle missing ServerURL from auth helper response

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
@@ -378,8 +378,11 @@ class RegistryAuthLocator {
         }
         logger.debug('Credential helper provided auth config for: {}', hostName)
 
+        // If the ServerURL field is not returned by the helper, fall back to the provided hostname
+        String registryAddress = helperResponse.ServerURL ?: hostName
+
         return new AuthConfig()
-                .withRegistryAddress(helperResponse.ServerURL)
+                .withRegistryAddress(registryAddress)
                 .withUsername(helperResponse.Username)
                 .withPassword(helperResponse.Secret)
     }

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -63,6 +63,23 @@ class RegistryAuthLocatorTest extends Specification {
         0 * logger.error(*_)
     }
 
+    def "AuthLocator works when helper returns no server URL (#955)"() {
+        given:
+        RegistryAuthLocator locator = createAuthLocatorForExistingConfigFile('config-with-store-no-server-url.json')
+
+        when:
+        AuthConfig config = locator.lookupAuthConfigWithDefaultAuthConfig('registry.example.com/org/repo')
+        AuthConfigurations allConfigs = locator.lookupAllAuthConfigs()
+
+        then:
+        config.getRegistryAddress() == 'registry.example.com'
+        config.getUsername() == 'username'
+        config.getPassword() == 'secret'
+        allConfigs.configs.size() == 1
+        allConfigs.configs.get("registry.example.com") == config
+        0 * logger.error(*_)
+    }
+
     def "AuthLocator works using auth"() {
         given:
         RegistryAuthLocator locator = createAuthLocatorForExistingConfigFile('config-auth.json')

--- a/src/test/resources/auth-config/config-with-store-no-server-url.json
+++ b/src/test/resources/auth-config/config-with-store-no-server-url.json
@@ -1,0 +1,9 @@
+{
+    "auths": {
+        "registry.example.com": {}
+    },
+    "HttpHeaders": {
+        "User-Agent": "Docker-Client/18.03.0-ce (darwin)"
+    },
+    "credsStore": "no-server-url"
+}

--- a/src/test/resources/auth-config/docker-credential-no-server-url
+++ b/src/test/resources/auth-config/docker-credential-no-server-url
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+if [[ $1 == "get" ]]; then
+    read > /dev/null
+
+    echo '{' \
+         '  "Username": "username",' \
+         '  "Secret": "secret"' \
+         '}'
+elif [[ $1 == "list" ]]; then
+    echo '{' \
+         '  "registry.example.com": "username"' \
+         '}'
+else
+    exit 1
+fi


### PR DESCRIPTION
Closes #955

I didn't add a test because there are currently no tests that cover this method, probably because it actually an external command. I think it would need a bit of restructuring to allow for a mocked command for testing.