### PR TITLE
Replace copy function with transferTo

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/internal/IOUtils.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/internal/IOUtils.groovy
@@ -8,17 +8,7 @@ import org.gradle.internal.service.ServiceRegistry
 @CompileStatic
 final class IOUtils {
 
-    private static final int DEFAULT_BUFFER_SIZE = 1024 * 4
-
     private IOUtils() { }
-
-    static void copy(InputStream input, OutputStream output) throws IOException {
-        byte[] buffer = new byte[DEFAULT_BUFFER_SIZE]
-        int n
-        while (-1 != (n = input.read(buffer))) {
-            output.write(buffer, 0, n)
-        }
-    }
 
     static void closeQuietly(Closeable toClose) {
         try {

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
@@ -127,7 +127,7 @@ class DockerSaveImage extends AbstractDockerRemoteApiTask {
                 os = new GZIPOutputStream(fs)
             }
             try {
-                IOUtils.copy(image, os)
+                image.transferTo(os)
             } catch (IOException e) {
                 throw new GradleException("Can't save image.", e)
             } finally {


### PR DESCRIPTION
Since we're on java 11 already, let's use the new `transferTo` method instead of continuing to use the custom copy.