### PR TITLE
Issue 1029: Stop DockerLogsContainer with StopExecutionException

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
@@ -22,6 +22,7 @@ import com.github.dockerjava.core.command.LogContainerResultCallback
 import groovy.transform.CompileStatic
 import org.gradle.api.Action
 import org.gradle.api.GradleException
+import org.gradle.api.tasks.StopExecutionException
 import org.gradle.api.InvalidUserDataException
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
@@ -144,6 +145,9 @@ class DockerLogsContainer extends DockerExistingContainer {
                                 sink.flush()
                                 break
                         }
+                    } catch (GradleException | StopExecutionException e) {
+                        logger.quiet('Handling normal Gradle Exception by throwing it', e)
+                        throw e;
                     } catch (Exception e) {
                         logger.error('Failed to handle frame', e)
                         return
@@ -158,6 +162,9 @@ class DockerLogsContainer extends DockerExistingContainer {
                 void onNext(Frame frame) {
                     try {
                         nextHandler.execute(frame)
+                    } catch (GradleException | StopExecutionException e) {
+                        logger.quiet('Handling normal Gradle Exception by throwing it', e)
+                        throw e;
                     } catch (Exception e) {
                         logger.error('Failed to handle frame', e)
                         return
@@ -180,6 +187,9 @@ class DockerLogsContainer extends DockerExistingContainer {
                             logger.error(new String(frame.payload).replaceFirst(/\s+$/, ''))
                             break
                     }
+                } catch (GradleException | StopExecutionException e) {
+                    logger.quiet('Handling normal Gradle Exception by throwing it', e)
+                    throw e;
                 } catch(Exception e) {
                     logger.error('Failed to handle frame', e)
                     return


### PR DESCRIPTION
This is my idea about how the plugin should handle GradleExceptions and particularly StopExecutionException. Throw it to Gradle.

Unfortunately, I was not able to test it in a meaningful way. A lot of other tests failed for me. I'm sorry about it, I'm not a groovy developer, not a Gradle plugin developer, I'm just a Java developer who was surprised by the way of exception handling.

The failing test is the reason why I wrote a tricky assertation part. I got NPE at the end of each test because `result.task(':logContainer')` was null for me, even in other tests. (I had to comment out tests so that I can verify mine at least runs.)

I really hope it will work (pass the tests) 🤞 but if not, I would like to require assistance! 🚑
Unfortunately, I don't have the time to learn groovy-based Gradle plugin development from the beginning. 😞