### PR TITLE
Enable configuration cache for all functional tests

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -54,7 +54,7 @@ abstract class AbstractFunctionalTest extends Specification {
     private GradleRunner createAndConfigureGradleRunner(String... arguments) {
         GradleRunner.create()
             .withProjectDir(projectDir)
-            .withArguments(arguments + '-s' as List<String>)
+            .withArguments(arguments + '-s' + CONFIGURATION_CACHE as List<String>)
             .withPluginClasspath()
             .withEnvironment(envVars)
     }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/AbstractFunctionalTest.groovy
@@ -12,7 +12,6 @@ abstract class AbstractFunctionalTest extends Specification {
     public static final String TEST_IMAGE = 'alpine'
     public static final String TEST_IMAGE_TAG = '3.4'
     public static final String TEST_IMAGE_WITH_TAG = "${TEST_IMAGE}:${TEST_IMAGE_TAG}"
-    public static final String CONFIGURATION_CACHE = '--configuration-cache'
 
     @TempDir
     File temporaryFolder
@@ -54,7 +53,7 @@ abstract class AbstractFunctionalTest extends Specification {
     private GradleRunner createAndConfigureGradleRunner(String... arguments) {
         GradleRunner.create()
             .withProjectDir(projectDir)
-            .withArguments(arguments + '-s' + CONFIGURATION_CACHE as List<String>)
+            .withArguments(arguments + '-s' + '--configuration-cache' as List<String>)
             .withPluginClasspath()
             .withEnvironment(envVars)
     }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -20,7 +20,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
 
     def "Can create image and start container for Java application with default configuration and configuration cache enabled"() {
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, 'buildAndCleanResources')
+        BuildResult result = build('buildAndCleanResources')
 
         then:
         assertGeneratedDockerfile()
@@ -29,7 +29,7 @@ class DockerJavaApplicationPluginFunctionalTest extends AbstractGroovyDslFunctio
         result.output.contains("0 problems were found storing the configuration cache.")
 
         when:
-        result = build(CONFIGURATION_CACHE, 'buildAndCleanResources')
+        result = build('buildAndCleanResources')
 
         then:
         result.output.contains("Configuration cache entry reused.")

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerJavaApplicationPluginFunctionalTest.groovy
@@ -382,15 +382,8 @@ ADD file2.txt /other/dir/file2.txt
 
     private void writeNoTasksRealizedAssertionToBuildFile() {
         buildFile << """
-            def configuredTasks = []
             tasks.configureEach {
-                configuredTasks << it
-            }
-
-            gradle.buildFinished {
-                def configuredTaskPaths = configuredTasks*.path
-
-                assert configuredTaskPaths == [':help', ':clean']
+                assert it.path in [':help', ':clean']
             }
         """
     }

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/DockerSpringBootApplicationPluginFunctionalTest.groovy
@@ -194,7 +194,7 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
                     images = expectedImages
                 }
             }
-            
+
             task verify {
                 doLast {
                     assert dockerBuildImage.images.get() == expectedImages
@@ -215,13 +215,14 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
         writeSpringBootBuildFile(reactedPluginIdentifier)
         configureRemoteApiPlugin()
         writeCustomTasksToBuildFile()
+        writeSpringBootApplicationClass()
     }
 
     private void writeSpringBootBuildFile(String reactedPluginIdentifier) {
         buildFile << """
             plugins {
-                id 'org.springframework.boot' version '2.0.3.RELEASE'
-                id 'io.spring.dependency-management' version '1.0.5.RELEASE'
+                id 'org.springframework.boot' version '2.7.5'
+                id 'io.spring.dependency-management' version '1.1.0'
                 id '$reactedPluginIdentifier'
                 id 'com.bmuschko.docker-spring-boot-application'
             }
@@ -244,6 +245,17 @@ class DockerSpringBootApplicationPluginFunctionalTest extends AbstractGroovyDslF
         buildFile << imageTasks()
         buildFile << containerTasks()
         buildFile << lifecycleTask()
+    }
+
+
+    void writeSpringBootApplicationClass() {
+        buildFile << """
+            docker {
+                springBootApplication {
+                    mainClassName = 'com.bmuschko.gradle.docker.springboot.Application'
+                }
+            }
+            """
     }
 
     enum ReactedPlugin {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
@@ -121,6 +121,33 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractGroovyDslFunctiona
         result.output.contains('Can specify either hostPath or tarFile not both')
     }
 
+    def "can copy a file into a container with configuration cache"() {
+        given:
+        writeHelloWorldFile()
+        buildFile << commonBuildScriptTasks()
+        buildFile << """
+            task copyFileIntoContainer(type: DockerCopyFileToContainer) {
+                dependsOn createContainer
+                finalizedBy removeContainer
+                targetContainerId createContainer.getContainerId()
+                hostPath = "${escapeFilePath(new File(projectDir, 'HelloWorld.txt'))}"
+                remotePath = "/root"
+            }
+        """
+
+        when:
+        BuildResult result = build(CONFIGURATION_CACHE, 'copyFileIntoContainer')
+
+        then:
+        result.output.contains("0 problems were found storing the configuration cache.")
+
+        when:
+        result = build(CONFIGURATION_CACHE, 'copyFileIntoContainer')
+
+        then:
+        result.output.contains("Configuration cache entry reused.")
+    }
+
     private void writeHelloWorldFile() {
         new File("$projectDir/HelloWorld.txt").withWriter('UTF-8') {
             it.write('Hello, World!')
@@ -144,7 +171,7 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractGroovyDslFunctiona
                 targetImageId pullImage.getImage()
                 cmd = ['echo', 'Hello World']
             }
-            
+
             task removeContainer(type: DockerRemoveContainer) {
                 removeVolumes = true
                 force = true

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainerFunctionalTest.groovy
@@ -136,13 +136,13 @@ class DockerCopyFileToContainerFunctionalTest extends AbstractGroovyDslFunctiona
         """
 
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, 'copyFileIntoContainer')
+        BuildResult result = build('copyFileIntoContainer')
 
         then:
         result.output.contains("0 problems were found storing the configuration cache.")
 
         when:
-        result = build(CONFIGURATION_CACHE, 'copyFileIntoContainer')
+        result = build('copyFileIntoContainer')
 
         then:
         result.output.contains("Configuration cache entry reused.")

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -141,12 +141,14 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
 
         then:
         result.output.contains("HWaddr 02:03:04:05:06:07")
+        result.output.contains("0 problems were found storing the configuration cache.")
 
         when:
         result = build('logContainer')
 
         then:
         result.output.contains("HWaddr 02:03:04:05:06:07")
+        result.output.contains("Configuration cache entry reused.")
     }
 
     def "can set multiple environment variables"() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -141,6 +141,12 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
 
         then:
         result.output.contains("HWaddr 02:03:04:05:06:07")
+
+        when:
+        result = build('logContainer')
+
+        then:
+        result.output.contains("HWaddr 02:03:04:05:06:07")
     }
 
     def "can set multiple environment variables"() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainerFunctionalTest.groovy
