### PR TITLE
Change to more concrete data type

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
@@ -99,7 +99,7 @@ class DockerLogsContainer extends DockerExistingContainer {
      */
     @Input
     @Optional
-    Writer sink
+    StringWriter sink
 
     // Allows subclasses to carry their own logic
     @Internal

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/extras/DockerLivenessContainer.groovy
@@ -19,6 +19,7 @@ package com.bmuschko.gradle.docker.tasks.container.extras
 import com.bmuschko.gradle.docker.domain.LivenessProbe
 import com.bmuschko.gradle.docker.tasks.container.DockerLogsContainer
 import com.github.dockerjava.api.command.InspectContainerResponse
+import groovy.transform.CompileStatic
 import org.gradle.api.GradleException
 import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
@@ -32,6 +33,7 @@ import static com.bmuschko.gradle.docker.internal.IOUtils.getProgressLogger
  *  Poll a given running container for an arbitrary log message to confirm liveness. If a livenessProbe is
  *  NOT defined then we fallback to check if the container is in a running state.
  */
+@CompileStatic
 class DockerLivenessContainer extends DockerLogsContainer {
 
     @Nested


### PR DESCRIPTION
Subclasses calls method on `StringWriter` which wouldn't work with a plain `Writer`. See https://github.com/bmuschko/gradle-docker-plugin/issues/886.

I believe there's a bug in the code in the same area as reported with https://github.com/bmuschko/gradle-docker-plugin/issues/946. Probably somewhere here:

```
logLine = null
getSink().getBuffer().setLength(0)
```

BTW: What do you use this class for? Is it even being used in your project?