### PR TITLE
Cleanup unused closeQuietly method

### DIFF
--- a/src/main/java/com/bmuschko/gradle/docker/internal/IOUtils.java
+++ b/src/main/java/com/bmuschko/gradle/docker/internal/IOUtils.java
@@ -4,23 +4,11 @@ import org.gradle.internal.logging.progress.ProgressLogger;
 import org.gradle.internal.logging.progress.ProgressLoggerFactory;
 import org.gradle.internal.service.ServiceRegistry;
 
-import java.io.Closeable;
-import java.io.IOException;
 import java.util.Objects;
 
 public final class IOUtils {
 
     private IOUtils() { }
-
-    public static void closeQuietly(Closeable toClose) {
-        try {
-            if (toClose != null) {
-                toClose.close();
-            }
-        } catch (IOException ignored) {
-            // ignore
-        }
-    }
 
     /**
      * Create a progress logger for an arbitrary project and class.


### PR DESCRIPTION
Same as https://github.com/bmuschko/gradle-docker-plugin/pull/1094, but now we only need to remove the unused closeQuietly method. All `Closable`s now use the try-with-resources.