### PR TITLE
Fix custom registry in logs

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
@@ -281,7 +281,7 @@ class RegistryAuthLocator {
      * @param image the name of the docker image
      * @return docker registry name
      */
-    static String getRegistry(String image) {
+    String getRegistry(String image) {
         final NameParser.ReposTag tag = NameParser.parseRepositoryTag(image)
         final NameParser.HostnameReposName repository = NameParser.resolveRepositoryName(tag.repos)
         return repository.hostname

--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocator.groovy
@@ -281,7 +281,7 @@ class RegistryAuthLocator {
      * @param image the name of the docker image
      * @return docker registry name
      */
-    private static String getRegistry(String image) {
+    static String getRegistry(String image) {
         final NameParser.ReposTag tag = NameParser.parseRepositoryTag(image)
         final NameParser.HostnameReposName repository = NameParser.resolveRepositoryName(tag.repos)
         return repository.hostname

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPullImage.groovy
@@ -60,7 +60,7 @@ class DockerPullImage extends AbstractDockerRemoteApiTask implements RegistryCre
     @Override
     void runRemoteCommand() {
         AuthConfig authConfig = getRegistryAuthLocator().lookupAuthConfig(image.get(), registryCredentials)
-        logger.quiet "Pulling image '${image.get()}' from ${authConfig.registryAddress}."
+        logger.quiet "Pulling image '${image.get()}' from ${getRegistryAuthLocator().getRegistry(image.get())}."
 
         PullImageCmd pullImageCmd = dockerClient.pullImageCmd(image.get())
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -16,6 +16,7 @@
 package com.bmuschko.gradle.docker.tasks.image
 
 import com.bmuschko.gradle.docker.DockerRegistryCredentials
+import com.bmuschko.gradle.docker.internal.RegistryAuthLocator
 import com.bmuschko.gradle.docker.tasks.AbstractDockerRemoteApiTask
 import com.bmuschko.gradle.docker.tasks.RegistryCredentialsAware
 import com.github.dockerjava.api.command.PushImageCmd
@@ -56,7 +57,7 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
 
         for (String image : images.get()) {
             AuthConfig authConfig = getRegistryAuthLocator().lookupAuthConfig(image, registryCredentials)
-            logger.quiet "Pushing image '${image}' to ${authConfig.registryAddress}."
+            logger.quiet "Pushing image '${image}' to ${RegistryAuthLocator.getRegistry(image)}."
 
             PushImageCmd pushImageCmd = dockerClient.pushImageCmd(image)
             pushImageCmd.withAuthConfig(authConfig)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -57,7 +57,7 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
 
         for (String image : images.get()) {
             AuthConfig authConfig = getRegistryAuthLocator().lookupAuthConfig(image, registryCredentials)
-            logger.quiet "Pushing image '${image}' to ${RegistryAuthLocator.getRegistry(image)}."
+            logger.quiet "Pushing image '${image}' to ${getRegistryAuthLocator().getRegistry(image)}."
 
             PushImageCmd pushImageCmd = dockerClient.pushImageCmd(image)
             pushImageCmd.withAuthConfig(authConfig)

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -152,6 +152,29 @@ class RegistryAuthLocatorTest extends Specification {
         0 * logger.error(*_)
     }
 
+    def "AuthLocator returns correct default registry"() {
+        given:
+        String image = 'ubuntu'
+
+        when:
+        String registry = RegistryAuthLocator.getRegistry(image)
+
+        then:
+        registry == 'https://index.docker.io/v1/'
+    }
+
+
+    def "AuthLocator returns correct custom registry"() {
+        given:
+        String image = 'gcr.io/distroless/java17'
+
+        when:
+        String registry = RegistryAuthLocator.getRegistry(image)
+
+        then:
+        registry == 'gcr.io'
+    }
+
     def "AuthLocator works for Docker Desktop config without existing credentials"() {
         given:
         RegistryAuthLocator locator = createAuthLocatorForExistingConfigFile('config-docker-desktop.json')

--- a/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/internal/RegistryAuthLocatorTest.groovy
@@ -157,7 +157,7 @@ class RegistryAuthLocatorTest extends Specification {
         String image = 'ubuntu'
 
         when:
-        String registry = RegistryAuthLocator.getRegistry(image)
+        String registry = new RegistryAuthLocator().getRegistry(image)
 
         then:
         registry == 'https://index.docker.io/v1/'
@@ -169,7 +169,7 @@ class RegistryAuthLocatorTest extends Specification {
         String image = 'gcr.io/distroless/java17'
 
         when:
-        String registry = RegistryAuthLocator.getRegistry(image)
+        String registry = new RegistryAuthLocator().getRegistry(image)
 
         then:
         registry == 'gcr.io'


### PR DESCRIPTION
Not 100% sure if `authConfig.registryAddress` is the correct choice for the log output, I've instead changed it to call the `getRegistry` function directly, otherwise it prints out dockerhub.

closes #1090
