### PR TITLE
Cleanup close calls

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/IOUtils.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/IOUtils.groovy
@@ -22,16 +22,6 @@ final class IOUtils {
         }
     }
 
-    static void closeQuietly(Closeable toClose) {
-        try {
-            if (toClose != null) {
-                toClose.close()
-            }
-        } catch (IOException ignored) {
-            // ignore
-        }
-    }
-
     /**
      * Create a progress logger for an arbitrary project and class.
      *

--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/MainClassFinder.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/MainClassFinder.groovy
@@ -157,7 +157,7 @@ class MainClassFinder {
     }
 
     private static ClassDescriptor createClassDescriptor(InputStream inputStream) {
-        try {
+        try (inputStream) {
             ClassReader classReader = new ClassReader(inputStream)
             ClassDescriptor classDescriptor = new ClassDescriptor()
             classReader.accept(classDescriptor, ClassReader.SKIP_CODE)
@@ -165,12 +165,6 @@ class MainClassFinder {
         }
         catch (IOException ex) {
             return null
-        } finally {
-            try {
-                inputStream.close()
-            } catch (IOException e) {
-                // do nothing
-            }
         }
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/MainClassFinder.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/MainClassFinder.groovy
@@ -157,14 +157,16 @@ class MainClassFinder {
     }
 
     private static ClassDescriptor createClassDescriptor(InputStream inputStream) {
-        try (inputStream) {
-            ClassReader classReader = new ClassReader(inputStream)
-            ClassDescriptor classDescriptor = new ClassDescriptor()
-            classReader.accept(classDescriptor, ClassReader.SKIP_CODE)
-            return classDescriptor
-        }
-        catch (IOException ex) {
-            return null
+        inputStream.withCloseable {
+            try {
+                ClassReader classReader = new ClassReader(it)
+                ClassDescriptor classDescriptor = new ClassDescriptor()
+                classReader.accept(classDescriptor, ClassReader.SKIP_CODE)
+                classDescriptor
+            }
+            catch (IOException ex) {
+                null
+            }
         }
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -62,7 +62,7 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
         CopyArchiveFromContainerCmd containerCommand = dockerClient.copyArchiveFromContainerCmd(containerId.get(), remotePath.get())
         logger.quiet "Copying '${remotePath.get()}' from container with ID '${containerId.get()}' to '${hostPath.get()}'."
 
-        try (InputStream tarStream = containerCommand.exec()) {
+        containerCommand.exec().withCloseable { InputStream tarStream ->
 
             if(nextHandler) {
                 nextHandler.execute(tarStream)

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -62,9 +62,7 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
         CopyArchiveFromContainerCmd containerCommand = dockerClient.copyArchiveFromContainerCmd(containerId.get(), remotePath.get())
         logger.quiet "Copying '${remotePath.get()}' from container with ID '${containerId.get()}' to '${hostPath.get()}'."
 
-        InputStream tarStream
-        try {
-            tarStream = containerCommand.exec()
+        try (InputStream tarStream = containerCommand.exec()) {
 
             if(nextHandler) {
                 nextHandler.execute(tarStream)
@@ -78,8 +76,6 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
                     copyFile(tarStream, hostDestination)
                 }
             }
-        } finally {
-            tarStream?.close()
         }
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
@@ -106,24 +106,12 @@ class DockerSaveImage extends AbstractDockerRemoteApiTask {
                 }
             }
         }
-        InputStream image = saveImagesCmd.exec()
-        OutputStream os
-        try {
-            FileOutputStream fs = new FileOutputStream(destFile.get().asFile)
-            os = fs
-            if (useCompression.get()) {
-                os = new GZIPOutputStream(fs)
-            }
-            try {
-                IOUtils.copy(image, os)
-            } catch (IOException e) {
-                throw new GradleException("Can't save image.", e)
-            } finally {
-                IOUtils.closeQuietly(image)
-            }
-        }
-        finally {
-            IOUtils.closeQuietly(os)
+        try (InputStream image = saveImagesCmd.exec()
+             FileOutputStream fs = new FileOutputStream(destFile.get().asFile)
+             OutputStream os = useCompression.get() ? new GZIPOutputStream(fs) : fs) {
+            IOUtils.copy(image, os)
+        } catch (IOException e) {
+            throw new GradleException("Can't save image.", e)
         }
 
         def imageIds = new Properties()


### PR DESCRIPTION
Not sure if this needs a related issue, but there are a few calls to `close()` methods that should no longer be necessary since the groovy 3 try-with-resources changes.

Removes now-unused `closeQuietly()` method.