@@ -409,14 +409,14 @@ class DockerCreateContainerFunctionalTest extends AbstractGroovyDslFunctionalTes
             containerLogAndRemove()
 
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, 'logContainer')
+        BuildResult result = build('logContainer')
 
         then:
         result.output.contains("Hello, world!")
         result.output.contains("0 problems were found storing the configuration cache.")
 
         when:
-        result = build(CONFIGURATION_CACHE, 'logContainer')
+        result = build('logContainer')
 
         then:
         result.output.contains("Configuration cache entry reused.")

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -187,6 +187,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
 
         then:
         result.output.contains('Hello World')
+        result.output.contains("0 problems were found storing the configuration cache.")
     }
 
     static String containerUsage(String containerExecutionTask, int sleep = 30) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -15,7 +15,6 @@
  */
 package com.bmuschko.gradle.docker.tasks.container
 
-import com.bmuschko.gradle.docker.AbstractFunctionalTest
 import com.bmuschko.gradle.docker.AbstractGroovyDslFunctionalTest
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
@@ -188,7 +187,6 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
 
         then:
         result.output.contains('Hello World')
-        println result.output
     }
 
     static String containerUsage(String containerExecutionTask, int sleep = 30) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -15,6 +15,7 @@
  */
 package com.bmuschko.gradle.docker.tasks.container
 
+import com.bmuschko.gradle.docker.AbstractFunctionalTest
 import com.bmuschko.gradle.docker.AbstractGroovyDslFunctionalTest
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.TaskOutcome
@@ -169,6 +170,25 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
 
         then:
         result.output.contains('Finished Probing Exec')
