### PR TITLE
Upgrade ASM for JDK 16 support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
     shaded("com.github.docker-java:docker-java:3.2.5")
     shaded("com.github.docker-java:docker-java-transport-httpclient5:3.2.5")
     shaded("javax.activation:activation:1.1.1")
-    shaded("org.ow2.asm:asm:7.3.1")
+    shaded("org.ow2.asm:asm:9.1")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {
         exclude(group = "org.codehaus.groovy")
     }


### PR DESCRIPTION
This PR upgrades asm to its latest version 9.1, in order to support JDK 16

closes #999 
