### PR TITLE
Writer type is not compatible with configuration cache

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerLogsContainerFunctionalTest.groovy
@@ -149,7 +149,7 @@ class DockerLogsContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
         String logContainerTask = """
             task logContainer(type: DockerLogsContainer) {
                 targetContainerId startContainer.getContainerId()
-                sink = project.file("log-sink.txt").newWriter()
+                sink = project.file("log-sink.txt")
                 tailAll = true
             }
         """


### PR DESCRIPTION
A `Writer` field is not compatible to Gradle's configuration cache. If a consumer wants the String then simply reading the file contents or referencing the `Property` will work just fine.

> Live JVM state types (e.g. ClassLoader, Thread, OutputStream, Socket etc…​) are simply disallowed. These types almost never represent a task input or output.

https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:requirements:disallowed_types