### PR TITLE
Correct links in user guide that point to outdated API docs

### DIFF
--- a/src/docs/asciidoc/user-guide/index.adoc
+++ b/src/docs/asciidoc/user-guide/index.adoc
@@ -1,6 +1,6 @@
 = Gradle Docker Plugin User Guide & Examples
 :uri-bmuschko-blog: https://bmuschko.com/blog
-:uri-ghpages: https://bmuschko.github.io/gradle-docker-plugin
+:uri-ghpages: https://bmuschko.github.io/gradle-docker-plugin/{gradle-project-version}
 :uri-github: https://github.com/bmuschko/gradle-docker-plugin
 :uri-gradle-docs: https://docs.gradle.org/current
 


### PR DESCRIPTION
For more information, see https://github.com/bmuschko/gradle-docker-plugin/issues/1121.