### PR TITLE
ISSUE-1022: Introduce http timeout parameters

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -24,9 +24,9 @@ repositories {
 }
 
 dependencies {
-    shaded("com.github.docker-java:docker-java-core:3.2.10")
-    shaded("com.github.docker-java:docker-java-api:3.2.10")
-    shaded("com.github.docker-java:docker-java-transport-httpclient5:3.2.10")
+    shaded("com.github.docker-java:docker-java-core:3.2.11")
+    shaded("com.github.docker-java:docker-java-api:3.2.11")
+    shaded("com.github.docker-java:docker-java-transport-httpclient5:3.2.11")
     shaded("javax.activation:activation:1.1.1")
     shaded("org.ow2.asm:asm:9.1")
     testImplementation("org.spockframework:spock-core:1.2-groovy-2.5") {

--- a/src/docs/asciidoc/12-extension.adoc
+++ b/src/docs/asciidoc/12-extension.adoc
@@ -9,6 +9,8 @@ The following properties can be configured:
 |`url`              |`Property<String>`  |`unix:///var/run/docker.sock` (Unix), `tcp://127.0.0.1:2375` (Windows)                  |The server URL to connect to via Docker's remote API.
 |`certPath`         |`DirectoryProperty` |Value of environment variable `DOCKER_CERT_PATH` if set                     |The path to certificates for communicating with https://docs.docker.com/articles/https/[Docker over SSL].
 |`apiVersion`       |`Property<String>`            |`null`                     |The https://docs.docker.com/develop/sdk/#view-the-api-reference[remote API version]. For most cases this can be left null.
+| `httpConnectionTimeout`   | `Property<Long>`|`null` | Determines the timeout until a new connection is fully established, 0 means infinite (if the HTTP transport is used)
+| `httpResponseTimeout`     | `Property<Long>`|`null` | Determines the timeout until arrival of a response from the opposite endpoint, 0 means infinite (if the HTTP transport is used)
 |=======
 
 Image pull or push operations against the public Docker Hub registry or a private registry may require authentication. By default, existing credentials are read from `$HOME/.docker/config.json` and reused for authentication purposes. You can overwrite those credentials with the help of the `registryCredentials` closure. The credentials provided in the extension automatically become available to all custom tasks that implement the interface {uri-ghpages}/api/com/bmuschko/gradle/docker/tasks/RegistryCredentialsAware.html[RegistryCredentialsAware].

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerExtension.groovy
@@ -62,6 +62,38 @@ class DockerExtension {
     final Property<String> apiVersion
 
     /**
+     * Determines the timeout until a new connection is fully established.
+     *
+     * <b>Only used if HTTP is used as the transport.</b>
+     *
+     * This may also include transport security negotiation exchanges
+     * such as {@code SSL} or {@code TLS} protocol negotiation).
+     * <p>
+     * A timeout value of zero is interpreted as an infinite timeout.
+     * </p>
+     * <p>
+     * Default: 3 minutes
+     * </p>
+     */
+    final Property<Long> httpConnectionTimeout
+
+    /**
+     * Determines the timeout until arrival of a response from the opposite
+     * endpoint. <b>Only used if HTTP is used as the transport.</b>
+     * <p>
+     * A timeout value of zero is interpreted as an infinite timeout.
+     * </p>
+     * <p>
+     * Please note that response timeout may be unsupported by
+     * HTTP transports with message multiplexing.
+     * </p>
+     * <p>
+     * Default: 3 minutes
+     * </p>
+     */
+    final Property<Long> httpResponseTimeout
+
+    /**
      * The target Docker registry credentials.
      */
     final DockerRegistryCredentials registryCredentials
@@ -78,6 +110,8 @@ class DockerExtension {
         }
 
         apiVersion = objectFactory.property(String)
+        httpConnectionTimeout = objectFactory.property(Long)
+        httpResponseTimeout = objectFactory.property(Long)
         registryCredentials = objectFactory.newInstance(DockerRegistryCredentials, objectFactory)
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClientConfiguration.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/DockerClientConfiguration.groovy
@@ -10,4 +10,6 @@ class DockerClientConfiguration {
     String url
     Directory certPath
     String apiVersion
+    Long httpConnectionTimeout;
+    Long httpResponseTimeout;
 }


### PR DESCRIPTION
Introduced connection timeout and response timeout parameters
to the remote-api task and the docker extension to mitigate the
change from httpcomponents-core 5.0.2 which changed the default
timeout from infinite to 3 minutes

closes #1022