### PR TITLE
Bump ASM opcode version.

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/MainClassFinder.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/MainClassFinder.groovy
@@ -195,7 +195,7 @@ class MainClassFinder {
         private boolean mainMethodFound
 
         ClassDescriptor() {
-            super(Opcodes.ASM7)
+            super(Opcodes.ASM9)
         }
 
         @Override


### PR DESCRIPTION
Although the project uses latest version of ASM library, it still constrained by ASM's API version when finding a application main class.

closes #1011
