### PR TITLE
Add checking for classpath issues

### DIFF
--- a/src/main/java/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.java
+++ b/src/main/java/com/bmuschko/gradle/docker/DockerRemoteApiPlugin.java
@@ -6,8 +6,11 @@ import com.bmuschko.gradle.docker.tasks.RegistryCredentialsAware;
 import org.gradle.api.Action;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
+import org.gradle.api.provider.Property;
 import org.gradle.api.provider.Provider;
 import org.gradle.api.services.BuildServiceSpec;
+
+import java.util.UUID;
 
 /**
  * Gradle plugin that provides custom tasks for interacting with Docker via its remote API.
@@ -30,16 +33,23 @@ public class DockerRemoteApiPlugin implements Plugin<Project> {
         final DockerExtension dockerExtension = project.getExtensions().create(EXTENSION_NAME, DockerExtension.class, project.getObjects());
         configureRegistryCredentialsAwareTasks(project, dockerExtension.getRegistryCredentials());
 
-        final Provider<DockerClientService> serviceProvider = project.getGradle().getSharedServices().registerIfAbsent("docker", DockerClientService.class, new Action<BuildServiceSpec<DockerClientService.Params>>() {
-            @Override
-            public void execute(BuildServiceSpec<DockerClientService.Params> pBuildServiceSpec) {
-                pBuildServiceSpec.parameters(parameters -> {
-                    parameters.getUrl().set(dockerExtension.getUrl());
-                    parameters.getCertPath().set(dockerExtension.getCertPath());
-                    parameters.getApiVersion().set(dockerExtension.getApiVersion());
-                });
-            }
+        final Property<DockerClientService> serviceProvider = project.getObjects().property(DockerClientService.class);
+        Action<BuildServiceSpec<DockerClientService.Params>> action = pBuildServiceSpec -> pBuildServiceSpec.parameters(parameters -> {
+            parameters.getUrl().set(dockerExtension.getUrl());
+            parameters.getCertPath().set(dockerExtension.getCertPath());
+            parameters.getApiVersion().set(dockerExtension.getApiVersion());
         });
+        try {
+            serviceProvider.set(project.getGradle().getSharedServices().registerIfAbsent("docker", DockerClientService.class, action));
+        } catch (IllegalArgumentException e) {
+            String message = "The Docker Gradle plugin was loaded multiple times in different subprojects, which is not supported and may break the build.\n" +
+                    "This might happen in subprojects that apply the Docker plugins with the Gradle 'plugins { ... }' DSL if they specify explicit versions, even if the versions are equal.\n" +
+                    "Please add the Docker plugin to the common parent project or the root project, then remove the versions in the subprojects.\n" +
+                    "If the parent project does not need the plugin, add 'apply false' to the plugin line.\n" +
+                    "See: https://docs.gradle.org/current/userguide/plugins.html#sec:subprojects_plugins_dsl";
+            project.getLogger().quiet(message);
+            serviceProvider.set(project.getGradle().getSharedServices().registerIfAbsent("docker" + UUID.randomUUID(), DockerClientService.class, action));
+        }
 
         project.getTasks().withType(AbstractDockerRemoteApiTask.class).configureEach(new Action<AbstractDockerRemoteApiTask>() {
             @Override


### PR DESCRIPTION
To fix https://github.com/bmuschko/gradle-docker-plugin/issues/1123

I took a cue from the [kotlin gradle plugin](https://github.com/JetBrains/kotlin/blob/master/libraries/tools/kotlin-gradle-plugin/src/common/kotlin/org/jetbrains/kotlin/gradle/plugin/KotlinPluginInMultipleProjectsHolder.kt) and added a bit of validation around shared build services.

We can register a new unique build service on failure, and for projects that have the plugin defined at the root (or if gradle fixes the bug) the code will be forwards compatible.