### PR TITLE
Use a stable tag for OpenJDK base image

### DIFF
--- a/src/docs/asciidoc/22-extension.adoc
+++ b/src/docs/asciidoc/22-extension.adoc
@@ -7,7 +7,7 @@ The following properties can be configured:
 [options="header"]
 |=======
 |Property name   |Type                               |Default value                                                 |Description
-|`baseImage`     |`Property<String>`                 |`openjdk:11-jre-slim`                                          |The Docker base image used for Java application.
+|`baseImage`     |`Property<String>`                 |`openjdk:11.0.15-jre-slim`                                          |The Docker base image used for Java application.
 |`maintainer`    |`Property<String>`                 |Value of system property `user.name`                          |The maintainer of the image.
 |`ports`         |`ListProperty<Integer>`            |`[8080]`                                                      |The Docker image exposed ports.
 |`images`        |`SetProperty<String>`              |`[<project.group>/<applicationName>:<project.version>]`       |The images used for the build and push operation.

--- a/src/docs/asciidoc/32-extension.adoc
+++ b/src/docs/asciidoc/32-extension.adoc
@@ -8,7 +8,7 @@ The following properties can be configured:
 [options="header"]
 |=======
 |Property name   |Type                    |Default value                                                 |Description
-|`baseImage`     |`Property<String>`      |`openjdk:11-jre-slim`                                          |The Docker base image used for the Spring Boot application.
+|`baseImage`     |`Property<String>`      |`openjdk:11.0.15-jre-slim`                                          |The Docker base image used for the Spring Boot application.
 |`maintainer`    |`Property<String>`      |Value of system property `user.name`                          |The maintainer of the image.
 |`ports`         |`ListProperty<Integer>` |`[8080]`                                                      |The Docker image exposed ports.
 |`images`        |`SetProperty<String>`   |`[<project.group>/<applicationName>:<project.version>]`       |The images used for the build and push operation.

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/fixtures/DockerConventionPluginFixture.groovy
@@ -3,7 +3,7 @@ package com.bmuschko.gradle.docker.fixtures
 final class DockerConventionPluginFixture {
 
     public static final String PROJECT_NAME = 'powered-by-docker'
-    public static final String DEFAULT_BASE_IMAGE = 'openjdk:11-jre-slim'
+    public static final String DEFAULT_BASE_IMAGE = 'openjdk:11.0.15-jre-slim'
     public static final String CUSTOM_BASE_IMAGE = 'openjdk:8u171-jre-alpine'
 
     private DockerConventionPluginFixture() {}

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationExtension.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerConventionJvmApplicationExtension.groovy
@@ -32,7 +32,7 @@ class DockerConventionJvmApplicationExtension {
     /**
      * The Docker base image used for Java application.
      * <p>
-     * Defaults to {@code openjdk:11-jre-slim}.
+     * Defaults to {@code openjdk:11.0.15-jre-slim}.
      */
     final Property<String> baseImage
 
@@ -80,7 +80,7 @@ class DockerConventionJvmApplicationExtension {
 
     DockerConventionJvmApplicationExtension(ObjectFactory objectFactory) {
         baseImage = objectFactory.property(String)
-        baseImage.set('openjdk:11-jre-slim')
+        baseImage.set('openjdk:11.0.15-jre-slim')
         maintainer = objectFactory.property(String)
         maintainer.set(System.getProperty('user.name'))
         ports = objectFactory.listProperty(Integer)


### PR DESCRIPTION
The `openjdk:11-jre-slim` tag can have new versions over time. Pick a stable tag of OpenJDK 11.