### PR TITLE
Remove call to getProject() at task execution time

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -12,6 +12,7 @@ abstract class AbstractFunctionalTest extends Specification {
     public static final String TEST_IMAGE = 'alpine'
     public static final String TEST_IMAGE_TAG = '3.4'
     public static final String TEST_IMAGE_WITH_TAG = "${TEST_IMAGE}:${TEST_IMAGE_TAG}"
+    public static final String CONFIGURATION_CACHE = '--configuration-cache'
 
     @TempDir
     File temporaryFolder

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.file.Directory
 import org.gradle.api.file.DirectoryProperty
 import org.gradle.api.file.RegularFile
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.CacheableTask
@@ -54,10 +55,13 @@ class Dockerfile extends DefaultTask {
     @OutputFile
     final RegularFileProperty destFile
 
+    private final ObjectFactory objects
+
     Dockerfile() {
         instructions = project.objects.listProperty(Instruction).empty()
         destFile = project.objects.fileProperty()
         destFile.set(project.layout.buildDirectory.file('docker/Dockerfile'))
+        objects = project.objects
     }
 
     /**
@@ -81,7 +85,7 @@ class Dockerfile extends DefaultTask {
         destFile.flatMap(new Transformer<Provider<Directory>, RegularFile>() {
             @Override
             Provider<Directory> transform(RegularFile f) {
-                DirectoryProperty destDir = project.objects.directoryProperty()
+                DirectoryProperty destDir = objects.directoryProperty()
                 destDir.set(f.asFile.parentFile)
                 destDir
             }


### PR DESCRIPTION
This closes one configuration cache issue found by adding `--configuration-cache` to the `DockerJavaApplicationPluginFunctionalTest`.

Relates to https://github.com/bmuschko/gradle-docker-plugin/issues/1102