### PR TITLE
Fix shading

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,6 +23,10 @@ repositories {
     mavenCentral()
 }
 
+configurations.shaded {
+    exclude("org.slf4j")
+}
+
 dependencies {
     shaded(libs.bundles.docker.java)
     shaded(libs.activation)

--- a/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
@@ -49,7 +49,9 @@ class ShadedArtifactsPlugin: Plugin<Project> {
                 "javax.ws",
                 "net.sf",
                 "org.objectweb",
-                "javax.activation"
+                "javax.activation",
+                "com.sun.activation",
+                "com.sun.jna",
         )
         return tasks.named<ShadowJar>("shadowJar") {
             archiveClassifier.set(null)

--- a/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
+++ b/buildSrc/src/main/kotlin/com/bmuschko/gradle/docker/ShadedArtifactsPlugin.kt
@@ -33,6 +33,7 @@ class ShadedArtifactsPlugin: Plugin<Project> {
     private
     fun Project.configureShadowJarTask(shaded: Configuration): TaskProvider<ShadowJar> {
         val packagesToRelocate = listOf(
+                "com.github.dockerjava",
                 "javassist",
                 "org.glassfish",
                 "org.jvnet",


### PR DESCRIPTION
A quick look through the packaged jar shows that `com.github.dockerjava` is still in the root directory. If we relocate this package, other plugins pulling in that library should work.

I've also excluded slf4j from the shaded configuration since that will be pulled in from other plugins, but replaced by gradle at runtime.

The producer https://github.com/bmuschko/gradle-docker-plugin/issues/954#issuecomment-1270100521 in Intellij shows two classes loaded in the same location.
<img width="1742" alt="Screen Shot 2022-12-19 at 4 31 20 PM" src="https://user-images.githubusercontent.com/889237/208548166-0f32a757-6fff-44d4-8a55-3b4f25099537.png">
