### PR TITLE
ISSUE-1204: Add HEALTHCHECK instruction for Dockerfiles

### DIFF
--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileFunctionalTest.groovy
@@ -155,6 +155,7 @@ LABEL maintainer=benjamin.muschko@gmail.com
                 workingDir('/tmp')
                 onBuild('RUN echo "Hello World"')
                 instruction('LABEL env=prod')
+                healthcheck(new Dockerfile.Healthcheck('/bin/check-running'))
             }
         """
 
@@ -180,6 +181,7 @@ USER root
 WORKDIR /tmp
 ONBUILD RUN echo "Hello World"
 LABEL env=prod
+HEALTHCHECK CMD /bin/check-running
 """)
     }
 
@@ -202,6 +204,7 @@ LABEL env=prod
                 workingDir(project.provider { '/path/to/workdir' })
                 onBuild(project.provider { 'ADD . /app/src' })
                 instruction(project.provider { 'LABEL env=prod' })
+                healthcheck(project.provider { new Dockerfile.Healthcheck('/bin/check-running') })
             }
         """
 
@@ -224,6 +227,7 @@ USER patrick
 WORKDIR /path/to/workdir
 ONBUILD ADD . /app/src
 LABEL env=prod
+HEALTHCHECK CMD /bin/check-running
 """)
     }
 
@@ -233,6 +237,7 @@ LABEL env=prod
             task ${DOCKERFILE_TASK_NAME}(type: Dockerfile) {
                 instructions.add(new Dockerfile.FromInstruction(new Dockerfile.From('$TEST_IMAGE_WITH_TAG')))
                 instructions.add(new Dockerfile.LabelInstruction(['maintainer': 'benjamin.muschko@gmail.com']))
+                instructions.add(new Dockerfile.HealthcheckInstruction(new Dockerfile.Healthcheck('/bin/check-running')))
             }
         """
 
@@ -242,6 +247,7 @@ LABEL env=prod
         then:
         assertDockerfileContent("""FROM $TEST_IMAGE_WITH_TAG
 LABEL maintainer=benjamin.muschko@gmail.com
