### PR TITLE
Expose repository and tag properties for DockerCommitImage task

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -15,7 +15,8 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 targetContainerId createContainer.getContainerId()
                 author = "john doe"
                 message = "My image created"
-                image = "myimage:latest"
+                repository = "myimage"
+                tag = "latest"
             }
         """
 
@@ -28,7 +29,7 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         BuildResult result = build(COMMIT_TASK_NAME)
 
         then:
-        result.output.contains("Committing image for container")
+        result.output.contains("Committing image 'myimage:latest' for container")
     }
 
     def "cannot commit image with invalid container"() {
@@ -37,7 +38,8 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
             task $COMMIT_TASK_NAME(type: DockerCommitImage) {
                 dependsOn startContainer
                 targetContainerId "idonotexist"
-                image = "myimage:latest"
+                repository = "myimage"
+                tag = "latest"
             }
         """
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
@@ -27,12 +27,20 @@ import org.gradle.api.tasks.Optional
 class DockerCommitImage extends DockerExistingContainer {
 
     /**
-     * The image including repository, image name and tag used e.g. {@code vieux/apache:2.0}.
+     * The repository and image name e.g. {@code vieux/apache}.
      *
-     * @since 6.0.0
+     * @since 9.0.0
      */
     @Input
-    final Property<String> image = project.objects.property(String)
+    final Property<String> repository = project.objects.property(String)
+
+    /**
+     * The tag e.g. {@code 2.0}.
+     *
+     * @since 9.0.0
+     */
+    @Input
+    final Property<String> tag = project.objects.property(String)
 
     /**
      * Commit message.
@@ -68,9 +76,10 @@ class DockerCommitImage extends DockerExistingContainer {
 
     @Override
     void runRemoteCommand() {
-        logger.quiet "Committing image for container '${getContainerId().get()}'."
+        logger.quiet "Committing image '${repository.get()}:${tag.get()}' for container '${getContainerId().get()}'."
         CommitCmd commitCmd = dockerClient.commitCmd(getContainerId().get())
-        commitCmd.withTag(image.get())
+        commitCmd.withRepository(repository.get())
+        commitCmd.withTag(tag.get())
 
         if(message.getOrNull()) {
             commitCmd.withMessage(message.get())


### PR DESCRIPTION
The functionality required introducing a breaking change.

For more information, see https://github.com/bmuschko/gradle-docker-plugin/issues/1098.