### PR TITLE
Fix Gradle 6.9.x support

### DIFF
--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -2,6 +2,33 @@ name: Build and Release [Linux]
 on: [push, pull_request]
 
 jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        gradle-version: [6.9.2, 7.4.2]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Set up Java
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Set up Docker private registry
+        run: |
+          docker run -d -p 5000:5000 --restart=always --name registry registry:2
+          docker run -d -p 5001:5000 --restart=always --name secure_registry -v "$(pwd)"/src/functTest/resources/auth:/auth:rw -e "REGISTRY_AUTH=htpasswd" -e "REGISTRY_AUTH_HTPASSWD_REALM=Registry Realm" -e "REGISTRY_AUTH_HTPASSWD_PATH=/auth/htpasswd" registry:2
+      - name: Functional tests
+        uses: gradle/gradle-build-action@v2
+        env:
+          GRADLE_VERSION: ${{ matrix.gradle-version }}
+          DOCKER_HUB_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
+          DOCKER_HUB_PASSWORD: ${{ secrets.DOCKER_HUB_PASSWORD }}
+          HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
+          HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
+        with:
+          arguments: functionalTest
   build:
     name: Build
     runs-on: ubuntu-20.04

--- a/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/FunctionalTestPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/FunctionalTestPlugin.kt
@@ -9,6 +9,7 @@ import org.gradle.kotlin.dsl.creating
 import org.gradle.kotlin.dsl.get
 import org.gradle.kotlin.dsl.getValue
 import org.gradle.kotlin.dsl.provideDelegate
+import org.gradle.util.GradleVersion
 
 class FunctionalTestPlugin : Plugin<Project> {
     override fun apply(project: Project): Unit = project.run {
@@ -33,6 +34,7 @@ class FunctionalTestPlugin : Plugin<Project> {
                 showStandardStreams = true
                 events("started", "passed", "failed")
             }
+            environment("CURRENT_GRADLE_VERSION", GradleVersion.current().version)
         }
 
         tasks["check"].dependsOn(functionalTest)

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -56,6 +56,7 @@ abstract class AbstractFunctionalTest extends Specification {
             .withArguments(arguments + '-s' + '--configuration-cache' as List<String>)
             .withPluginClasspath()
             .withEnvironment(envVars)
+            .withGradleVersion(System.getenv("GRADLE_VERSION") ?: System.getenv("CURRENT_GRADLE_VERSION"))
     }
 
     protected File file(String relativePath) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -2,6 +2,7 @@ package com.bmuschko.gradle.docker
 
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
+import org.gradle.util.GradleVersion
 import spock.lang.Specification
 import spock.lang.TempDir
 
@@ -30,6 +31,12 @@ abstract class AbstractFunctionalTest extends Specification {
 
         if (isWindows()) {
             envVars.put("PATH", System.getenv("PATH"))
+        }
+
+        if (GradleVersion.version("7.0") >= GradleVersion.version(System.getenv("GRADLE_VERSION") ?: System.getenv("CURRENT_GRADLE_VERSION"))) {
+            configurationCacheStorageSuccess = "0 problems were found storing the configuration cache."
+        } else {
+            configurationCacheStorageSuccess = "Configuration cache entry stored."
         }
     }
 
@@ -67,4 +74,6 @@ abstract class AbstractFunctionalTest extends Specification {
 
     abstract String getBuildFileName()
     abstract String getSettingsFileName()
+
+    protected String configurationCacheStorageSuccess
 }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -27,7 +27,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
         assertGeneratedDockerfile()
         assertBuildContextLibs()
         assertBuildContextClasses()
-        result.output.contains("0 problems were found storing the configuration cache.")
+        result.output.contains(configurationCacheStorageSuccess)
 
         when:
         result = build('buildAndCleanResources')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -1,6 +1,7 @@
 package com.bmuschko.gradle.docker
 
 import org.gradle.testkit.runner.BuildResult
+import org.gradle.util.GradleVersion
 import spock.lang.Requires
 
 import static com.bmuschko.gradle.docker.TextUtils.equalsIgnoreLineEndings
@@ -378,6 +379,14 @@ ADD file2.txt /other/dir/file2.txt
         buildFile << imageTasks()
         buildFile << containerTasks()
         buildFile << lifecycleTask()
+    }
+
+    private String realizedTasks() {
+        if (GradleVersion.version("6.9.2") == GradleVersion.version(System.getenv("GRADLE_VERSION") ?: System.getenv("CURRENT_GRADLE_VERSION"))) {
+            "':help'"
+        } else {
+            "':help', ':clean'"
+        }
     }
 
     private void writeNoTasksRealizedAssertionToBuildFile() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