+HEALTHCHECK CMD /bin/check-running
 """)
     }
 

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -7,6 +7,7 @@ import java.util.logging.Level
 import java.util.logging.Logger
 
 import static com.bmuschko.gradle.docker.tasks.image.Dockerfile.*
+import static java.time.Duration.ofSeconds
 
 class DockerfileTest extends Specification {
     private static final Logger LOG = Logger.getLogger(DockerfileTest.class.getCanonicalName())
@@ -55,11 +56,11 @@ class DockerfileTest extends Specification {
         new EnvironmentVariableInstruction(' ', 'Linux')                                              | 'ENV'           | IllegalArgumentException.class
         new EnvironmentVariableInstruction('OS', '"Linux"')                                           | 'ENV'           | 'ENV OS="Linux"'
         new EnvironmentVariableInstruction('OS', 'Linux or Windows')                                  | 'ENV'           | 'ENV OS="Linux or Windows"'
-        new EnvironmentVariableInstruction('long', '''Multiple line env 
+        new EnvironmentVariableInstruction('long', '''Multiple line env
 with linebreaks in between''')                                                                        | 'ENV'           | "ENV long=\"Multiple line env \\\n\
 with linebreaks in between\""
         new EnvironmentVariableInstruction(['OS': 'Linux'])                                           | 'ENV'           | 'ENV OS=Linux'
-        new EnvironmentVariableInstruction(['long': '''Multiple line env 
+        new EnvironmentVariableInstruction(['long': '''Multiple line env
 with linebreaks in between'''])                                                                       | 'ENV'           | "ENV long=\"Multiple line env \\\n\
 with linebreaks in between\""
         new EnvironmentVariableInstruction(['OS': 'Linux', 'TZ': 'UTC'])                              | 'ENV'           | 'ENV OS=Linux TZ=UTC'
@@ -74,5 +75,13 @@ with linebreaks in between\""
         new LabelInstruction(['description': 'Single label' ])                                        | 'LABEL'         | 'LABEL description="Single label"'
         new LabelInstruction(['"un subscribe"': 'true' ])                                             | 'LABEL'         | 'LABEL "un subscribe"=true'
         new LabelInstruction(['description': 'Multiple labels', 'version': '1.0' ])                   | 'LABEL'         | 'LABEL description="Multiple labels" version=1.0'
+        new HealthcheckInstruction(new Healthcheck("/bin/check-running"))                             | 'HEALTHCHECK'   | 'HEALTHCHECK CMD /bin/check-running'
+        new HealthcheckInstruction(new Healthcheck("/bin/check-running").withInterval(ofSeconds(10))) | 'HEALTHCHECK'   | 'HEALTHCHECK --interval=10s CMD /bin/check-running'
+        new HealthcheckInstruction(new Healthcheck("/bin/check-running").withTimeout(ofSeconds(20)))  | 'HEALTHCHECK'   | 'HEALTHCHECK --timeout=20s CMD /bin/check-running'
+        new HealthcheckInstruction(new Healthcheck("/bin/check-running")
+            .withStartInterval(ofSeconds(30)))                                                        | 'HEALTHCHECK'   | 'HEALTHCHECK --start-interval=30s CMD /bin/check-running'
+        new HealthcheckInstruction(new Healthcheck("/bin/check-running")
+            .withStartPeriod(ofSeconds(40)))                                                          | 'HEALTHCHECK'   | 'HEALTHCHECK --start-period=40s CMD /bin/check-running'
+        new HealthcheckInstruction(new Healthcheck("/bin/check-running").withRetries(5))              | 'HEALTHCHECK'   | 'HEALTHCHECK --retries=5 CMD /bin/check-running'
     }
 }

--- a/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
+++ b/src/test/groovy/com/bmuschko/gradle/docker/tasks/image/DockerfileTest.groovy
@@ -56,11 +56,11 @@ class DockerfileTest extends Specification {
         new EnvironmentVariableInstruction(' ', 'Linux')                                              | 'ENV'           | IllegalArgumentException.class
         new EnvironmentVariableInstruction('OS', '"Linux"')                                           | 'ENV'           | 'ENV OS="Linux"'
         new EnvironmentVariableInstruction('OS', 'Linux or Windows')                                  | 'ENV'           | 'ENV OS="Linux or Windows"'
-        new EnvironmentVariableInstruction('long', '''Multiple line env
+        new EnvironmentVariableInstruction('long', '''Multiple line env 
 with linebreaks in between''')                                                                        | 'ENV'           | "ENV long=\"Multiple line env \\\n\
 with linebreaks in between\""
         new EnvironmentVariableInstruction(['OS': 'Linux'])                                           | 'ENV'           | 'ENV OS=Linux'
-        new EnvironmentVariableInstruction(['long': '''Multiple line env
+        new EnvironmentVariableInstruction(['long': '''Multiple line env 
 with linebreaks in between'''])                                                                       | 'ENV'           | "ENV long=\"Multiple line env \\\n\
 with linebreaks in between\""
         new EnvironmentVariableInstruction(['OS': 'Linux', 'TZ': 'UTC'])                              | 'ENV'           | 'ENV OS=Linux TZ=UTC'


### PR DESCRIPTION
Closes #1204.

## What?

This adds a new instruction to support `HEALTHCHECK`s:

https://docs.docker.com/engine/reference/builder/#healthcheck

Users will be able to configure health checks by declaring tasks such as:

```groovy
task createDockerfile(type: Dockerfile) {
    ...
    healthcheck(
      new Dockerfile.Healthcheck('/bin/check-running')
        .withTimeout(Duration.ofSeconds(10))
        .withInterval(Duration.ofSeconds(20))
        .withRetries(10)
    )
}
```

Resulting in:

```Dockerfile
...
HEALTHCHECK --timeout=10s --interval=20s --retries=10 CMD /bin/check-running
```