### PR TITLE
Bump `docker-java` to v`3.2.14`

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 plugin-publish = "0.14.0"
-docker-java = "3.2.13"
+docker-java = "3.2.14"
 activation = "1.1.1"
 asm = "9.4"
 spock = "2.0-groovy-3.0"


### PR DESCRIPTION
Fixes issue caused by underlying JNA implementation causing crashes on Apple M1 computers.

closes #1130
