### PR TITLE
Deprecate `withCommand` methods for DockerExecContainer task

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerReactiveMethodsFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/DockerReactiveMethodsFunctionalTest.groovy
@@ -288,7 +288,7 @@ class DockerReactiveMethodsFunctionalTest extends AbstractGroovyDslFunctionalTes
                 dependsOn startContainer
                 finalizedBy removeContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['echo', 'Hello World'])
+                commands.add(['echo', 'Hello World'] as String[])
                 
                 onNext { f ->
                     logger.quiet f.toString()

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerExecContainerFunctionalTest.groovy
@@ -28,7 +28,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             task execContainer(type: DockerExecContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['echo', 'Hello World'])
+                commands.add(['echo', 'Hello World'] as String[])
             }
         """
         buildFile << containerUsage(containerExecutionTask)
@@ -47,9 +47,9 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             task execContainer(type: DockerExecContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['echo', 'Hello World One'])
-                withCommand(['echo', 'Hello World Two'])
-                withCommand(['echo', 'Hello World Three'])
+                commands.add(['echo', 'Hello World One'] as String[])
+                commands.add(['echo', 'Hello World Two'] as String[])
+                commands.add(['echo', 'Hello World Three'] as String[])
                 doLast {
                     logger.quiet "FOUND EXEC-IDS: " + execIds.get().size()
                 }
@@ -74,7 +74,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
                 dependsOn createContainer
                 finalizedBy removeContainer
                 targetContainerId createContainer.getContainerId()
-                withCommand(['echo', 'Hello World'])
+                commands.add(['echo', 'Hello World'] as String[])
             }
         """
         buildFile << containerUsage(containerExecutionTask)
@@ -94,7 +94,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
                 dependsOn startContainer
                 finalizedBy removeContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['sh', '-c', 'id -u && id -g'])
+                commands.add(['sh', '-c', 'id -u && id -g'] as String[])
                 user = '10000:10001'
             }
         """
@@ -114,7 +114,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
                 dependsOn startContainer
                 finalizedBy removeContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['pwd'])
+                commands.add(['pwd'] as String[])
                 workingDir = '/usr/local/bin/'
             }
         """
@@ -134,7 +134,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
                 dependsOn startContainer
                 finalizedBy removeContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['test', '-e', '/not_existing_file'])
+                commands.add(['test', '-e', '/not_existing_file'] as String[])
                 successOnExitCodes = [0]
             }
         """
@@ -154,7 +154,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             task execContainer(type: DockerExecContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['sleep', '10'])
+                commands.add(['sleep', '10'] as String[])
                 successOnExitCodes = [0]
                 execProbe(15000, 1000)
                 onComplete {
@@ -177,7 +177,7 @@ class DockerExecContainerFunctionalTest extends AbstractGroovyDslFunctionalTest 
             task execContainer(type: DockerExecContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['echo', 'Hello World'])
+                commands.add(['echo', 'Hello World'] as String[])
             }
         """
         buildFile << containerUsage(containerExecutionTask)

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectExecContainerFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/container/DockerInspectExecContainerFunctionalTest.groovy
@@ -14,7 +14,7 @@ class DockerInspectExecContainerFunctionalTest extends AbstractGroovyDslFunction
             task execContainer(type: DockerExecContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['touch', '/tmp/test.txt'])
+                commands.add(['touch', '/tmp/test.txt'] as String[])
             }
             
             task inspectExec(type: DockerInspectExecContainer) {
@@ -38,7 +38,7 @@ class DockerInspectExecContainerFunctionalTest extends AbstractGroovyDslFunction
             task execContainer(type: DockerExecContainer) {
                 dependsOn startContainer
                 targetContainerId startContainer.getContainerId()
-                withCommand(['test', '-e', '/not_existing_file'])
+                commands.add(['test', '-e', '/not_existing_file'] as String[])
             }
 
             task inspectExec(type: DockerInspectExecContainer) {

--- a/src/main/java/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.java
+++ b/src/main/java/com/bmuschko/gradle/docker/tasks/container/DockerExecContainer.java
@@ -189,10 +189,24 @@ public class DockerExecContainer extends DockerExistingContainer {
         }
     }
 
+    /**
+     * Convenience method for adding commands.
+     *
+     * @param commandsToExecute The commands to execute
+     * @deprecated Use the method named {@link #getCommands()} directly
+     */
+    @Deprecated
     public void withCommand(List<String> commandsToExecute) {
         withCommand(commandsToExecute.toArray(String[]::new));
     }
 
+    /**
+     * Convenience method for adding commands.
+     *
+     * @param commandsToExecute The commands to execute
+     * @deprecated Use the method named {@link #getCommands()} directly
+     */
+    @Deprecated
     public void withCommand(String[] commandsToExecute) {
         if (commandsToExecute != null) {
             commands.add(commandsToExecute);


### PR DESCRIPTION
It hard to discover the method `withCommand`. Users should interact with `Property` field directly.