@@ -139,7 +139,7 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractGroovyDslFunctiona
         BuildResult result = build('copyFileIntoContainer')
 
         then:
-        result.output.contains("0 problems were found storing the configuration cache.")
+        result.output.contains(configurationCacheStorageSuccess)
 
         when:
         result = build('copyFileIntoContainer')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -141,7 +141,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
 
         then:
         result.output.contains("HWaddr 02:03:04:05:06:07")
-        result.output.contains("0 problems were found storing the configuration cache.")
+        result.output.contains(configurationCacheStorageSuccess)
 
         when:
         result = build('logContainer')
@@ -421,7 +421,7 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
 
         then:
         result.output.contains("Hello, world!")
-        result.output.contains("0 problems were found storing the configuration cache.")
+        result.output.contains(configurationCacheStorageSuccess)
 
         when:
         result = build('logContainer')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -187,7 +187,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
 
         then:
         result.output.contains('Hello World')
-        result.output.contains("0 problems were found storing the configuration cache.")
+        result.output.contains(configurationCacheStorageSuccess)
     }
 
     static String containerUsage(String containerExecutionTask, int sleep = 30) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -30,7 +30,7 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
         then:
         result.output.contains("Committing image 'myimage:latest' for container")
-        result.output.contains("0 problems were found storing the configuration cache.")
+        result.output.contains(configurationCacheStorageSuccess)
 
         when:
         result = build(COMMIT_TASK_NAME)

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
@@ -320,7 +320,7 @@ class DockerSaveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
         then:
         file(IMAGE_FILE).size() > 0
-        result.output.contains("0 problems were found storing the configuration cache.")
+        result.output.contains(configurationCacheStorageSuccess)
 
         when:
         result = build('saveImage')

--- a/src/main/java/com/bmuschko/gradle/docker/DockerRegistryCredentials.java
+++ b/src/main/java/com/bmuschko/gradle/docker/DockerRegistryCredentials.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2014 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package com.bmuschko.gradle.docker;
 
 import org.gradle.api.credentials.PasswordCredentials;
@@ -28,6 +43,7 @@ public class DockerRegistryCredentials {
      * The registry URL used as default value for the property {@link #url}.
      */
     public static final String DEFAULT_URL = "https://index.docker.io/v1/";
+
     /**
      * Registry URL needed to push images.
      * <p>

--- a/src/main/java/com/bmuschko/gradle/docker/internal/ConventionPluginHelper.java
+++ b/src/main/java/com/bmuschko/gradle/docker/internal/ConventionPluginHelper.java
@@ -4,9 +4,12 @@ import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.file.CopySpec;
+import org.gradle.api.plugins.JavaPlatformExtension;
 import org.gradle.api.plugins.JavaPlugin;
+import org.gradle.api.plugins.JavaPluginConvention;
 import org.gradle.api.plugins.JavaPluginExtension;
 import org.gradle.api.tasks.SourceSet;
+import org.gradle.api.tasks.SourceSetContainer;
 import org.gradle.api.tasks.SourceSetOutput;
 
 public final class ConventionPluginHelper {
@@ -15,8 +18,18 @@ public final class ConventionPluginHelper {
     }
 
     public static SourceSetOutput getMainJavaSourceSetOutput(Project project) {
-        JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
-        return javaPluginExtension.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput();
+        SourceSetContainer sourceSets = getMainJavaSourceSetContainer(project);
+        return sourceSets.getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput();
+    }
+
+    private static SourceSetContainer getMainJavaSourceSetContainer(Project project) {
+        try {
+            JavaPluginExtension javaPluginExtension = project.getExtensions().getByType(JavaPluginExtension.class);
+            return javaPluginExtension.getSourceSets();
+        } catch (NoSuchMethodError e) {
+            JavaPluginConvention javaConvention = project.getConvention().getPlugin(JavaPluginConvention.class);
+            return javaConvention.getSourceSets();
+        }
     }
 
     public static CopySpec createAppFilesCopySpec(final Project project) {


### PR DESCRIPTION
Fixes a compatibility issue with Gradle 6.9.x

Without this builds fail with
```
> Task :dockerCreateDockerfile
FAILURE: Build failed with an exception.

* What went wrong:
Receiver class com.bmuschko.gradle.docker.tasks.image.Dockerfile$CopyFile does not define or inherit an implementation of the resolved method 'abstract java.lang.Object getProperty(java.lang.String)' of interface groovy.lang.GroovyObject.
2 actionable tasks: 2 executed
```

closes #1096
