### PR TITLE
Fix DockerLoadImage input

### DIFF
--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -20,6 +20,10 @@ jobs:
         uses: gradle/gradle-build-action@v2
         with:
           arguments: classes
+      - name: Validate plugins
+        uses: gradle/gradle-build-action@v2
+        with:
+          arguments: validatePlugins
       - name: Unit tests
         uses: gradle/gradle-build-action@v2
         with:

--- a/src/main/java/com/bmuschko/gradle/docker/tasks/image/DockerLoadImage.java
+++ b/src/main/java/com/bmuschko/gradle/docker/tasks/image/DockerLoadImage.java
@@ -2,14 +2,14 @@ package com.bmuschko.gradle.docker.tasks.image;
 
 import com.bmuschko.gradle.docker.tasks.AbstractDockerRemoteApiTask;
 import org.gradle.api.file.RegularFileProperty;
-import org.gradle.api.tasks.Input;
+import org.gradle.api.tasks.InputFile;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 
 public class DockerLoadImage extends AbstractDockerRemoteApiTask {
 
-    @Input
+    @InputFile
     public final RegularFileProperty getImageFile() {
         return imageFile;
     }


### PR DESCRIPTION
Fixes `DockerLoadImage` task to have `@InputFile` and not `@Input`, found while running `check`. It doesn't look like this project calls check during ci, so instead I've added the `validatePlugins` task to our the list of tasks run in github.