### PR TITLE
Configure test tasks to use JUnit Platform which is necessary for Spock 2+

### DIFF
--- a/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/TestSetupPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/TestSetupPlugin.kt
@@ -21,6 +21,7 @@ class TestSetupPlugin : Plugin<Project> {
         }
 
         tasks.withType<Test>().configureEach {
+            useJUnitPlatform()
             testLogging {
                 events("skipped")
             }


### PR DESCRIPTION
When updating to Spock 2 you disabled each and every test.
You probably missed the important information in the release notes,
that Spock 2+ is now based on JUnit Platform, so it is necessary
to tell Gradle to not use JUnit 4, but JUnit Platform.