### PR TITLE
Convert JsonSlurper to ObjectMapper

### DIFF
--- a/src/main/java/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.java
+++ b/src/main/java/com/bmuschko/gradle/docker/tasks/AbstractDockerRemoteApiTask.java
@@ -166,10 +166,8 @@ public abstract class AbstractDockerRemoteApiTask extends DefaultTask {
      */
     @Internal
     protected RegistryAuthLocator getRegistryAuthLocator() {
-        return registryAuthLocator;
+        return new RegistryAuthLocator();
     }
-
-    private final RegistryAuthLocator registryAuthLocator = new RegistryAuthLocator();
 
     private DockerClientConfiguration createDockerClientConfig() {
         DockerClientConfiguration dockerClientConfig = new DockerClientConfiguration();


### PR DESCRIPTION
JsonSlurper is untyped and ObjectMapper will make it easier to convert the RegistryAuthLocator class to java.

I had to remove the caching of the auto locator class otherwise gradle's configuration cache will try to cache the objectmapper instance and you'll see this error
```
Could not load the value of field `_locale` of `com.fasterxml.jackson.databind.util.StdDateFormat` bean found in field `_dateFormat` of `com.fasterxml.jackson.databind.cfg.BaseSettings` bean found in field `_base` of `com.fasterxml.jackson.databind.DeserializationConfig` bean found in field `_deserializationConfig` of `com.fasterxml.jackson.databind.json.JsonMapper` bean found in field `objectMapper` of `com.bmuschko.gradle.docker.internal.RegistryAuthLocator` bean found in field `registryAuthLocator` of task `:dockerBuildImage` of type `com.bmuschko.gradle.docker.tasks.image.DockerBuildImage`. 
```

Alternatively, I could leave the RegistryAuthLocator as a private final field, but inline the ObjectMapper. 
Or there's a way to tell Gradle to not attempt to serialize the ObjectMapper instance.