### PR TITLE
Create parent directory for container id

### DIFF
--- a/src/main/java/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.java
+++ b/src/main/java/com/bmuschko/gradle/docker/tasks/container/DockerCreateContainer.java
@@ -287,7 +287,9 @@ public class DockerCreateContainer extends DockerExistingImage {
         final String orNull = containerName.getOrNull();
         final String localContainerName = orNull != null ? orNull : container.getId();
         getLogger().quiet("Created container with ID '" + localContainerName + "'.");
-        Files.writeString(containerIdFile.get().getAsFile().toPath(), container.getId());
+        File containerIdFile = this.containerIdFile.get().getAsFile();
+        containerIdFile.getParentFile().mkdirs();
+        Files.writeString(containerIdFile.toPath(), container.getId());
         if (getNextHandler() != null) {
             getNextHandler().execute(container);
         }


### PR DESCRIPTION
> Please do not create a Pull Request without first creating an ISSUE.
Any change needs to be discussed before proceeding.
Failure to do so may result in the rejection of the Pull Request.

Discussion can happen here. This wasn't a big up-front investment so if it is the wrong approach please do close =)

> Explain the **details** for making this change: What existing problem does the Pull Request solve? Why is this feature beneficial?

Noticed this problem after updating the docker plugin from 8.1.0 to 9.1.0:

```
> Task :flywayMigrate FAILED
Created container with ID 'codegen-postgres'.

FAILURE: Build failed with an exception.

...

* What went wrong:
Execution failed for task ':flywayMigrate'.
> java.nio.file.NoSuchFileException: /Users/foo/bar/build/.docker/createCodegenDbContainer-containerId.txt
```

This is fixed by executing in the project directory:
```
mkdir build/.docker
```

It seems to be the Groovy migration of `new File(".docker/foo").text="bar"` to `Files.writeString(new File(".docker/foo"), "bar"` might have introduced a behaviour difference where it does not create missing directories. Not easily noticable unless you clean the build environment.

My best guess is that explicitly creating the parent directory should avoid this problem, as suggested in the PR.