### PR TITLE
Don't use set to define default property values

### DIFF
--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCopyFileFromContainer.groovy
@@ -61,8 +61,8 @@ class DockerCopyFileFromContainer extends DockerExistingContainer {
     final DirectoryProperty buildDirectory = project.layout.buildDirectory
 
     DockerCopyFileFromContainer() {
-        hostPath.set(project.projectDir.path)
-        compressed.set(false)
+        hostPath.convention(project.projectDir.path)
+        compressed.convention(false)
     }
 
     @Override

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.groovy
@@ -167,20 +167,14 @@ class DockerCreateContainer extends DockerExistingImage {
     DockerCreateContainer(ObjectFactory objectFactory) {
         hostConfig = objectFactory.newInstance(HostConfig, objectFactory)
         healthCheck = objectFactory.newInstance(HealthCheckConfig, objectFactory)
-        portSpecs.empty()
-        stdinOpen.set(false)
-        stdinOnce.set(false)
-        attachStdin.set(false)
-        attachStdout.set(false)
-        attachStderr.set(false)
-        cmd.empty()
-        entrypoint.empty()
-        networkAliases.empty()
-        volumes.empty()
-        exposedPorts.empty()
-        tty.set(false)
+        stdinOpen.convention(false)
+        stdinOnce.convention(false)
+        attachStdin.convention(false)
+        attachStdout.convention(false)
+        attachStderr.convention(false)
+        tty.convention(false)
 
-        containerId.set(containerIdFile.map { RegularFile it ->
+        containerId.convention(containerIdFile.map { RegularFile it ->
             File file = it.asFile
             if (file.exists()) {
                 return file.text
@@ -189,7 +183,7 @@ class DockerCreateContainer extends DockerExistingImage {
         })
 
         String safeTaskPath = path.replaceFirst("^:", "").replaceAll(":", "_")
-        containerIdFile.set(project.layout.buildDirectory.file(".docker/${safeTaskPath}-containerId.txt"))
+        containerIdFile.convention(project.layout.buildDirectory.file(".docker/${safeTaskPath}-containerId.txt"))
 
         outputs.upToDateWhen upToDateWhenSpec
     }
@@ -228,11 +222,7 @@ class DockerCreateContainer extends DockerExistingImage {
     }
 
     void withEnvVar(String key, String value) {
-        if (envVars.getOrNull()) {
-            envVars.put(key, value)
-        } else {
-            envVars.set([(key): value])
-        }
+        envVars.put(key, value)
     }
 
     private static HealthCheck getOrCreateHealthCheck(CreateContainerCmd containerCommand) {
@@ -628,35 +618,28 @@ class DockerCreateContainer extends DockerExistingImage {
         @Inject
         HostConfig(ObjectFactory objectFactory) {
             groups = objectFactory.listProperty(String)
-            groups.empty()
             memory = objectFactory.property(Long)
             memorySwap = objectFactory.property(Long)
             cpuset = objectFactory.property(String)
             dns = objectFactory.listProperty(String)
-            dns.empty()
             network = objectFactory.property(String)
             links = objectFactory.listProperty(String)
-            links.empty()
             volumesFrom = objectFactory.listProperty(String)
-            volumesFrom.empty()
             portBindings = objectFactory.listProperty(String)
-            portBindings.empty()
             publishAll = objectFactory.property(Boolean)
-            publishAll.set(false)
+            publishAll.convention(false)
             binds = objectFactory.mapProperty(String, String)
             tmpFs = objectFactory.mapProperty(String, String)
             extraHosts = objectFactory.listProperty(String)
-            extraHosts.empty()
             logConfig = objectFactory.property(LogConfig)
             privileged = objectFactory.property(Boolean)
-            privileged.set(false)
+            privileged.convention(false)
             restartPolicy = objectFactory.property(String)
             capAdd = objectFactory.listProperty(String)
             capDrop = objectFactory.listProperty(String)
             devices = objectFactory.listProperty(String)
             shmSize = objectFactory.property(Long)
             autoRemove = objectFactory.property(Boolean)
-            autoRemove.set(false)
             ipcMode = objectFactory.property(String)
             sysctls = objectFactory.mapProperty(String, String)
         }
@@ -717,7 +700,6 @@ class DockerCreateContainer extends DockerExistingImage {
             interval = objectFactory.property(Long)
             timeout = objectFactory.property(Long)
             cmd = objectFactory.listProperty(String)
-            cmd.empty()
             retries = objectFactory.property(Integer)
             startPeriod = objectFactory.property(Long)
         }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.groovy
@@ -87,11 +87,8 @@ class DockerExecContainer extends DockerExistingContainer {
     final ListProperty<String> execIds = project.objects.listProperty(String)
 
     DockerExecContainer() {
-        commands.empty()
-        attachStdout.set(true)
-        attachStderr.set(true)
-        successOnExitCodes.empty()
-        execIds.empty()
+        attachStdout.convention(true)
+        attachStderr.convention(true)
     }
 
     @Override

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainer.groovy
@@ -117,8 +117,8 @@ class DockerLogsContainer extends DockerExistingContainer {
     }
 
     DockerLogsContainer() {
-        stdOut.set(true)
-        stdErr.set(true)
+        stdOut.convention(true)
+        stdErr.convention(true)
     }
 
     @Override

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerBuildImage.groovy
@@ -219,15 +219,13 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
     final Property<String> imageId = project.objects.property(String)
 
     DockerBuildImage() {
-        inputDir.set(project.layout.buildDirectory.dir('docker'))
-        images.empty()
-        noCache.set(false)
-        remove.set(false)
-        quiet.set(false)
-        pull.set(false)
-        cacheFrom.empty()
+        inputDir.convention(project.layout.buildDirectory.dir('docker'))
+        noCache.convention(false)
+        remove.convention(false)
+        quiet.convention(false)
+        pull.convention(false)
 
-        imageId.set(imageIdFile.map { RegularFile it ->
+        imageId.convention(imageIdFile.map { RegularFile it ->
             File file = it.asFile
             if (file.exists()) {
                 return file.text
@@ -237,7 +235,7 @@ class DockerBuildImage extends AbstractDockerRemoteApiTask implements RegistryCr
 
         String safeTaskPath = path.replaceFirst("^:", "").replaceAll(":", "_")
         registryCredentials = project.objects.newInstance(DockerRegistryCredentials, project.objects)
-        imageIdFile.set(project.layout.buildDirectory.file(".docker/${safeTaskPath}-imageId.txt"))
+        imageIdFile.convention(project.layout.buildDirectory.file(".docker/${safeTaskPath}-imageId.txt"))
 
         outputs.upToDateWhen upToDateWhenSpec
     }

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerCommitImage.groovy
@@ -86,7 +86,7 @@ class DockerCommitImage extends DockerExistingContainer {
     final Property<String> imageId = project.objects.property(String)
 
     DockerCommitImage() {
-        imageId.set(imageIdFile.map { RegularFile it ->
+        imageId.convention(imageIdFile.map { RegularFile it ->
             File file = it.asFile
             if (file.exists()) {
                 return file.text
@@ -95,7 +95,7 @@ class DockerCommitImage extends DockerExistingContainer {
         })
 
         String safeTaskPath = path.replaceFirst("^:", "").replaceAll(":", "_")
-        imageIdFile.set(project.layout.buildDirectory.file(".docker/${safeTaskPath}-imageId.txt"))
+        imageIdFile.convention(project.layout.buildDirectory.file(".docker/${safeTaskPath}-imageId.txt"))
     }
 
     @Override

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerPushImage.groovy
@@ -37,7 +37,7 @@ class DockerPushImage extends AbstractDockerRemoteApiTask implements RegistryCre
      * @since 6.0.0
      */
     @Input
-    final SetProperty<String> images = project.objects.setProperty(String).empty()
+    final SetProperty<String> images = project.objects.setProperty(String)
 
     /**
      * {@inheritDoc}

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/DockerSaveImage.groovy
@@ -54,9 +54,9 @@ class DockerSaveImage extends AbstractDockerRemoteApiTask {
     final RegularFileProperty imageIdsFile = project.objects.fileProperty()
 
     DockerSaveImage() {
-        useCompression.set(false)
+        useCompression.convention(false)
         String safeTaskPath = path.replaceFirst("^:", "").replaceAll(":", "_")
-        imageIdsFile.set(project.layout.buildDirectory.file(".docker/${safeTaskPath}-imageIds.properties"))
+        imageIdsFile.convention(project.layout.buildDirectory.file(".docker/${safeTaskPath}-imageIds.properties"))
 
         onlyIf onlyIfSpec
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/image/Dockerfile.groovy
@@ -58,9 +58,9 @@ class Dockerfile extends DefaultTask {
     private final ObjectFactory objects
 
     Dockerfile() {
-        instructions = project.objects.listProperty(Instruction).empty()
+        instructions = project.objects.listProperty(Instruction)
         destFile = project.objects.fileProperty()
-        destFile.set(project.layout.buildDirectory.file('docker/Dockerfile'))
+        destFile.convention(project.layout.buildDirectory.file('docker/Dockerfile'))
         objects = project.objects
     }
 

--- a/src/main/groovy/com/bmuschko/gradle/docker/tasks/network/DockerCreateNetwork.groovy
+++ b/src/main/groovy/com/bmuschko/gradle/docker/tasks/network/DockerCreateNetwork.groovy
@@ -86,7 +86,7 @@ class DockerCreateNetwork extends AbstractDockerRemoteApiTask {
         @Inject
         Ipam(ObjectFactory objectFactory) {
             driver = objectFactory.property(String)
-            configs = objectFactory.listProperty(Config).empty()
+            configs = objectFactory.listProperty(Config)
         }
 
         @PackageScope

--- a/src/main/java/com/bmuschko/gradle/docker/DockerConventionJvmApplicationExtension.java
+++ b/src/main/java/com/bmuschko/gradle/docker/DockerConventionJvmApplicationExtension.java
@@ -102,14 +102,14 @@ public class DockerConventionJvmApplicationExtension {
 
     public DockerConventionJvmApplicationExtension(ObjectFactory objectFactory) {
         baseImage = objectFactory.property(String.class);
-        baseImage.set("openjdk:11.0.15-jre-slim");
+        baseImage.convention("openjdk:11.0.15-jre-slim");
         maintainer = objectFactory.property(String.class);
-        maintainer.set(System.getProperty("user.name"));
+        maintainer.convention(System.getProperty("user.name"));
         ports = objectFactory.listProperty(Integer.class);
-        ports.set(List.of(8080));
-        images = objectFactory.setProperty(String.class).empty();
-        jvmArgs = objectFactory.listProperty(String.class).empty();
+        ports.convention(List.of(8080));
+        images = objectFactory.setProperty(String.class);
+        jvmArgs = objectFactory.listProperty(String.class);
         mainClassName = objectFactory.property(String.class);
-        args = objectFactory.listProperty(String.class).empty();
+        args = objectFactory.listProperty(String.class);
     }
 }

--- a/src/main/java/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.java
+++ b/src/main/java/com/bmuschko/gradle/docker/DockerConventionJvmApplicationPlugin.java
@@ -185,7 +185,7 @@ public abstract class DockerConventionJvmApplicationPlugin<EXT extends DockerCon
                 pushImage.setGroup(DockerRemoteApiPlugin.DEFAULT_TASK_GROUP);
                 pushImage.setDescription("Pushes created Docker image to the repository.");
                 pushImage.dependsOn(dockerBuildImageTask);
-                pushImage.getImages().set(dockerBuildImageTask.get().getImages());
+                pushImage.getImages().convention(dockerBuildImageTask.get().getImages());
             }
         });
     }

--- a/src/main/java/com/bmuschko/gradle/docker/DockerExtension.java
+++ b/src/main/java/com/bmuschko/gradle/docker/DockerExtension.java
@@ -67,13 +67,13 @@ public class DockerExtension {
         DockerConfigResolver dockerConfigResolver = new DefaultDockerConfigResolver();
 
         url = objectFactory.property(String.class);
-        url.set(dockerConfigResolver.getDefaultDockerUrl());
+        url.convention(dockerConfigResolver.getDefaultDockerUrl());
         certPath = objectFactory.directoryProperty();
 
         File defaultDockerCert = dockerConfigResolver.getDefaultDockerCert();
 
         if (defaultDockerCert != null) {
-            certPath.set(defaultDockerCert);
+            certPath.convention(objectFactory.directoryProperty().fileValue(defaultDockerCert));
         }
 
         apiVersion = objectFactory.property(String.class);

--- a/src/main/java/com/bmuschko/gradle/docker/DockerRegistryCredentials.java
+++ b/src/main/java/com/bmuschko/gradle/docker/DockerRegistryCredentials.java
@@ -81,7 +81,7 @@ public class DockerRegistryCredentials {
     @Inject
     public DockerRegistryCredentials(ObjectFactory objectFactory) {
         url = objectFactory.property(String.class);
-        url.set(DEFAULT_URL);
+        url.convention(DEFAULT_URL);
         username = objectFactory.property(String.class);
         password = objectFactory.property(String.class);
         email = objectFactory.property(String.class);

--- a/src/main/java/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.java
+++ b/src/main/java/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.java
@@ -53,10 +53,10 @@ public class DockerRemoteApiPlugin implements Plugin<Project> {
         project.getTasks().withType(RegistryCredentialsAware.class).configureEach(new Action<RegistryCredentialsAware>() {
             @Override
             public void execute(RegistryCredentialsAware task) {
-                task.getRegistryCredentials().getUrl().set(extensionRegistryCredentials.getUrl());
-                task.getRegistryCredentials().getUsername().set(extensionRegistryCredentials.getUsername());
-                task.getRegistryCredentials().getPassword().set(extensionRegistryCredentials.getPassword());
-                task.getRegistryCredentials().getEmail().set(extensionRegistryCredentials.getEmail());
+                task.getRegistryCredentials().getUrl().convention(extensionRegistryCredentials.getUrl());
+                task.getRegistryCredentials().getUsername().convention(extensionRegistryCredentials.getUsername());
+                task.getRegistryCredentials().getPassword().convention(extensionRegistryCredentials.getPassword());
+                task.getRegistryCredentials().getEmail().convention(extensionRegistryCredentials.getEmail());
             }
         });
     }


### PR DESCRIPTION
Changes all occurences where a property default value is defined using
the set method to use convention instead, which is the idiomatic way of
setting a default value.
Furthermore all calls to `empty` on List-, Set-, and MapProperties are
dropped without replacement. These containers default to an empty
collection anyway but calling `empty` will _set_ their value to an empty
collection.

Resolves #1119