+    }
+
+    def "Execute command with configuration cache enabled"() {
+        given:
+        String containerExecutionTask = """
+            task execContainer(type: DockerExecContainer) {
+                dependsOn startContainer
+                targetContainerId startContainer.getContainerId()
+                withCommand(['echo', 'Hello World'])
+            }
+        """
+        buildFile << containerUsage(containerExecutionTask)
+
+        when:
+        BuildResult result = build(CONFIGURATION_CACHE, 'logContainer')
+
+        then:
+        result.output.contains('Hello World')
+        println result.output
     }
 
     static String containerUsage(String containerExecutionTask, int sleep = 30) {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -184,7 +184,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
         buildFile << containerUsage(containerExecutionTask)
 
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, 'logContainer')
+        BuildResult result = build('logContainer')
 
         then:
         result.output.contains('Hello World')

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
@@ -19,6 +19,7 @@ import com.bmuschko.gradle.docker.AbstractGroovyDslFunctionalTest
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.TaskOutcome
+import spock.lang.Ignore
 
 class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
@@ -144,6 +145,7 @@ class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
         result.output ==~ ~/(?s).*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9][.][0-9]+Z\s+Hello World.*/
     }
 
+    @Ignore("the only test task that doesn't support configuration cache")
     def "Can write output to file"() {
         given:
         String logContainerTask = """
@@ -261,7 +263,7 @@ class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
                 dependsOn createContainer
                 targetContainerId createContainer.getContainerId()
             }
-            
+
             task removeContainer(type: DockerRemoveContainer) {
                 removeVolumes = true
                 force = true

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
@@ -19,7 +19,6 @@ import com.bmuschko.gradle.docker.AbstractGroovyDslFunctionalTest
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.BuildTask
 import org.gradle.testkit.runner.TaskOutcome
-import spock.lang.Ignore
 
 class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest {
 
@@ -145,7 +144,6 @@ class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
         result.output ==~ ~/(?s).*[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]T[0-9][0-9]:[0-9][0-9]:[0-9][0-9][.][0-9]+Z\s+Hello World.*/
     }
 
-    @Ignore("the only test task that doesn't support configuration cache")
     def "Can write output to file"() {
         given:
         String logContainerTask = """

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -154,21 +154,13 @@ USER \$user"""
         buildFile << dockerFileTask() << """
             import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
 
-            task buildImage(type: CustomDockerBuildImage) {
+            task buildImage(type: DockerBuildImage) {
                 dependsOn dockerfile
-                labels = ["build-date": "\${getBuildDate()}"]
+                labels = ["build-date": getBuildDate()]
             }
 
             def getBuildDate() {
                 return new Date().format('yyyyMMddHHmmss.SSS')
-            }
-
-            class CustomDockerBuildImage extends DockerBuildImage {
-                @Override
-                @Internal
-                MapProperty<String, String> getLabels() {
-                    super.getLabels()
-                }
             }
         """
 

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImageFunctionalTest.groovy
@@ -478,14 +478,14 @@ USER \$user"""
         buildFile << imageCreationTask()
 
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, 'buildImage')
+        BuildResult result = build('buildImage')
 
         then:
         result.output.contains("Created image with ID")
         result.output.contains("Configuration cache entry stored.")
 
         when:
-        result = build(CONFIGURATION_CACHE, 'buildImage')
+        result = build('buildImage')
 
         then:
         result.output.contains("Reusing configuration cache.")

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -26,14 +26,14 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         """
 
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, COMMIT_TASK_NAME)
+        BuildResult result = build(COMMIT_TASK_NAME)
 
         then:
         result.output.contains("Committing image 'myimage:latest' for container")
         result.output.contains("0 problems were found storing the configuration cache.")
 
         when:
-        result = build(CONFIGURATION_CACHE, COMMIT_TASK_NAME)
+        result = build(COMMIT_TASK_NAME)
 
         then:
         result.output.contains("Configuration cache entry reused.")

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImageFunctionalTest.groovy
@@ -31,6 +31,12 @@ class DockerCommitImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         then:
         result.output.contains("Committing image 'myimage:latest' for container")
         result.output.contains("0 problems were found storing the configuration cache.")
+
+        when:
+        result = build(CONFIGURATION_CACHE, COMMIT_TASK_NAME)
+
+        then:
+        result.output.contains("Configuration cache entry reused.")
     }
 
     def "cannot commit image with invalid container"() {

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImageFunctionalTest.groovy
@@ -316,14 +316,14 @@ class DockerSaveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         """
 
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, 'saveImage')
+        BuildResult result = build('saveImage')
 
         then:
         file(IMAGE_FILE).size() > 0
         result.output.contains("0 problems were found storing the configuration cache.")
 
         when:
