### PR TITLE
Enable putting environment variable as jvmArgs

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -165,7 +165,7 @@ LABEL maintainer=benjamin.muschko@gmail.com
 WORKDIR /app
 COPY libs libs/
 COPY classes classes/
-ENTRYPOINT ["java", "-cp", "/app/resources:/app/classes:/app/libs/*", "com.bmuschko.gradle.docker.application.JettyMain"]
+ENTRYPOINT ["sh", "-c", "java -cp /app/resources:/app/classes:/app/libs/* com.bmuschko.gradle.docker.application.JettyMain"]
 EXPOSE 9090
 ADD file1.txt /some/dir/file1.txt
 ADD file2.txt /other/dir/file2.txt
@@ -415,7 +415,7 @@ ENTRYPOINT ${buildEntrypoint(expectedDockerfile.jmvArgs, expectedDockerfile.main
         }
 
         entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", mainClassName])
-        entrypoint
+        ["sh", "-c", entrypoint.join(" ")]
     }
 
     private void assertBuildContextLibs() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -288,7 +288,7 @@ ENTRYPOINT ${buildEntrypoint(expectedDockerfile.jvmArgs, expectedDockerfile.main
         }
 
         entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", mainClassName])
-        entrypoint
+        ["sh", "-c", entrypoint.join(" ")]
     }
 
     private static class ExpectedDockerfile {

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.groovy
@@ -129,7 +129,7 @@ abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerConvention
                             }
 
                             entrypoint.addAll(["-cp", "/app/resources:/app/classes:/app/libs/*", getApplicationMainClassName(project, extension)])
-                            entrypoint
+                            ["sh", "-c", entrypoint.join(" ")]
                         }
                     }))
                     exposePort(extension.ports)


### PR DESCRIPTION
#### Problem:
Environment variables in jvmArgs are not working

Related issue https://github.com/bmuschko/gradle-docker-plugin/issues/970

```
// Environment variables in jvmArgs are not working
// E.g. docker run -e "JAVA_OPTS=xxx" images
docker {
    springBootApplication {
        baseImage = 'openjdk:8-alpine'
        ports = [9090, 8080]
        images = ['awesome-spring-boot:1.115', 'awesome-spring-boot:latest']
        jvmArgs = ['$JAVA_OPTS']
    }
}
```

#### Cause by:
The entrypoint for java plugins is "java ...jvmArgs -cp xxxx Main", which don't resolve the environment variables

#### Solution:
Change the entrypoint as ```sh -c "java ...jvmArgs -cp xxxx Main"```
