### PR TITLE
Use Gradle cache in CI/CD workflow

### DIFF
--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
       - name: Set up Docker private registry

--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'gradle'
       - name: Set up Docker private registry
         run: |

--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -7,11 +7,12 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          cache: 'gradle'
       - name: Set up Docker private registry
         run: |
           docker run -d -p 5000:5000 --restart=always --name registry registry:2

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Set up Java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -11,6 +11,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v3
         with:
+          distribution: 'temurin'
           java-version: 11
           cache: 'gradle'
       - name: Compilation

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -7,11 +7,12 @@ jobs:
     runs-on: windows-2019
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v4
       - name: Set up Java
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
           java-version: 11
+          cache: 'gradle'
       - name: Compilation
         uses: gradle/gradle-build-action@v2
         with:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -12,7 +12,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
-          java-version: 11
+          java-version: 17
           cache: 'gradle'
       - name: Compilation
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
Use Gradle cache across workflow runs to shorten build times.

https://github.com/actions/setup-java#caching-gradle-dependencies