### PR TITLE
Support Java up to version 20 with latest ASM library

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 plugin-publish = "0.14.0"
 docker-java = "3.2.13"
 activation = "1.1.1"
-asm = "9.1"
+asm = "9.4"
 spock = "2.0-groovy-3.0"
 zt-zip = "1.13"
 commons-vfs2 = "2.9.0"


### PR DESCRIPTION
The currently used ASM library version only supports Java 17 but not higher.