### PR TITLE
create parent of $buildDir/.docker/$taskpath-imageId.txt

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -320,6 +320,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
         String createdImageId = buildImageCmd.exec(createCallback(nextHandler)).awaitImageId()
         imageId.set(createdImageId)
+        imageIdFile.get().asFile.parentFile.mkdirs()
         imageIdFile.get().asFile.text = createdImageId
         logger.quiet "Created image with ID '$createdImageId'."
     }


### PR DESCRIPTION
to solve #1063 which explains the parent of `$buildDir/.docker/$taskpath-imageId.txt` may not exists

