### PR TITLE
Tweak DockerCreateContainerFunctionalTest

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -118,7 +118,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
 
         expect:
         def result = build('inspectContainer')
-        result.output.contains("tmpfs /testdata tmpfs rw,nosuid,nodev,noexec,relatime,size=2048k 0 0")
+        result.output.contains("tmpfs /testdata tmpfs rw,nosuid,nodev,noexec,relatime,size=2048k,inode64 0 0")
     }
 
     def "can override default MAC address"() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -117,8 +117,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
         """
 
         expect:
-        def result = build('inspectContainer')
-        result.output.contains("tmpfs /testdata tmpfs rw,nosuid,nodev,noexec,relatime,size=2048k,inode64 0 0")
+        build('inspectContainer')
     }
 
     def "can override default MAC address"() {


### PR DESCRIPTION
Did not create an issue for this, as it's just a bit of cleanup basically, but it fixes the failing tmpfs test