### PR TITLE
Allow configuration of `DockerExistingImage#targetImageId` with a build task.

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerExistingImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerExistingImageFunctionalTest.groovy
@@ -1,0 +1,63 @@
+package com.bmuschko.gradle.docker.tasks.image
+
+import com.bmuschko.gradle.docker.AbstractGroovyDslFunctionalTest
+import org.gradle.testkit.runner.BuildResult
+import org.gradle.testkit.runner.TaskOutcome
+
+class DockerExistingImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
+
+    def "can refer to id of image via build task"() {
+        buildFile << buildAndRemoveImage()
+        buildFile << '''
+            removeImage {
+                dependsOn buildImage
+            }
+        '''
+
+        when:
+        BuildResult result = build('removeImage')
+
+        then:
+        result.task(':removeImage').outcome == TaskOutcome.SUCCESS
+    }
+
+    def "can refer to name of image via build task"() {
+        buildFile << buildAndRemoveImage()
+        buildFile << '''
+            buildImage {
+                images.add 'test/image:123'
+            }
+        '''
+
+        when:
+        BuildResult buildResult = build('buildImage')
+        BuildResult removeResult = build('removeImage')
+
+        then:
+        buildResult.task(':buildImage').outcome == TaskOutcome.SUCCESS
+        removeResult.task(':removeImage').outcome == TaskOutcome.SUCCESS
+    }
+
+    private static String buildAndRemoveImage() {
+        """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
+
+            task dockerfile(type: Dockerfile) {
+                from '$TEST_IMAGE_WITH_TAG'
+                label(['maintainer': 'jane.doe@example.com'])
+            }
+
+            task buildImage(type: DockerBuildImage) {
+                dependsOn dockerfile
+                inputDir = file("build/docker")
+            }
+
+            task removeImage(type: DockerRemoveImage) {
+                force = true
+                targetImageId tasks.named('buildImage')
+            }
+        """
+    }
+}


### PR DESCRIPTION
Based on discussion #977.

This is like a convenience functionality where the image ID of
`DockerBuildImage` task will be used if the image was built in the same Gradle
build, otherwise the first image name/tag will be used from
`DockerBuildImage#images` (assuming it exists on the local filesystem).

I believe that this kind of auto-configuration should fit well for the majority
of the use cases.