-        result = build(CONFIGURATION_CACHE, 'saveImage')
+        result = build('saveImage')
 
         then:
         result.output.contains("Configuration cache entry reused.")

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
@@ -288,7 +288,7 @@ LABEL maintainer=benjamin.muschko@gmail.com
         given:
         buildFile << """
             ext.labelVersion = project.properties.getOrDefault('labelVersion', '1.0')
-            
+
             task ${DOCKERFILE_TASK_NAME}(type: Dockerfile) {
                 instruction('FROM $TEST_IMAGE_WITH_TAG')
                 instruction('LABEL maintainer=benjamin.muschko@gmail.com')
@@ -354,7 +354,7 @@ COPY --from=builder /opt/h2.jar /opt/h2.jar
         """
 
         when:
-        BuildResult result = build(CONFIGURATION_CACHE, DOCKERFILE_TASK_NAME)
+        BuildResult result = build(DOCKERFILE_TASK_NAME)
 
         then:
         result.output.contains("Configuration cache entry stored.")
@@ -362,7 +362,7 @@ COPY --from=builder /opt/h2.jar /opt/h2.jar
 """)
 
         when:
-        result = build(CONFIGURATION_CACHE, DOCKERFILE_TASK_NAME)
+        result = build(DOCKERFILE_TASK_NAME)
 
         then:
         result.output.contains("Reusing configuration cache.")

--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/IOUtils.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/IOUtils.groovy
@@ -1,8 +1,6 @@
 package com.bmuschko.gradle.docker.internal
 
 import groovy.transform.CompileStatic
-import org.gradle.api.Project
-import org.gradle.api.internal.GradleInternal
 import org.gradle.internal.logging.progress.ProgressLogger
 import org.gradle.internal.logging.progress.ProgressLoggerFactory
 import org.gradle.internal.service.ServiceRegistry
@@ -35,12 +33,11 @@ final class IOUtils {
     /**
      * Create a progress logger for an arbitrary project and class.
      *
-     * @param project the project to create a ProgressLogger for.
+     * @param services the service registry.
      * @param clazz optional class to pair the ProgressLogger to. Defaults to _this_ class if null.
      * @return instance of ProgressLogger.
      */
-    static ProgressLogger getProgressLogger(final Project project, final Class clazz) {
-        ServiceRegistry registry = (project.gradle as GradleInternal).getServices()
+    static ProgressLogger getProgressLogger(final ServiceRegistry registry, final Class clazz) {
         ProgressLoggerFactory factory = registry.get(ProgressLoggerFactory)
         ProgressLogger progressLogger = factory.newOperation(Objects.requireNonNull(clazz))
         progressLogger.setDescription("ProgressLogger for ${clazz.getSimpleName()}")

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileToContainer.groovy
@@ -19,6 +19,7 @@ import com.bmuschko.gradle.docker.domain.CopyFileToContainer
 import com.github.dockerjava.api.command.CopyArchiveToContainerCmd
 import org.gradle.api.GradleException
 import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.internal.project.ProjectInternal
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
@@ -73,13 +74,15 @@ class DockerCopyFileToContainer extends DockerExistingContainer {
         }
     }
 
+    private final fileOperations = (project as ProjectInternal).fileOperations
+
     private void setContainerCommandConfig(CopyArchiveToContainerCmd containerCommand, CopyFileToContainer copyFileToContainer) {
 
         def localHostPath
         if (copyFileToContainer.hostPath instanceof Closure) {
-            localHostPath = project.file(copyFileToContainer.hostPath.call())
+            localHostPath = fileOperations.file(copyFileToContainer.hostPath.call())
         } else {
-            localHostPath = project.file(copyFileToContainer.hostPath)
+            localHostPath = fileOperations.file(copyFileToContainer.hostPath)
         }
 
         def localRemotePath

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -669,7 +669,7 @@ class DockerCreateContainer extends DockerExistingImage {
             this.restartPolicy.set("${name}:${maximumRetryCount}".toString())
         }
 
-        static class LogConfig {
+        static class LogConfig implements Serializable {
             String type
             Map<String, String> config = [:]
         }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -182,7 +182,7 @@ class DockerCreateContainer extends DockerExistingImage {
 
         containerId.set(containerIdFile.map { RegularFile it ->
             File file = it.asFile
-            if(file.exists()) {
+            if (file.exists()) {
                 return file.text
             }
             return null
@@ -198,7 +198,7 @@ class DockerCreateContainer extends DockerExistingImage {
         @Override
         boolean isSatisfiedBy(Task element) {
             File file = containerIdFile.get().asFile
-            if(file.exists()) {
+            if (file.exists()) {
                 try {
                     def fileContainerId = file.text
                     dockerClient.inspectContainerCmd(fileContainerId).exec()

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
@@ -114,7 +114,7 @@ class DockerExecContainer extends DockerExistingContainer {
 
 
             // create progressLogger for pretty printing of terminal log progression.
-            final def progressLogger = getProgressLogger(project, DockerExecContainer)
+            final def progressLogger = getProgressLogger(services, DockerExecContainer)
             progressLogger.started()
 
             // if no livenessProbe defined then create a default

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
@@ -100,6 +100,13 @@ class DockerLogsContainer extends DockerExistingContainer {
     @Optional
     Writer sink
 
+    def setSink(Writer sink) {
+        if (sink != null) {
+            notCompatibleWithConfigurationCache("Setting sink is not compatible with configuration cache")
+            this.sink = sink
+        }
+    }
+
     // Allows subclasses to carry their own logic
     @Internal
     protected Date getInternalSince() {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
@@ -104,6 +104,9 @@ class DockerLogsContainer extends DockerExistingContainer {
         if (sink != null) {
             notCompatibleWithConfigurationCache("Setting sink is not compatible with configuration cache")
             this.sink = sink
+        } else {
+            isCompatibleWithConfigurationCache()
+            this.sink = null
         }
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -229,7 +229,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
         imageId.set(imageIdFile.map { RegularFile it ->
             File file = it.asFile
-            if(file.exists()) {
+            if (file.exists()) {
                 return file.text
             }
             return null
@@ -246,7 +246,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
         @Override
         boolean isSatisfiedBy(Task element) {
             File file = imageIdFile.get().asFile
-            if(file.exists()) {
+            if (file.exists()) {
                 try {
                     def fileImageId = file.text
                     def repoTags = dockerClient.inspectImageCmd(fileImageId).exec().repoTags

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
@@ -88,7 +88,7 @@ class DockerCommitImage extends DockerExistingContainer {
     DockerCommitImage() {
         imageId.set(imageIdFile.map { RegularFile it ->
             File file = it.asFile
-            if(file.exists()) {
+            if (file.exists()) {
                 return file.text
             }
             return null

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerExistingImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerExistingImage.groovy
@@ -19,6 +19,7 @@ import com.bmuschko.gradle.docker.tasks.AbstractDockerRemoteApiTask
 import groovy.transform.CompileStatic
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.provider.ProviderFactory
 import org.gradle.api.tasks.Input
 
 import java.util.concurrent.Callable
@@ -30,6 +31,8 @@ abstract class DockerExistingImage extends AbstractDockerRemoteApiTask {
      */
     @Input
     final Property<String> imageId = project.objects.property(String)
+
+    private final ProviderFactory providers = project.providers
 
     /**
      * Sets the target image ID or name.
@@ -50,7 +53,7 @@ abstract class DockerExistingImage extends AbstractDockerRemoteApiTask {
      * @see #targetImageId(Provider)
      */
     void targetImageId(Callable<String> imageId) {
-        targetImageId(project.provider(imageId))
+        targetImageId(providers.provider(imageId))
     }
 
     /**


### PR DESCRIPTION
Mostly the same fixes we've seen before.

Fixed DockerCreateContainer to have the same file backing code as in https://github.com/bmuschko/gradle-docker-plugin/pull/1108/files#diff-be81629192d1cfcf7ebdbfb002ee9f04492909eb2511895b4d39e9eb2fc8d640.

Exposed port needs Serializable.

DockerExecContainer needs a logger which we can get from `getServices`, avoiding the call to project.