### PR TITLE
Use build service for Docker client to better support Gradle's configuration cache feature

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -26,10 +26,11 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         """
 
         when:
-        BuildResult result = build(COMMIT_TASK_NAME)
+        BuildResult result = build(CONFIGURATION_CACHE, COMMIT_TASK_NAME)
 
         then:
         result.output.contains("Committing image 'myimage:latest' for container")
+        result.output.contains("0 problems were found storing the configuration cache.")
     }
 
     def "cannot commit image with invalid container"() {

--- a/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.groovy
@@ -15,7 +15,7 @@
  */
 package com.bmuschko.gradle.docker
 
-import com.bmuschko.gradle.docker.services.DockerClientService
+import com.bmuschko.gradle.docker.internal.services.DockerClientService
 import com.bmuschko.gradle.docker.tasks.AbstractDockerRemoteApiTask
 import com.bmuschko.gradle.docker.tasks.RegistryCredentialsAware
 import groovy.transform.CompileStatic

--- a/src/main/groovy/com/bmuschko/gradle/docker/services/DockerClientService.java
+++ b/src/main/groovy/com/bmuschko/gradle/docker/services/DockerClientService.java
@@ -1,0 +1,108 @@
+package com.bmuschko.gradle.docker.services;
+
+import com.bmuschko.gradle.docker.tasks.DockerClientConfiguration;
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientImpl;
+import com.github.dockerjava.httpclient5.ApacheDockerHttpClient;
+import com.google.common.io.Closer;
+import org.gradle.api.file.Directory;
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.services.BuildService;
+import org.gradle.api.services.BuildServiceParameters;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+public abstract class DockerClientService implements BuildService<DockerClientService.Params>, AutoCloseable {
+    private final Map<DefaultDockerClientConfig, DockerClient> dockerClients;
+
+    private final ObjectFactory objects;
+
+    public interface Params extends BuildServiceParameters {
+        Property<String> getUrl();
+        DirectoryProperty getCertPath();
+        Property<String> getApiVersion();
+    }
+
+    @Inject
+    public DockerClientService(ObjectFactory objects) {
+        this.objects = objects;
+        dockerClients = new ConcurrentHashMap<>();
+    }
+
+    public DockerClient getDockerClient(DockerClientConfiguration dockerClientConfiguration) {
+        String dockerUrl = getDockerHostUrl(dockerClientConfiguration);
+        File dockerCertPath = thingOrProperty(objects.directoryProperty(), dockerClientConfiguration.getCertPath(), getParameters().getCertPath()).map(Directory::getAsFile).getOrNull();
+        String apiVersion = thingOrProperty(objects.property(String.class), dockerClientConfiguration.getApiVersion(), getParameters().getApiVersion()).getOrNull();
+
+        // Create configuration
+        DefaultDockerClientConfig.Builder dockerClientConfigBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder();
+        dockerClientConfigBuilder.withDockerHost(dockerUrl);
+
+        if (dockerCertPath != null) {
+            String caninicalCertPath;
+            try {
+                caninicalCertPath = dockerCertPath.getCanonicalPath();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+            dockerClientConfigBuilder.withDockerTlsVerify(true);
+            dockerClientConfigBuilder.withDockerCertPath(caninicalCertPath);
+        } else {
+            dockerClientConfigBuilder.withDockerTlsVerify(false);
+        }
+
+        if (apiVersion != null) {
+            dockerClientConfigBuilder.withApiVersion(apiVersion);
+        }
+
+        DefaultDockerClientConfig dockerClientConfig = dockerClientConfigBuilder.build();
+        return createDefaultDockerClient(dockerClientConfig);
+    }
+
+    private DockerClient createDefaultDockerClient(DefaultDockerClientConfig config) {
+        return dockerClients.computeIfAbsent(config, i -> {
+            ApacheDockerHttpClient dockerClient = new ApacheDockerHttpClient.Builder()
+                    .dockerHost(config.getDockerHost())
+                    .sslConfig(config.getSSLConfig())
+                    .build();
+            return DockerClientImpl.getInstance(
+                    config,
+                    dockerClient
+            );
+        });
+    }
+
+    /**
+     * Checks if Docker host URL starts with http(s) and if so, converts it to tcp
+     * which is accepted by docker-java library.
+     *
+     * @param dockerClientConfiguration docker client configuration
+     * @return Docker host URL as string
+     */
+    private String getDockerHostUrl(DockerClientConfiguration dockerClientConfiguration) {
+        String url = thingOrProperty(objects.property(String.class), dockerClientConfiguration.getUrl(), getParameters().getUrl()).map(String::toLowerCase).get();
+        return url.startsWith("http") ? "tcp" + url.substring(url.indexOf(':')) : url;
+    }
+
+    private <T> Provider<T> thingOrProperty(Property<T> prop, T t, Property<T> tp) {
+        prop.set(t);
+        return prop.orElse(tp);
+    }
+
+    @Override
+    public void close() throws Exception {
+        try (final Closer closer = Closer.create()) {
+            dockerClients.values().forEach(closer::register);
+        }
+    }
+}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -16,7 +16,7 @@
 package com.bmuschko.gradle.docker.tasks
 
 import com.bmuschko.gradle.docker.internal.RegistryAuthLocator
-import com.bmuschko.gradle.docker.services.DockerClientService
+import com.bmuschko.gradle.docker.internal.services.DockerClientService
 import com.github.dockerjava.api.DockerClient
 import groovy.transform.CompileStatic
 import org.gradle.api.Action

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.groovy
@@ -15,16 +15,10 @@
  */
 package com.bmuschko.gradle.docker.tasks
 
-import com.bmuschko.gradle.docker.DockerExtension
-import com.bmuschko.gradle.docker.DockerRemoteApiPlugin
 import com.bmuschko.gradle.docker.internal.RegistryAuthLocator
+import com.bmuschko.gradle.docker.services.DockerClientService
 import com.github.dockerjava.api.DockerClient
-import com.github.dockerjava.core.DefaultDockerClientConfig
-import com.github.dockerjava.core.DockerClientConfig
-import com.github.dockerjava.core.DockerClientImpl
-import com.github.dockerjava.httpclient5.ApacheDockerHttpClient
 import groovy.transform.CompileStatic
-import groovy.transform.Memoized
 import org.gradle.api.Action
 import org.gradle.api.DefaultTask
 import org.gradle.api.file.DirectoryProperty
@@ -61,6 +55,9 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
     @Input
     @Optional
     final Property<String> apiVersion = project.objects.property(String)
+
+    @Internal
+    final Property<DockerClientService> dockerClientService = project.objects.property(DockerClientService)
 
     private Action<? super Throwable> errorHandler
     private Action nextHandler
@@ -123,6 +120,7 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
      * Gets the Docker client uses to communicate with Docker via its remote API.
      * Initialized instance upon first request.
      * Returns the same instance for any successive method call.
+     * To support the configuration cache we rely on DockerClientService's internal cache.
      * <p>
      * Before accessing the Docker client, all data used for configuring its runtime behavior needs to be evaluated.
      * The data includes:
@@ -140,48 +138,8 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
      * @return The Docker client
      */
     @Internal
-    @Memoized
     DockerClient getDockerClient() {
-        DockerClientConfiguration dockerClientConfiguration = createDockerClientConfig()
-        DockerExtension dockerExtension = (DockerExtension) project.extensions.getByName(DockerRemoteApiPlugin.EXTENSION_NAME)
-        String dockerUrl = getDockerHostUrl(dockerClientConfiguration, dockerExtension)
-        File dockerCertPath = dockerClientConfiguration.certPath?.asFile ?: dockerExtension.certPath.getOrNull()?.asFile
-        String apiVersion = dockerClientConfiguration.apiVersion ?: dockerExtension.apiVersion.getOrNull()
-
-        // Create configuration
-        DefaultDockerClientConfig.Builder dockerClientConfigBuilder = DefaultDockerClientConfig.createDefaultConfigBuilder()
-        dockerClientConfigBuilder.withDockerHost(dockerUrl)
-
-        if (dockerCertPath) {
-            dockerClientConfigBuilder.withDockerTlsVerify(true)
-            dockerClientConfigBuilder.withDockerCertPath(dockerCertPath.canonicalPath)
-        } else {
-            dockerClientConfigBuilder.withDockerTlsVerify(false)
-        }
-
-        if (apiVersion) {
-            dockerClientConfigBuilder.withApiVersion(apiVersion)
-        }
-
-        DefaultDockerClientConfig dockerClientConfig = dockerClientConfigBuilder.build()
-
-        DockerClient dockerClient = createDefaultDockerClient(dockerClientConfig)
-        // register buildFinished-hook to close docker client.
-        project.gradle.buildFinished {
-            dockerClient.close()
-        }
-        dockerClient
-    }
-
-    private DockerClient createDefaultDockerClient(DockerClientConfig config) {
-        ApacheDockerHttpClient dockerClient = new ApacheDockerHttpClient.Builder()
-                .dockerHost(config.getDockerHost())
-                .sslConfig(config.getSSLConfig())
-                .build()
-        DockerClientImpl.getInstance(
-            config,
-            dockerClient
-        )
+        dockerClientService.get().getDockerClient(createDockerClientConfig())
     }
 
     /**
@@ -192,10 +150,11 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
      * @return The registry authentication locator
      */
     @Internal
-    @Memoized
     protected RegistryAuthLocator getRegistryAuthLocator() {
-        new RegistryAuthLocator()
+        registryAuthLocator
     }
+
+    private final RegistryAuthLocator registryAuthLocator = new RegistryAuthLocator()
 
     private DockerClientConfiguration createDockerClientConfig() {
         DockerClientConfiguration dockerClientConfig = new DockerClientConfiguration()
@@ -203,18 +162,6 @@ abstract class AbstractDockerRemoteApiTask extends DefaultTask {
         dockerClientConfig.certPath = certPath.getOrNull()
         dockerClientConfig.apiVersion = apiVersion.getOrNull()
         dockerClientConfig
-    }
-
-    /**
-     * Checks if Docker host URL starts with http(s) and if so, converts it to tcp
-     * which is accepted by docker-java library.
-     *
-     * @param dockerClientConfiguration docker client configuration
-     * @return Docker host URL as string
-     */
-    private String getDockerHostUrl(DockerClientConfiguration dockerClientConfiguration, DockerExtension dockerExtension) {
-        String url = (dockerClientConfiguration.url ?: dockerExtension.url.getOrNull()).toLowerCase()
-        url.startsWith('http') ? 'tcp' + url.substring(url.indexOf(':')) : url
     }
 
     abstract void runRemoteCommand()


### PR DESCRIPTION
The main fix here is the removal of the buildFinished call
```
- Unknown location: registration of listener on 'Gradle.buildFinished' is unsupported
  See https://docs.gradle.org/7.4.2/userguide/configuration_cache.html#config_cache:requirements:build_listeners
```
Now we register a build service that implements AutoClosable. This build service contains the same code that previously existed in the base abstract class moved to its own class. I also implemented a simple 'caching' system where already requested clients will simply be cached in a ConcurrentHashMap. I expect most users will have one docker client configuration. The caching system was implemented to mimic the `@Memoized` used previously.

We had to remove the `@Memoized` annotations since those have issues with gradle's build cache.
```
* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':buildImage'.
...
Caused by: java.lang.ClassCastException: class java.lang.Object cannot be cast to class com.bmuschko.gradle.docker.tasks.AbstractDockerRemoteApiTask (java.lang.Object is in module java.base of loader 'bootstrap'; com.bmuschko.gradle.docker.tasks.AbstractDockerRemoteApiTask is in unnamed module of loader org.gradle.internal.classloader.VisitableURLClassLoader @f540b62)
```

The upToDateWhen was changed from a Closure to a Spec to avoid an issue where gradle's configuration cache would capture too much of the surrounding scope.
```
* Exception is:
...
Caused by: org.codehaus.groovy.runtime.typehandling.GroovyCastException: Cannot cast object 'java.lang.Object@7fed6142' with class 'java.lang.Object' to class 'com.bmuschko.gradle.docker.tasks.image.DockerBuildImage'
...
```

The `imageId` property was changed from Internal + setter to based off the output file. I'm not sure if this is the best fix, but task outputs can only be files so basing the value of `imageId` off of the value of the output file seemed the most sane.
```
* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':assertImageIdForBuildImage'.
...
Caused by: org.gradle.api.GradleException: The imageId property was not set from task buildImage
...
```

To fix the imageIdValidation task, which had this issue
```
1 problem was found storing the configuration cache.
- Task `:assertImageIdForBuildImage` of type `org.gradle.api.DefaultTask`: cannot serialize object of type 'com.bmuschko.gradle.docker.tasks.image.DockerBuildImage', a subtype of 'org.gradle.api.Task', as these are not supported with the configuration cache.
  See https://docs.gradle.org/7.4.2/userguide/configuration_cache.html#config_cache:requirements:task_access
```
I've replaced the calls to dependantTask with the values outside of the doLast closure.
