### PR TITLE
Fix if-missing default auth lookup logic

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
@@ -243,7 +243,9 @@ class RegistryAuthLocator {
      */
     AuthConfigurations lookupAllAuthConfigs(AuthConfig additionalAuthConfig) {
         AuthConfigurations allAuthConfigs = lookupAllAuthConfigs()
-        allAuthConfigs.addConfig(additionalAuthConfig)
+        if (allAuthConfigs.configs.isEmpty()) {
+            allAuthConfigs.addConfig(additionalAuthConfig)
+        }
         return allAuthConfigs
     }
 

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -134,6 +134,24 @@ class RegistryAuthLocatorTest extends Specification {
         4 * logger.error(*_)
     }
 
+    @Issue('https://github.com/bmuschko/gradle-docker-plugin/issues/985')
+    def "AuthLocator returns auth from file over default"() {
+        given:
+        RegistryAuthLocator locator =
+            createAuthLocatorForExistingConfigFile('config-docker-hub-user-pass.json', false)
+
+        when:
+        AuthConfigurations allConfigs = locator.lookupAllAuthConfigs(new AuthConfig())
+
+        then:
+        AuthConfig config = new AuthConfig()
+            .withUsername('username')
+            .withPassword('secret')
+        allConfigs.configs.size() == 1
+        allConfigs.configs.get(config.registryAddress) == config
+        0 * logger.error(*_)
+    }
+
     def "AuthLocator works for Docker Desktop config without existing credentials"() {
         given:
         RegistryAuthLocator locator = createAuthLocatorForExistingConfigFile('config-docker-desktop.json')

--- a/src/test/resources/auth-config/config-docker-hub-user-pass.json
+++ b/src/test/resources/auth-config/config-docker-hub-user-pass.json
@@ -1,0 +1,8 @@
+{
+  "auths" : {
+    "https://index.docker.io/v1/" : {
+      "username": "username",
+      "password": "secret"
+    }
+  }
+}


### PR DESCRIPTION
Fixes the issue where having credentials in the config.json are overwritten by default (but unset) auth-config passed in.

The javadoc of the function explicitly states
```
If missing, an AuthConfigurations object containing only the passed additionalAuthConfig is returned
```
But no if-missing logic was ever implemented. The `addConfig` function doesn't check to see if an existing registryAddress has already been registered, which causes it to stomp on the previously-loaded config.json loaded login details.

closes #985
