### PR TITLE
Minor improvement to CI/CD pipeline

### DIFF
--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -1,5 +1,7 @@
 name: Build and Release [Linux]
 on: [push, pull_request]
+permissions:
+  pages: write
 
 jobs:
   build:
@@ -65,4 +67,4 @@ jobs:
           PLUGIN_PORTAL_KEY: ${{ secrets.PLUGIN_PORTAL_KEY }}
           PLUGIN_PORTAL_SECRET: ${{ secrets.PLUGIN_PORTAL_SECRET }}
         with:
-          arguments: publishPlugins gitPublishPush -Pgradle.publish.key=${{ secrets.PLUGIN_PORTAL_KEY }} -Pgradle.publish.secret=${{ secrets.PLUGIN_PORTAL_SECRET }} -Dorg.ajoberstar.grgit.auth.username=${{ secrets.GH_TOKEN }} -is
+          arguments: publishPlugins gitPublishPush -Pgradle.publish.key=${{ secrets.PLUGIN_PORTAL_KEY }} -Pgradle.publish.secret=${{ secrets.PLUGIN_PORTAL_SECRET }} -Dorg.ajoberstar.grgit.auth.username=${{ secrets.GITHUB_TOKEN }} -is

--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -63,8 +63,5 @@ jobs:
       - name: Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: gradle/gradle-build-action@v2
-        env:
-          PLUGIN_PORTAL_KEY: ${{ secrets.PLUGIN_PORTAL_KEY }}
-          PLUGIN_PORTAL_SECRET: ${{ secrets.PLUGIN_PORTAL_SECRET }}
         with:
           arguments: publishPlugins gitPublishPush -Pgradle.publish.key=${{ secrets.PLUGIN_PORTAL_KEY }} -Pgradle.publish.secret=${{ secrets.PLUGIN_PORTAL_SECRET }} -Dorg.ajoberstar.grgit.auth.username=${{ secrets.GITHUB_TOKEN }} -is


### PR DESCRIPTION
* Use standard GitHub token for publishing to pages.
* Plugin portal only requires setting credentials via project properties.