### PR TITLE
Support listing multiple images to remove

### DIFF
--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -38,7 +38,7 @@ jobs:
         run: ./gradlew functionalTest
       - name: Documentation tests
         run: ./gradlew docTest
-      - name: Store Test Reports
+      - name: Upload test reports
         if: ${{ failure() }}
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -36,6 +36,11 @@ jobs:
           HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
           HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
         run: ./gradlew functionalTest
+      - name: Store build reports for functionalTest
+        uses: actions/upload-artifact@v3
+        with:
+          name: functionalTest-reports
+          path: build/reports/tests/functionalTest/
       - name: Documentation tests
         run: ./gradlew docTest
       - name: Assemble artifacts

--- a/.github/workflows/linux-build-release.yml
+++ b/.github/workflows/linux-build-release.yml
@@ -36,13 +36,14 @@ jobs:
           HARBOR_USERNAME: ${{ secrets.HARBOR_USERNAME }}
           HARBOR_PASSWORD: ${{ secrets.HARBOR_PASSWORD }}
         run: ./gradlew functionalTest
-      - name: Store build reports for functionalTest
-        uses: actions/upload-artifact@v3
-        with:
-          name: functionalTest-reports
-          path: build/reports/tests/functionalTest/
       - name: Documentation tests
         run: ./gradlew docTest
+      - name: Store Test Reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: build/reports/tests
       - name: Assemble artifacts
         run: ./gradlew assemble javadoc asciidoctorAllGuides
       - name: Upload binaries

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -23,5 +23,11 @@ jobs:
         run: ./gradlew test
       - name: Integration tests
         run: ./gradlew integrationTest
+      - name: Upload test reports
+        if: ${{ failure() }}
+        uses: actions/upload-artifact@v3
+        with:
+          name: test-reports
+          path: build/reports/tests
       - name: Assemble artifacts
         run: ./gradlew assemble javadoc asciidoctorAllGuides

--- a/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
+++ b/src/functTest/groovy/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImageFunctionalTest.groovy
@@ -21,13 +21,13 @@ class DockerRemoveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 dependsOn dockerfile
                 inputDir = file("build/docker")
             }
-            
+
             task removeImage(type: DockerRemoveImage) {
                 dependsOn buildImage
                 force = true
                 targetImageId buildImage.getImageId()
             }
-            
+
             task removeImageAndCheckRemoval(type: DockerListImages) {
                 dependsOn removeImage
                 showAll = true
@@ -41,6 +41,75 @@ class DockerRemoveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
         then:
         !result.output.contains("repository")
     }
+
+    def "can remove multiple images"() {
+        // Given a few Official Images that are small... :-)
+        String firstImage = "alpine:3"
+        String secondImage = "busybox:1.36"
+        String thirdImage = "bash:5.2.21"
+
+        // And a build script that uses them...
+        buildFile << """
+            import com.bmuschko.gradle.docker.tasks.image.Dockerfile
+            import com.bmuschko.gradle.docker.tasks.image.DockerBuildImage
+            import com.bmuschko.gradle.docker.tasks.image.DockerListImages
+            import com.bmuschko.gradle.docker.tasks.image.DockerRemoveImage
+
+            task firstDockerfile(type: Dockerfile) {
+                from '$firstImage'
+                label(['maintainer': 'jane.doe@example.com'])
+            }
+            task buildFirstImage(type: DockerBuildImage) {
+                dependsOn firstDockerfile
+                inputDir = file("build/docker")
+            }
+
+            task secondDockerfile(type: Dockerfile) {
+                from '$secondImage'
+                label(['maintainer': 'jane.doe@example.com'])
+            }
+            task buildSecondImage(type: DockerBuildImage) {
+                dependsOn secondDockerfile
+                inputDir = file("build/docker")
+            }
+
+            task thirdDockerfile(type: Dockerfile) {
+                from '$thirdImage'
+                label(['maintainer': 'jane.doe@example.com'])
+            }
+            task buildThirdImage(type: DockerBuildImage) {
+                dependsOn thirdDockerfile
+                inputDir = file("build/docker")
+            }
+
+            task removeImages(type: DockerRemoveImage) {
+                dependsOn buildFirstImage
+                dependsOn buildSecondImage
+                dependsOn buildThirdImage
+
+                force = true
+
+                images(
+                    buildFirstImage.getImageId(),
+                    buildSecondImage.getImageId(),
+                    buildThirdImage.getImageId()
+                )
+            }
+
+            task removeImageAndCheckRemoval(type: DockerListImages) {
+                dependsOn removeImages
+                showAll = true
+                dangling = true
+            }
+        """
+
+        when:
+        BuildResult result = build('removeImageAndCheckRemoval')
+
+        then:
+        !result.output.contains("repository")
+    }
+
 
     def "can remove image tagged in multiple repositories"() {
         buildFile << """
@@ -59,21 +128,21 @@ class DockerRemoveImageFunctionalTest extends AbstractGroovyDslFunctionalTest {
                 dependsOn dockerfile
                 inputDir = file("build/docker")
             }
-            
+
             task tagImage(type: DockerTagImage) {
                 dependsOn buildImage
                 repository = "repository"
                 tag = "tag2"
                 targetImageId buildImage.getImageId()
             }
-            
+
             task tagImageSecondTime(type: DockerTagImage) {
                 dependsOn tagImage
                 repository = "repository"
                 tag = "tag2"
                 targetImageId buildImage.getImageId()
             }
-            
+
             task removeImage(type: DockerRemoveImage) {
                 dependsOn tagImageSecondTime
                 force = true

--- a/src/main/java/com/bmuschko/gradle/docker/internal/DefaultDockerConfigResolver.java
+++ b/src/main/java/com/bmuschko/gradle/docker/internal/DefaultDockerConfigResolver.java
@@ -1,8 +1,5 @@
 package com.bmuschko.gradle.docker.internal;
 
-import org.gradle.api.logging.Logger;
-import org.gradle.api.logging.Logging;
-
 import javax.annotation.Nullable;
 import java.io.File;
 

--- a/src/main/java/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.java
+++ b/src/main/java/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.java
@@ -22,13 +22,26 @@ import org.gradle.api.tasks.Optional;
 
 public class DockerRemoveImage extends DockerExistingImage {
 
+    /**
+     * Configures `--force` option when removing the images.
+     */
     @Input
     @Optional
     public final Property<Boolean> getForce() {
         return force;
     }
 
+    /**
+     * Configures `--no-prune` option when removing the images.
+     */
+    @Input
+    @Optional
+    public final Property<Boolean> getNoPrune() {
+        return noPrune;
+    }
+
     private final Property<Boolean> force = getProject().getObjects().property(Boolean.class);
+    private final Property<Boolean> noPrune = getProject().getObjects().property(Boolean.class);
 
     @Override
     public void runRemoteCommand() {

--- a/src/main/java/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.java
+++ b/src/main/java/com/bmuschko/gradle/docker/tasks/image/DockerRemoveImage.java
@@ -167,6 +167,6 @@ public class DockerRemoveImage extends DockerExistingImage {
     }
 
     private boolean mixesBothProperties() {
-        return this.images.isPresent() && this.getImageId().isPresent();
+        return !this.images.get().isEmpty() && java.util.Optional.ofNullable(this.getImageId().getOrNull()).isPresent();
     }
 }


### PR DESCRIPTION
## What?

Fixes #1190.

It allows users to list multiple images to remove.

## How?

A new `ListProperty` allows users to set a list of the images they want to remove. The old property is maintained, but it will generate a warning if used and throw an error if used together with the list property.

## Status

This is a WIP/draft for now. But I think it is close to be ready to merge.
