### PR TITLE
Reduce Docker Java dependency size

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,7 +24,8 @@ repositories {
 }
 
 dependencies {
-    shaded("com.github.docker-java:docker-java:3.2.8")
+    shaded("com.github.docker-java:docker-java-core:3.2.8")
+    shaded("com.github.docker-java:docker-java-api:3.2.8")
     shaded("com.github.docker-java:docker-java-transport-httpclient5:3.2.8")
     shaded("javax.activation:activation:1.1.1")
     shaded("org.ow2.asm:asm:9.1")

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -20,8 +20,8 @@ import com.bmuschko.gradle.docker.DockerRemoteApiPlugin
 import com.bmuschko.gradle.docker.internal.RegistryAuthLocator
 import com.github.dockerjava.api.DockerClient
 import com.github.dockerjava.core.DefaultDockerClientConfig
-import com.github.dockerjava.core.DockerClientBuilder
 import com.github.dockerjava.core.DockerClientConfig
+import com.github.dockerjava.core.DockerClientImpl
 import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 import groovy.transform.CompileStatic
 import groovy.transform.Memoized
@@ -178,9 +178,10 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
                 .dockerHost(config.getDockerHost())
                 .sslConfig(config.getSSLConfig())
                 .build()
-        DockerClientBuilder.getInstance(config)
-                .withDockerHttpClient(dockerClient)
-                .build()
+        DockerClientImpl.getInstance(
+            config,
+            dockerClient
+        )
     }
 
     /**


### PR DESCRIPTION
This removes the dependency on the docker-java meta-package since that pulls in two other http clients we don't use. This brings the shaded jar down from 24mb to around 16mb.

closes #1015 