### PR TITLE
Added subnet functionality to DockerCreateNetwork.

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/network/DockerNetworkFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/network/DockerNetworkFunctionalTest.groovy
@@ -45,7 +45,9 @@ class DockerNetworkFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
             task createNetworkWithSubnet(type: DockerCreateNetwork) {
                 networkName = '$uniqueNetworkName'
-                subnet = '$TEST_SUBNET'
+                ipam.config = [
+                    [subnet : '$TEST_SUBNET']
+                ]
             }
 
             task removeNetworkWithSubnet(type: DockerRemoveNetwork) {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/network/DockerCreateNetwork.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/network/DockerCreateNetwork.groovy
@@ -5,10 +5,15 @@ import com.github.dockerjava.api.command.CreateNetworkCmd
 import com.github.dockerjava.api.command.CreateNetworkResponse
 import com.github.dockerjava.api.model.Network
 import groovy.transform.CompileStatic
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Nested
 import org.gradle.api.tasks.Optional
+
+import javax.inject.Inject
 
 @CompileStatic
 class DockerCreateNetwork extends AbstractDockerRemoteApiTask {
@@ -20,23 +25,31 @@ class DockerCreateNetwork extends AbstractDockerRemoteApiTask {
     @Input
     final Property<String> networkName = project.objects.property(String)
 
-    @Input
-    @Optional
-    final Property<String> subnet = project.objects.property(String)
-
     /**
      * The id of the created network.
      */
     @Internal
     final Property<String> networkId = project.objects.property(String)
 
+    /**
+     * @since X.X.X
+     */
+    @Nested
+    final Ipam ipam
+
+    @Inject
+    DockerCreateNetwork(ObjectFactory objectFactory) {
+        ipam = objectFactory.newInstance(Ipam, objectFactory)
+    }
+
     void runRemoteCommand() {
         logger.quiet "Creating network '${networkName.get()}'."
 
         CreateNetworkCmd networkCmd = dockerClient.createNetworkCmd().withName(networkName.get())
 
-        if (subnet.getOrNull()) {
-            networkCmd.withIpam(new Network.Ipam().withConfig(new Network.Ipam.Config().withSubnet(subnet.get())))
+        List<Network.Ipam.Config> ipamConfig = ipam.createIpamConfigs()
+        if (!ipamConfig.empty) {
+            networkCmd.withIpam(new Network.Ipam().withConfig(ipamConfig))
         }
 
         CreateNetworkResponse network = networkCmd.exec()
@@ -48,5 +61,37 @@ class DockerCreateNetwork extends AbstractDockerRemoteApiTask {
         String createdNetworkId = network.id
         networkId.set(createdNetworkId)
         logger.quiet "Created network with ID '$createdNetworkId'."
+    }
+
+
+    static class Ipam {
+        private static final String SUBNET = "subnet"
+
+        @Input
+        @Optional
+        ListProperty<Map> config
+
+        @Inject
+        Ipam(ObjectFactory objectFactory) {
+            config = objectFactory.listProperty(Map)
+        }
+
+        List<Network.Ipam.Config> createIpamConfigs() {
+            List<Network.Ipam.Config> configList = new ArrayList<>()
+
+            if (config.getOrNull()) {
+                for (Map<String, String> configMap in config.get()) {
+                    Network.Ipam.Config ipamConfig = new Network.Ipam.Config()
+
+                    if (configMap.containsKey(SUBNET)) {
+                        ipamConfig.withSubnet(configMap.get(SUBNET).toString())
+                    }
+
+                    configList.add(ipamConfig)
+                }
+            }
+
+            return configList
+        }
     }
 }


### PR DESCRIPTION
From the related issue #979 : Adding the capability for the DockerCreateNetwork task to allow for subnet as a configuration value.

**On adding new code**
_Any new code added must contain relevant functionalTest(s) exercising all possible paths the code may take._

New functional test added to test subnet functionality. Left existing functional tests in place to confirm that _not_ specifying a subnet does not cause an error (subnet is optional). 

Test results:
```
[/workplace/github/gradle-docker-plugin] ./gradlew functionalTest

> Configure project :
Inferred project: gradle-docker-plugin, version: 6.6.2-SNAPSHOT

> Task :functionalTest
WARNING: An illegal reflective access operation has occurred
WARNING: Please consider reporting this to the maintainers of org.codehaus.groovy.vmplugin.v7.Java7$1
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

com.bmuschko.gradle.docker.tasks.network.DockerNetworkFunctionalTest > can create and tear down a network STARTED

com.bmuschko.gradle.docker.tasks.network.DockerNetworkFunctionalTest > can create and tear down a network PASSED

com.bmuschko.gradle.docker.tasks.network.DockerNetworkFunctionalTest > can create and tear down a network with a specified subnet STARTED

com.bmuschko.gradle.docker.tasks.network.DockerNetworkFunctionalTest > can create and tear down a network with a specified subnet PASSED

com.bmuschko.gradle.docker.tasks.network.DockerNetworkFunctionalTest > can create a container and assign a network and alias STARTED

com.bmuschko.gradle.docker.tasks.network.DockerNetworkFunctionalTest > can create a container and assign a network and alias PASSED
```

**On CI testing (currently using travis)**

Code will not be reviewed until CI passes.

**On automtatic closing of ISSUES**

Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such).
